### PR TITLE
chore: converts all policies to use oneOfs

### DIFF
--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -129,22 +129,28 @@ components:
 http:
   api:
     property:
-      modificationTime: Modified
-      creationTime: Created
+      id: ID
+      json: JSON
+      tcp: TCP
+      http: HTTP
+      http2: HTTP2
+      grpc: gRPC
       tls: TLS
       mtls: mTLS
       mTLS: mTLS
-      id: ID
+      cds: CDS
+      eds: EDS
+      lds: LDS
+      rds: RDS
+      openTelemetry: OpenTelemetry
+      modificationTime: Modified
+      creationTime: Created
       globalInstanceId: Global instance ID
       controlPlaneInstanceId: CP instance ID
       zoneInstanceId: Zone leader instance ID
       connectTime: Connected
       disconnectTime: Disconnected
       version: Version
-      cds: CDS
-      eds: EDS
-      lds: LDS
-      rds: RDS
       responsesSent: Responses sent
       responsesAcknowledged: Responses acknowledged
       responsesRejected: Responses rejected

--- a/packages/kuma-http-api/dist/components/schemas/MeshAccessLogItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshAccessLogItem_Put_RequestBody.yaml
@@ -55,8 +55,7 @@ properties:
                       file:
                         path: ''
                     oneOf:
-                      - title: TCP
-                        type: object
+                      - type: object
                         default:
                           type: Tcp
                           tcp:
@@ -90,8 +89,7 @@ properties:
                                 required:
                                   - type
                                 oneOf:
-                                  - title: JSON
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Json
                                       json: []
@@ -115,8 +113,7 @@ properties:
                                             value: '%START_TIME%'
                                           - key: bytes_received
                                             value: '%BYTES_RECEIVED%'
-                                  - title: Plain
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Plain
                                       plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -128,8 +125,7 @@ properties:
                                         example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                             required:
                               - address
-                      - title: File
-                        type: object
+                      - type: object
                         default:
                           type: File
                           file:
@@ -158,8 +154,7 @@ properties:
                                 required:
                                   - type
                                 oneOf:
-                                  - title: JSON
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Json
                                       json: []
@@ -183,8 +178,7 @@ properties:
                                             value: '%START_TIME%'
                                           - key: bytes_received
                                             value: '%BYTES_RECEIVED%'
-                                  - title: Plain
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Plain
                                       plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -201,8 +195,7 @@ properties:
                                 minLength: 1
                             required:
                               - path
-                      - title: OpenTelemetry
-                        type: object
+                      - type: object
                         default:
                           type: OpenTelemetry
                           openTelemetry:
@@ -348,8 +341,7 @@ properties:
                       file:
                         path: ''
                     oneOf:
-                      - title: TCP
-                        type: object
+                      - type: object
                         default:
                           type: Tcp
                           tcp:
@@ -383,8 +375,7 @@ properties:
                                 required:
                                   - type
                                 oneOf:
-                                  - title: JSON
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Json
                                       json: []
@@ -408,8 +399,7 @@ properties:
                                             value: '%START_TIME%'
                                           - key: bytes_received
                                             value: '%BYTES_RECEIVED%'
-                                  - title: Plain
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Plain
                                       plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -421,8 +411,7 @@ properties:
                                         example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                             required:
                               - address
-                      - title: File
-                        type: object
+                      - type: object
                         default:
                           type: File
                           file:
@@ -451,8 +440,7 @@ properties:
                                 required:
                                   - type
                                 oneOf:
-                                  - title: JSON
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Json
                                       json: []
@@ -476,8 +464,7 @@ properties:
                                             value: '%START_TIME%'
                                           - key: bytes_received
                                             value: '%BYTES_RECEIVED%'
-                                  - title: Plain
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Plain
                                       plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -494,8 +481,7 @@ properties:
                                 minLength: 1
                             required:
                               - path
-                      - title: OpenTelemetry
-                        type: object
+                      - type: object
                         default:
                           type: OpenTelemetry
                           openTelemetry:
@@ -646,8 +632,7 @@ properties:
                       file:
                         path: ''
                     oneOf:
-                      - title: TCP
-                        type: object
+                      - type: object
                         default:
                           type: Tcp
                           tcp:
@@ -681,8 +666,7 @@ properties:
                                 required:
                                   - type
                                 oneOf:
-                                  - title: JSON
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Json
                                       json: []
@@ -706,8 +690,7 @@ properties:
                                             value: '%START_TIME%'
                                           - key: bytes_received
                                             value: '%BYTES_RECEIVED%'
-                                  - title: Plain
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Plain
                                       plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -719,8 +702,7 @@ properties:
                                         example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                             required:
                               - address
-                      - title: File
-                        type: object
+                      - type: object
                         default:
                           type: File
                           file:
@@ -749,8 +731,7 @@ properties:
                                 required:
                                   - type
                                 oneOf:
-                                  - title: JSON
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Json
                                       json: []
@@ -774,8 +755,7 @@ properties:
                                             value: '%START_TIME%'
                                           - key: bytes_received
                                             value: '%BYTES_RECEIVED%'
-                                  - title: Plain
-                                    type: object
+                                  - type: object
                                     default:
                                       type: Plain
                                       plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -792,8 +772,7 @@ properties:
                                 minLength: 1
                             required:
                               - path
-                      - title: OpenTelemetry
-                        type: object
+                      - type: object
                         default:
                           type: OpenTelemetry
                           openTelemetry:

--- a/packages/kuma-http-api/dist/components/schemas/MeshHTTPRouteItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshHTTPRouteItem_Put_RequestBody.yaml
@@ -188,250 +188,11 @@ properties:
                           required:
                             - kind
                           type: object
+                          x-kuma-type: TargetRef
                       filters:
                         type: array
                         items:
                           properties:
-                            requestHeaderModifier:
-                              description: |-
-                                Only one action is supported per header name.
-                                Configuration to set or add multiple values for a header must use RFC 7230
-                                header value formatting, separating each value with a comma.
-                              type: object
-                              properties:
-                                add:
-                                  type: array
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                        maxLength: 256
-                                        minLength: 1
-                                        pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  maxItems: 16
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                remove:
-                                  type: array
-                                  items:
-                                    type: string
-                                  maxItems: 16
-                                set:
-                                  type: array
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                        maxLength: 256
-                                        minLength: 1
-                                        pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  maxItems: 16
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                            requestMirror:
-                              type: object
-                              properties:
-                                backendRef:
-                                  description: BackendRef defines where to forward traffic.
-                                  type: object
-                                  properties:
-                                    kind:
-                                      description: Kind of the referenced resource
-                                      type: string
-                                      enum:
-                                        - Mesh
-                                        - MeshSubset
-                                        - MeshGateway
-                                        - MeshService
-                                        - MeshExternalService
-                                        - MeshMultiZoneService
-                                        - MeshServiceSubset
-                                        - MeshHTTPRoute
-                                        - Dataplane
-                                    labels:
-                                      description: |-
-                                        Labels are used to select group of MeshServices that match labels. Either Labels or
-                                        Name and Namespace can be used.
-                                      type: object
-                                      additionalProperties:
-                                        type: string
-                                    mesh:
-                                      description: Mesh is reserved for future use to identify cross mesh resources.
-                                      type: string
-                                    name:
-                                      description: |-
-                                        Name of the referenced resource. Can only be used with kinds: `MeshService`,
-                                        `MeshServiceSubset` and `MeshGatewayRoute`
-                                      type: string
-                                    namespace:
-                                      description: |-
-                                        Namespace specifies the namespace of target resource. If empty only resources in policy namespace
-                                        will be targeted.
-                                      type: string
-                                    port:
-                                      description: Port is only supported when this ref refers to a real MeshService object
-                                      type: integer
-                                      format: int32
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      type: array
-                                      items:
-                                        enum:
-                                          - Sidecar
-                                          - Gateway
-                                        type: string
-                                    sectionName:
-                                      description: |-
-                                        SectionName is used to target specific section of resource.
-                                        For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
-                                      type: string
-                                    tags:
-                                      description: |-
-                                        Tags used to select a subset of proxies by tags. Can only be used with kinds
-                                        `MeshSubset` and `MeshServiceSubset`
-                                      type: object
-                                      additionalProperties:
-                                        type: string
-                                    weight:
-                                      type: integer
-                                      default: 1
-                                      minimum: 0
-                                  required:
-                                    - kind
-                                percentage:
-                                  description: |-
-                                    Percentage of requests to mirror. If not specified, all requests
-                                    to the target cluster will be mirrored.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                              required:
-                                - backendRef
-                            requestRedirect:
-                              type: object
-                              properties:
-                                hostname:
-                                  description: |-
-                                    PreciseHostname is the fully qualified domain name of a network host. This
-                                    matches the RFC 1123 definition of a hostname with 1 notable exception that
-                                    numeric IP addresses are not allowed.
-
-                                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-                                    alphanumeric characters or '-', and must start and end with an alphanumeric
-                                    character. No other punctuation is allowed.
-                                  type: string
-                                  maxLength: 253
-                                  minLength: 1
-                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                path:
-                                  description: |-
-                                    Path defines parameters used to modify the path of the incoming request.
-                                    The modified path is then used to construct the location header.
-                                    When empty, the request path is used as-is.
-                                  type: object
-                                  properties:
-                                    replaceFullPath:
-                                      type: string
-                                    replacePrefixMatch:
-                                      type: string
-                                    type:
-                                      type: string
-                                      enum:
-                                        - ReplaceFullPath
-                                        - ReplacePrefixMatch
-                                  required:
-                                    - type
-                                port:
-                                  description: |-
-                                    Port is the port to be used in the value of the `Location`
-                                    header in the response.
-                                    When empty, port (if specified) of the request is used.
-                                  type: integer
-                                  format: int32
-                                  maximum: 65535
-                                  minimum: 1
-                                scheme:
-                                  type: string
-                                  enum:
-                                    - http
-                                    - https
-                                statusCode:
-                                  description: StatusCode is the HTTP status code to be used in response.
-                                  type: integer
-                                  default: 302
-                                  enum:
-                                    - 301
-                                    - 302
-                                    - 303
-                                    - 307
-                                    - 308
-                            responseHeaderModifier:
-                              description: |-
-                                Only one action is supported per header name.
-                                Configuration to set or add multiple values for a header must use RFC 7230
-                                header value formatting, separating each value with a comma.
-                              type: object
-                              properties:
-                                add:
-                                  type: array
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                        maxLength: 256
-                                        minLength: 1
-                                        pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  maxItems: 16
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                remove:
-                                  type: array
-                                  items:
-                                    type: string
-                                  maxItems: 16
-                                set:
-                                  type: array
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                        maxLength: 256
-                                        minLength: 1
-                                        pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  maxItems: 16
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
                             type:
                               type: string
                               enum:
@@ -440,38 +201,334 @@ properties:
                                 - RequestRedirect
                                 - URLRewrite
                                 - RequestMirror
-                            urlRewrite:
-                              type: object
-                              properties:
-                                hostToBackendHostname:
-                                  description: |-
-                                    HostToBackendHostname rewrites the hostname to the hostname of the
-                                    upstream host. This option is only available when targeting MeshGateways.
-                                  type: boolean
-                                hostname:
-                                  description: Hostname is the value to be used to replace the host header value during forwarding.
-                                  type: string
-                                  maxLength: 253
-                                  minLength: 1
-                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                path:
-                                  description: Path defines a path rewrite.
-                                  type: object
-                                  properties:
-                                    replaceFullPath:
-                                      type: string
-                                    replacePrefixMatch:
-                                      type: string
-                                    type:
-                                      type: string
-                                      enum:
-                                        - ReplaceFullPath
-                                        - ReplacePrefixMatch
-                                  required:
-                                    - type
                           required:
                             - type
                           type: object
+                          default:
+                            type: RequestHeaderModifier
+                          oneOf:
+                            - type: object
+                              default:
+                                type: RequestHeaderModifier
+                                roundRobin: {}
+                              properties:
+                                type:
+                                  const: RequestHeaderModifier
+                                requestHeaderModifier:
+                                  description: |-
+                                    Only one action is supported per header name.
+                                    Configuration to set or add multiple values for a header must use RFC 7230
+                                    header value formatting, separating each value with a comma.
+                                  type: object
+                                  properties:
+                                    add:
+                                      type: array
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      maxItems: 16
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      type: array
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                    set:
+                                      type: array
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      maxItems: 16
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                            - type: object
+                              default:
+                                type: ResponseHeaderModifier
+                                responseHeaderModifier: {}
+                              properties:
+                                type:
+                                  const: ResponseHeaderModifier
+                                responseHeaderModifier:
+                                  description: |-
+                                    Only one action is supported per header name.
+                                    Configuration to set or add multiple values for a header must use RFC 7230
+                                    header value formatting, separating each value with a comma.
+                                  type: object
+                                  properties:
+                                    add:
+                                      type: array
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      maxItems: 16
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      type: array
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                    set:
+                                      type: array
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      maxItems: 16
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                            - type: object
+                              default:
+                                type: RequestRedirect
+                                responseHeaderModifier: {}
+                              properties:
+                                type:
+                                  const: RequestRedirect
+                                requestRedirect:
+                                  type: object
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        PreciseHostname is the fully qualified domain name of a network host. This
+                                        matches the RFC 1123 definition of a hostname with 1 notable exception that
+                                        numeric IP addresses are not allowed.
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      type: string
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    path:
+                                      description: |-
+                                        Path defines parameters used to modify the path of the incoming request.
+                                        The modified path is then used to construct the location header.
+                                        When empty, the request path is used as-is.
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - ReplaceFullPath
+                                            - ReplacePrefixMatch
+                                      required:
+                                        - type
+                                      default:
+                                        type: ReplaceFullPath
+                                        replaceFullPath: ''
+                                      oneOf:
+                                        - type: object
+                                          default:
+                                            type: ReplaceFullPath
+                                            replaceFullPath: ''
+                                          properties:
+                                            type:
+                                              const: ReplaceFullPath
+                                            replaceFullPath:
+                                              type: string
+                                        - type: object
+                                          default:
+                                            type: ReplacePrefixMatch
+                                            replacePrefixMatch: ''
+                                          properties:
+                                            type:
+                                              const: ReplacePrefixMatch
+                                            replacePrefixMatch:
+                                              type: string
+                                    port:
+                                      description: |-
+                                        Port is the port to be used in the value of the `Location`
+                                        header in the response.
+                                        When empty, port (if specified) of the request is used.
+                                      type: integer
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                    scheme:
+                                      type: string
+                                      enum:
+                                        - http
+                                        - https
+                                    statusCode:
+                                      description: StatusCode is the HTTP status code to be used in response.
+                                      type: integer
+                                      default: 302
+                                      enum:
+                                        - 301
+                                        - 302
+                                        - 303
+                                        - 307
+                                        - 308
+                            - type: object
+                              default:
+                                type: URLRewrite
+                                urlRewrite: {}
+                              properties:
+                                type:
+                                  const: URLRewrite
+                                urlRewrite:
+                                  type: object
+                                  properties:
+                                    hostToBackendHostname:
+                                      description: |-
+                                        HostToBackendHostname rewrites the hostname to the hostname of the
+                                        upstream host. This option is only available when targeting MeshGateways.
+                                      type: boolean
+                                    hostname:
+                                      description: Hostname is the value to be used to replace the host header value during forwarding.
+                                      type: string
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    path:
+                                      description: Path defines a path rewrite.
+                                      type: object
+                                      properties:
+                                        replaceFullPath:
+                                          type: string
+                                        replacePrefixMatch:
+                                          type: string
+                                        type:
+                                          type: string
+                                          enum:
+                                            - ReplaceFullPath
+                                            - ReplacePrefixMatch
+                                      required:
+                                        - type
+                            - type: object
+                              default:
+                                type: RequestMirror
+                                requestMirror: {}
+                              properties:
+                                type:
+                                  const: RequestMirror
+                                requestMirror:
+                                  type: object
+                                  properties:
+                                    backendRef:
+                                      description: BackendRef defines where to forward traffic.
+                                      type: object
+                                      properties:
+                                        kind:
+                                          description: Kind of the referenced resource
+                                          type: string
+                                          enum:
+                                            - Mesh
+                                            - MeshSubset
+                                            - MeshGateway
+                                            - MeshService
+                                            - MeshExternalService
+                                            - MeshMultiZoneService
+                                            - MeshServiceSubset
+                                            - MeshHTTPRoute
+                                            - Dataplane
+                                        labels:
+                                          description: |-
+                                            Labels are used to select group of MeshServices that match labels. Either Labels or
+                                            Name and Namespace can be used.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        mesh:
+                                          description: Mesh is reserved for future use to identify cross mesh resources.
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                            `MeshServiceSubset` and `MeshGatewayRoute`
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                            will be targeted.
+                                          type: string
+                                        port:
+                                          description: Port is only supported when this ref refers to a real MeshService object
+                                          type: integer
+                                          format: int32
+                                        proxyTypes:
+                                          description: |-
+                                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                            all data plane types are targeted by the policy.
+                                          type: array
+                                          items:
+                                            enum:
+                                              - Sidecar
+                                              - Gateway
+                                            type: string
+                                        sectionName:
+                                          description: |-
+                                            SectionName is used to target specific section of resource.
+                                            For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                          type: string
+                                        tags:
+                                          description: |-
+                                            Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                            `MeshSubset` and `MeshServiceSubset`
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        weight:
+                                          type: integer
+                                          default: 1
+                                          minimum: 0
+                                      required:
+                                        - kind
+                                    percentage:
+                                      description: |-
+                                        Percentage of requests to mirror. If not specified, all requests
+                                        to the target cluster will be mirrored.
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - backendRef
                   matches:
                     description: |-
                       Matches describes how to match HTTP requests this rule should be applied

--- a/packages/kuma-http-api/dist/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.yaml
@@ -187,258 +187,6 @@ properties:
                   description: LoadBalancer allows to specify load balancing algorithm.
                   type: object
                   properties:
-                    leastRequest:
-                      description: |-
-                        LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
-                        and picks the host which has the fewest active requests
-                      type: object
-                      properties:
-                        activeRequestBias:
-                          description: |-
-                            ActiveRequestBias refers to dynamic weights applied when hosts have varying load
-                            balancing weights. A higher value here aggressively reduces the weight of endpoints
-                            that are currently handling active requests. In essence, the higher the ActiveRequestBias
-                            value, the more forcefully it reduces the load balancing weight of endpoints that are
-                            actively serving requests.
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
-                        choiceCount:
-                          description: |-
-                            ChoiceCount is the number of random healthy hosts from which the host with
-                            the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
-                            two-choice selection if the field is not set.
-                          type: integer
-                          format: int32
-                          minimum: 2
-                    maglev:
-                      description: |-
-                        Maglev implements consistent hashing to upstream hosts. Maglev can be used as
-                        a drop in replacement for the ring hash load balancer any place in which
-                        consistent hashing is desired.
-                      type: object
-                      properties:
-                        hashPolicies:
-                          description: |-
-                            HashPolicies specify a list of request/connection properties that are used to calculate a hash.
-                            These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
-                            set to true, and there is already a hash generated, the hash is returned immediately,
-                            ignoring the rest of the hash policy list.
-                          type: array
-                          items:
-                            properties:
-                              connection:
-                                type: object
-                                properties:
-                                  sourceIP:
-                                    description: Hash on source IP address.
-                                    type: boolean
-                              cookie:
-                                type: object
-                                properties:
-                                  name:
-                                    description: The name of the cookie that will be used to obtain the hash key.
-                                    type: string
-                                    minLength: 1
-                                  path:
-                                    description: The name of the path for the cookie.
-                                    type: string
-                                  ttl:
-                                    description: If specified, a cookie with the TTL will be generated if the cookie is not present.
-                                    type: string
-                                required:
-                                  - name
-                              filterState:
-                                type: object
-                                properties:
-                                  key:
-                                    description: |-
-                                      The name of the Object in the per-request filterState, which is
-                                      an Envoy::Hashable object. If there is no data associated with the key,
-                                      or the stored object is not Envoy::Hashable, no hash will be produced.
-                                    type: string
-                                    minLength: 1
-                                required:
-                                  - key
-                              header:
-                                type: object
-                                properties:
-                                  name:
-                                    description: The name of the request header that will be used to obtain the hash key.
-                                    type: string
-                                    minLength: 1
-                                required:
-                                  - name
-                              queryParameter:
-                                type: object
-                                properties:
-                                  name:
-                                    description: |-
-                                      The name of the URL query parameter that will be used to obtain the hash key.
-                                      If the parameter is not present, no hash will be produced. Query parameter names
-                                      are case-sensitive.
-                                    type: string
-                                    minLength: 1
-                                required:
-                                  - name
-                              terminal:
-                                description: |-
-                                  Terminal is a flag that short-circuits the hash computing. This field provides
-                                  a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
-                                  to rest of the policy list”, it saves time when the terminal policy works.
-                                  If true, and there is already a hash computed, ignore rest of the list of hash polices.
-                                type: boolean
-                              type:
-                                type: string
-                                enum:
-                                  - Header
-                                  - Cookie
-                                  - Connection
-                                  - SourceIP
-                                  - QueryParameter
-                                  - FilterState
-                            required:
-                              - type
-                            type: object
-                        tableSize:
-                          description: |-
-                            The table size for Maglev hashing. Maglev aims for “minimal disruption”
-                            rather than an absolute guarantee. Minimal disruption means that when
-                            the set of upstream hosts change, a connection will likely be sent
-                            to the same upstream as it was before. Increasing the table size reduces
-                            the amount of disruption. The table size must be prime number limited to 5000011.
-                            If it is not specified, the default is 65537.
-                          type: integer
-                          format: int32
-                          maximum: 5000011
-                          minimum: 1
-                    random:
-                      description: |-
-                        Random selects a random available host. The random load balancer generally
-                        performs better than round-robin if no health checking policy is configured.
-                        Random selection avoids bias towards the host in the set that comes after a failed host.
-                      type: object
-                    ringHash:
-                      description: |-
-                        RingHash  implements consistent hashing to upstream hosts. Each host is mapped
-                        onto a circle (the “ring”) by hashing its address; each request is then routed
-                        to a host by hashing some property of the request, and finding the nearest
-                        corresponding host clockwise around the ring.
-                      type: object
-                      properties:
-                        hashFunction:
-                          description: |-
-                            HashFunction is a function used to hash hosts onto the ketama ring.
-                            The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
-                          type: string
-                          enum:
-                            - XXHash
-                            - MurmurHash2
-                        hashPolicies:
-                          description: |-
-                            HashPolicies specify a list of request/connection properties that are used to calculate a hash.
-                            These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
-                            set to true, and there is already a hash generated, the hash is returned immediately,
-                            ignoring the rest of the hash policy list.
-                          type: array
-                          items:
-                            properties:
-                              connection:
-                                type: object
-                                properties:
-                                  sourceIP:
-                                    description: Hash on source IP address.
-                                    type: boolean
-                              cookie:
-                                type: object
-                                properties:
-                                  name:
-                                    description: The name of the cookie that will be used to obtain the hash key.
-                                    type: string
-                                    minLength: 1
-                                  path:
-                                    description: The name of the path for the cookie.
-                                    type: string
-                                  ttl:
-                                    description: If specified, a cookie with the TTL will be generated if the cookie is not present.
-                                    type: string
-                                required:
-                                  - name
-                              filterState:
-                                type: object
-                                properties:
-                                  key:
-                                    description: |-
-                                      The name of the Object in the per-request filterState, which is
-                                      an Envoy::Hashable object. If there is no data associated with the key,
-                                      or the stored object is not Envoy::Hashable, no hash will be produced.
-                                    type: string
-                                    minLength: 1
-                                required:
-                                  - key
-                              header:
-                                type: object
-                                properties:
-                                  name:
-                                    description: The name of the request header that will be used to obtain the hash key.
-                                    type: string
-                                    minLength: 1
-                                required:
-                                  - name
-                              queryParameter:
-                                type: object
-                                properties:
-                                  name:
-                                    description: |-
-                                      The name of the URL query parameter that will be used to obtain the hash key.
-                                      If the parameter is not present, no hash will be produced. Query parameter names
-                                      are case-sensitive.
-                                    type: string
-                                    minLength: 1
-                                required:
-                                  - name
-                              terminal:
-                                description: |-
-                                  Terminal is a flag that short-circuits the hash computing. This field provides
-                                  a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
-                                  to rest of the policy list”, it saves time when the terminal policy works.
-                                  If true, and there is already a hash computed, ignore rest of the list of hash polices.
-                                type: boolean
-                              type:
-                                type: string
-                                enum:
-                                  - Header
-                                  - Cookie
-                                  - Connection
-                                  - SourceIP
-                                  - QueryParameter
-                                  - FilterState
-                            required:
-                              - type
-                            type: object
-                        maxRingSize:
-                          description: |-
-                            Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
-                            but can be lowered to further constrain resource use.
-                          type: integer
-                          format: int32
-                          maximum: 8000000
-                          minimum: 1
-                        minRingSize:
-                          description: |-
-                            Minimum hash ring size. The larger the ring is (that is,
-                            the more hashes there are for each provided host) the better the request distribution
-                            will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
-                          type: integer
-                          format: int32
-                          maximum: 8000000
-                          minimum: 1
-                    roundRobin:
-                      description: |-
-                        RoundRobin is a load balancing algorithm that distributes requests
-                        across available upstream hosts in round-robin order.
-                      type: object
                     type:
                       type: string
                       enum:
@@ -449,6 +197,374 @@ properties:
                         - Maglev
                   required:
                     - type
+                  default:
+                    type: RoundRobin
+                  oneOf:
+                    - type: object
+                      default:
+                        type: RoundRobin
+                        roundRobin: {}
+                      properties:
+                        type:
+                          const: RoundRobin
+                        roundRobin:
+                          description: |-
+                            RoundRobin is a load balancing algorithm that distributes requests
+                            across available upstream hosts in round-robin order.
+                          type: object
+                    - type: object
+                      default:
+                        type: LeastRequest
+                        leastRequest: {}
+                      properties:
+                        type:
+                          const: LeastRequest
+                        leastRequest:
+                          description: |-
+                            LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
+                            and picks the host which has the fewest active requests
+                          type: object
+                          properties:
+                            activeRequestBias:
+                              description: |-
+                                ActiveRequestBias refers to dynamic weights applied when hosts have varying load
+                                balancing weights. A higher value here aggressively reduces the weight of endpoints
+                                that are currently handling active requests. In essence, the higher the ActiveRequestBias
+                                value, the more forcefully it reduces the load balancing weight of endpoints that are
+                                actively serving requests.
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            choiceCount:
+                              description: |-
+                                ChoiceCount is the number of random healthy hosts from which the host with
+                                the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
+                                two-choice selection if the field is not set.
+                              type: integer
+                              format: int32
+                              minimum: 2
+                    - type: object
+                      default:
+                        type: RingHash
+                        ringHash: {}
+                      properties:
+                        type:
+                          const: RingHash
+                        ringHash:
+                          description: |-
+                            RingHash  implements consistent hashing to upstream hosts. Each host is mapped
+                            onto a circle (the “ring”) by hashing its address; each request is then routed
+                            to a host by hashing some property of the request, and finding the nearest
+                            corresponding host clockwise around the ring.
+                          type: object
+                          properties:
+                            hashFunction:
+                              description: |-
+                                HashFunction is a function used to hash hosts onto the ketama ring.
+                                The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
+                              type: string
+                              enum:
+                                - XXHash
+                                - MurmurHash2
+                            hashPolicies:
+                              description: |-
+                                HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                set to true, and there is already a hash generated, the hash is returned immediately,
+                                ignoring the rest of the hash policy list.
+                              type: array
+                              items:
+                                properties:
+                                  terminal:
+                                    description: |-
+                                      Terminal is a flag that short-circuits the hash computing. This field provides
+                                      a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                      to rest of the policy list”, it saves time when the terminal policy works.
+                                      If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                    type: boolean
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Header
+                                      - Cookie
+                                      - Connection
+                                      - SourceIP
+                                      - QueryParameter
+                                      - FilterState
+                                required:
+                                  - type
+                                type: object
+                                default:
+                                  type: Header
+                                  header: {}
+                                oneOf:
+                                  - type: object
+                                    default:
+                                      type: Header
+                                      header: {}
+                                    properties:
+                                      type:
+                                        const: Header
+                                      header:
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: The name of the request header that will be used to obtain the hash key.
+                                            type: string
+                                            minLength: 1
+                                        required:
+                                          - name
+                                  - type: object
+                                    default:
+                                      type: Cookie
+                                      header: {}
+                                    properties:
+                                      type:
+                                        const: Cookie
+                                      header:
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: The name of the cookie that will be used to obtain the hash key.
+                                            type: string
+                                            minLength: 1
+                                          path:
+                                            description: The name of the path for the cookie.
+                                            type: string
+                                          ttl:
+                                            description: If specified, a cookie with the TTL will be generated if the cookie is not present.
+                                            type: string
+                                        required:
+                                          - name
+                                  - type: object
+                                    default:
+                                      type: Connection
+                                      connection: {}
+                                    properties:
+                                      type:
+                                        const: Connection
+                                      connection:
+                                        type: object
+                                        properties:
+                                          sourceIP:
+                                            description: Hash on source IP address.
+                                            type: boolean
+                                  - type: object
+                                    default:
+                                      type: QueryParameter
+                                      queryParameter: {}
+                                    properties:
+                                      type:
+                                        const: QueryParameter
+                                      queryParameter:
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The name of the URL query parameter that will be used to obtain the hash key.
+                                              If the parameter is not present, no hash will be produced. Query parameter names
+                                              are case-sensitive.
+                                            type: string
+                                            minLength: 1
+                                        required:
+                                          - name
+                                  - type: object
+                                    default:
+                                      type: FilterState
+                                      filterState: {}
+                                    properties:
+                                      type:
+                                        const: FilterState
+                                      filterState:
+                                        type: object
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The name of the Object in the per-request filterState, which is
+                                              an Envoy::Hashable object. If there is no data associated with the key,
+                                              or the stored object is not Envoy::Hashable, no hash will be produced.
+                                            type: string
+                                            minLength: 1
+                                        required:
+                                          - key
+                            maxRingSize:
+                              description: |-
+                                Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
+                                but can be lowered to further constrain resource use.
+                              type: integer
+                              format: int32
+                              maximum: 8000000
+                              minimum: 1
+                            minRingSize:
+                              description: |-
+                                Minimum hash ring size. The larger the ring is (that is,
+                                the more hashes there are for each provided host) the better the request distribution
+                                will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
+                              type: integer
+                              format: int32
+                              maximum: 8000000
+                              minimum: 1
+                    - type: object
+                      default:
+                        type: Random
+                        random: {}
+                      properties:
+                        type:
+                          const: Random
+                        random:
+                          description: |-
+                            Random selects a random available host. The random load balancer generally
+                            performs better than round-robin if no health checking policy is configured.
+                            Random selection avoids bias towards the host in the set that comes after a failed host.
+                          type: object
+                    - type: object
+                      default:
+                        type: Maglev
+                        maglev: {}
+                      properties:
+                        type:
+                          const: Maglev
+                        maglev:
+                          description: |-
+                            Maglev implements consistent hashing to upstream hosts. Maglev can be used as
+                            a drop in replacement for the ring hash load balancer any place in which
+                            consistent hashing is desired.
+                          type: object
+                          properties:
+                            hashPolicies:
+                              description: |-
+                                HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                set to true, and there is already a hash generated, the hash is returned immediately,
+                                ignoring the rest of the hash policy list.
+                              type: array
+                              items:
+                                properties:
+                                  terminal:
+                                    description: |-
+                                      Terminal is a flag that short-circuits the hash computing. This field provides
+                                      a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                      to rest of the policy list”, it saves time when the terminal policy works.
+                                      If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                    type: boolean
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Header
+                                      - Cookie
+                                      - Connection
+                                      - SourceIP
+                                      - QueryParameter
+                                      - FilterState
+                                required:
+                                  - type
+                                type: object
+                                default:
+                                  type: Header
+                                  header: {}
+                                oneOf:
+                                  - type: object
+                                    default:
+                                      type: Header
+                                      header: {}
+                                    properties:
+                                      type:
+                                        const: Header
+                                      header:
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: The name of the request header that will be used to obtain the hash key.
+                                            type: string
+                                            minLength: 1
+                                        required:
+                                          - name
+                                  - type: object
+                                    default:
+                                      type: Cookie
+                                      header: {}
+                                    properties:
+                                      type:
+                                        const: Cookie
+                                      header:
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: The name of the cookie that will be used to obtain the hash key.
+                                            type: string
+                                            minLength: 1
+                                          path:
+                                            description: The name of the path for the cookie.
+                                            type: string
+                                          ttl:
+                                            description: If specified, a cookie with the TTL will be generated if the cookie is not present.
+                                            type: string
+                                        required:
+                                          - name
+                                  - type: object
+                                    default:
+                                      type: Connection
+                                      connection: {}
+                                    properties:
+                                      type:
+                                        const: Connection
+                                      connection:
+                                        type: object
+                                        properties:
+                                          sourceIP:
+                                            description: Hash on source IP address.
+                                            type: boolean
+                                  - type: object
+                                    default:
+                                      type: QueryParameter
+                                      queryParameter: {}
+                                    properties:
+                                      type:
+                                        const: QueryParameter
+                                      queryParameter:
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The name of the URL query parameter that will be used to obtain the hash key.
+                                              If the parameter is not present, no hash will be produced. Query parameter names
+                                              are case-sensitive.
+                                            type: string
+                                            minLength: 1
+                                        required:
+                                          - name
+                                  - type: object
+                                    default:
+                                      type: FilterState
+                                      filterState: {}
+                                    properties:
+                                      type:
+                                        const: FilterState
+                                      filterState:
+                                        type: object
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The name of the Object in the per-request filterState, which is
+                                              an Envoy::Hashable object. If there is no data associated with the key,
+                                              or the stored object is not Envoy::Hashable, no hash will be produced.
+                                            type: string
+                                            minLength: 1
+                                        required:
+                                          - key
+                            tableSize:
+                              description: |-
+                                The table size for Maglev hashing. Maglev aims for “minimal disruption”
+                                rather than an absolute guarantee. Minimal disruption means that when
+                                the set of upstream hosts change, a connection will likely be sent
+                                to the same upstream as it was before. Increasing the table size reduces
+                                the amount of disruption. The table size must be prime number limited to 5000011.
+                                If it is not specified, the default is 65537.
+                              type: integer
+                              format: int32
+                              maximum: 5000011
+                              minimum: 1
                 localityAwareness:
                   description: LocalityAwareness contains configuration for locality aware load balancing.
                   type: object

--- a/packages/kuma-http-api/dist/components/schemas/MeshMetricItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshMetricItem_Put_RequestBody.yaml
@@ -57,46 +57,6 @@ properties:
             type: array
             items:
               properties:
-                openTelemetry:
-                  description: OpenTelemetry backend configuration
-                  type: object
-                  properties:
-                    endpoint:
-                      description: Endpoint for OpenTelemetry collector
-                      type: string
-                    refreshInterval:
-                      description: RefreshInterval defines how frequent metrics should be pushed to collector
-                      type: string
-                  required:
-                    - endpoint
-                prometheus:
-                  description: Prometheus backend configuration.
-                  type: object
-                  properties:
-                    clientId:
-                      description: ClientId of the Prometheus backend. Needed when using MADS for DP discovery.
-                      type: string
-                    path:
-                      description: Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
-                      type: string
-                      default: /metrics
-                    port:
-                      description: Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
-                      type: integer
-                      format: int32
-                      default: 5670
-                    tls:
-                      description: Configuration of TLS for prometheus listener.
-                      type: object
-                      properties:
-                        mode:
-                          description: Configuration of TLS for Prometheus listener.
-                          type: string
-                          default: Disabled
-                          enum:
-                            - Disabled
-                            - ProvidedTLS
-                            - ActiveMTLSBackend
                 type:
                   description: Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
                   type: string
@@ -106,6 +66,63 @@ properties:
               required:
                 - type
               type: object
+              default:
+                type: Prometheus
+              oneOf:
+                - type: object
+                  default:
+                    type: Prometheus
+                    prometheus: {}
+                  properties:
+                    type:
+                      const: Prometheus
+                    prometheus:
+                      description: Prometheus backend configuration.
+                      type: object
+                      properties:
+                        clientId:
+                          description: ClientId of the Prometheus backend. Needed when using MADS for DP discovery.
+                          type: string
+                        path:
+                          description: Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                          type: string
+                          default: /metrics
+                        port:
+                          description: Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                          type: integer
+                          format: int32
+                          default: 5670
+                        tls:
+                          description: Configuration of TLS for prometheus listener.
+                          type: object
+                          properties:
+                            mode:
+                              description: Configuration of TLS for Prometheus listener.
+                              type: string
+                              default: Disabled
+                              enum:
+                                - Disabled
+                                - ProvidedTLS
+                                - ActiveMTLSBackend
+                - type: object
+                  default:
+                    type: OpenTelemetry
+                    openTelemetry: {}
+                  properties:
+                    type:
+                      const: OpenTelemetry
+                    openTelemetry:
+                      description: OpenTelemetry backend configuration
+                      type: object
+                      properties:
+                        endpoint:
+                          description: Endpoint for OpenTelemetry collector
+                          type: string
+                        refreshInterval:
+                          description: RefreshInterval defines how frequent metrics should be pushed to collector
+                          type: string
+                      required:
+                        - endpoint
           sidecar:
             description: Sidecar metrics collection configuration
             type: object

--- a/packages/kuma-http-api/dist/components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml
@@ -181,6 +181,7 @@ properties:
                           required:
                             - kind
                           type: object
+                          x-kuma-type: TargetRef
                 required:
                   - default
                 type: object

--- a/packages/kuma-http-api/dist/components/schemas/MeshTraceItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTraceItem_Put_RequestBody.yaml
@@ -41,75 +41,104 @@ properties:
             items:
               description: Only one of zipkin, datadog or openTelemetry can be used.
               properties:
-                datadog:
-                  description: Datadog backend configuration.
-                  type: object
-                  properties:
-                    splitService:
-                      description: |-
-                        Determines if datadog service name should be split based on traffic
-                        direction and destination. For example, with `splitService: true` and a
-                        `backend` service that communicates with a couple of databases, you would
-                        get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
-                        `backend_OUTBOUND_db2` in Datadog.
-                      type: boolean
-                      default: false
-                    url:
-                      description: |-
-                        Address of Datadog collector, only host and port are allowed (no paths,
-                        fragments etc.)
-                      type: string
-                  required:
-                    - url
-                openTelemetry:
-                  description: OpenTelemetry backend configuration.
-                  type: object
-                  properties:
-                    endpoint:
-                      description: Address of OpenTelemetry collector.
-                      type: string
-                      example: otel-collector:4317
-                      minLength: 1
-                  required:
-                    - endpoint
                 type:
                   type: string
                   enum:
                     - Zipkin
                     - Datadog
                     - OpenTelemetry
-                zipkin:
-                  description: Zipkin backend configuration.
-                  type: object
-                  properties:
-                    apiVersion:
-                      description: |-
-                        Version of the API.
-                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
-                      type: string
-                      default: httpJson
-                      enum:
-                        - httpJson
-                        - httpProto
-                    sharedSpanContext:
-                      description: |-
-                        Determines whether client and server spans will share the same span
-                        context.
-                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
-                      type: boolean
-                      default: true
-                    traceId128bit:
-                      description: Generate 128bit traces.
-                      type: boolean
-                      default: false
-                    url:
-                      description: Address of Zipkin collector.
-                      type: string
-                  required:
-                    - url
               required:
                 - type
               type: object
+              default:
+                type: Zipkin
+                zipkin:
+                  url: ''
+              oneOf:
+                - type: object
+                  default:
+                    type: Zipkin
+                    zipkin:
+                      url: ''
+                  properties:
+                    type:
+                      const: Zipkin
+                    zipkin:
+                      description: Zipkin backend configuration.
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: |-
+                            Version of the API.
+                            https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
+                          type: string
+                          default: httpJson
+                          enum:
+                            - httpJson
+                            - httpProto
+                        sharedSpanContext:
+                          description: |-
+                            Determines whether client and server spans will share the same span
+                            context.
+                            https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
+                          type: boolean
+                          default: true
+                        traceId128bit:
+                          description: Generate 128bit traces.
+                          type: boolean
+                          default: false
+                        url:
+                          description: Address of Zipkin collector.
+                          type: string
+                      required:
+                        - url
+                - type: object
+                  default:
+                    type: Datadog
+                    datadog:
+                      url: ''
+                  properties:
+                    type:
+                      const: Datadog
+                    datadog:
+                      description: Datadog backend configuration.
+                      type: object
+                      properties:
+                        splitService:
+                          description: |-
+                            Determines if datadog service name should be split based on traffic
+                            direction and destination. For example, with `splitService: true` and a
+                            `backend` service that communicates with a couple of databases, you would
+                            get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+                            `backend_OUTBOUND_db2` in Datadog.
+                          type: boolean
+                          default: false
+                        url:
+                          description: |-
+                            Address of Datadog collector, only host and port are allowed (no paths,
+                            fragments etc.)
+                          type: string
+                      required:
+                        - url
+                - type: object
+                  default:
+                    type: OpenTelemetry
+                    openTelemetry:
+                      endpoint: ''
+                  properties:
+                    type:
+                      const: OpenTelemetry
+                    openTelemetry:
+                      description: OpenTelemetry backend configuration.
+                      type: object
+                      properties:
+                        endpoint:
+                          description: Address of OpenTelemetry collector.
+                          type: string
+                          example: otel-collector:4317
+                          minLength: 1
+                      required:
+                        - endpoint
             maxItems: 1
           sampling:
             description: |-

--- a/packages/kuma-http-api/index.d.ts
+++ b/packages/kuma-http-api/index.d.ts
@@ -10661,7 +10661,7 @@ export interface components {
                                      *     success_rate_standard_deviation_factor).
                                      *     Either int or decimal represented as string.
                                      */
-                                    standardDeviationFactor?: number | string;
+                                    standardDeviationFactor?: string;
                                 };
                                 /**
                                  * @description In the default mode (outlierDetection.splitExternalAndLocalErrors is
@@ -10693,7 +10693,7 @@ export interface components {
                              *     the default is 50%. To disable panic mode, set to 0%.
                              *     Either int or decimal represented as string.
                              */
-                            healthyPanicThreshold?: number | string;
+                            healthyPanicThreshold?: string;
                             /**
                              * @description The time interval between ejection analysis sweeps. This can result in
                              *     both new ejections and hosts being returned to service.
@@ -10938,7 +10938,7 @@ export interface components {
                                      *     success_rate_standard_deviation_factor).
                                      *     Either int or decimal represented as string.
                                      */
-                                    standardDeviationFactor?: number | string;
+                                    standardDeviationFactor?: string;
                                 };
                                 /**
                                  * @description In the default mode (outlierDetection.splitExternalAndLocalErrors is
@@ -10970,7 +10970,7 @@ export interface components {
                              *     the default is 50%. To disable panic mode, set to 0%.
                              *     Either int or decimal represented as string.
                              */
-                            healthyPanicThreshold?: number | string;
+                            healthyPanicThreshold?: string;
                             /**
                              * @description The time interval between ejection analysis sweeps. This can result in
                              *     both new ejections and hosts being returned to service.
@@ -11224,7 +11224,7 @@ export interface components {
                                      *     success_rate_standard_deviation_factor).
                                      *     Either int or decimal represented as string.
                                      */
-                                    standardDeviationFactor?: number | string;
+                                    standardDeviationFactor?: string;
                                 };
                                 /**
                                  * @description In the default mode (outlierDetection.splitExternalAndLocalErrors is
@@ -11256,7 +11256,7 @@ export interface components {
                              *     the default is 50%. To disable panic mode, set to 0%.
                              *     Either int or decimal represented as string.
                              */
-                            healthyPanicThreshold?: number | string;
+                            healthyPanicThreshold?: string;
                             /**
                              * @description The time interval between ejection analysis sweeps. This can result in
                              *     both new ejections and hosts being returned to service.
@@ -11378,7 +11378,7 @@ export interface components {
                                  * @description Percentage of requests on which abort will be injected, has to be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                             };
                             /** @description Delay defines configuration of delaying a response from a destination */
                             delay?: {
@@ -11386,7 +11386,7 @@ export interface components {
                                  * @description Percentage of requests on which delay will be injected, has to be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                                 /** @description The duration during which the response will be delayed */
                                 value: string;
                             };
@@ -11404,7 +11404,7 @@ export interface components {
                                  * @description Percentage of requests on which response bandwidth limit will be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                             };
                         }[];
                     };
@@ -11466,7 +11466,7 @@ export interface components {
                                  * @description Percentage of requests on which abort will be injected, has to be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                             };
                             /** @description Delay defines configuration of delaying a response from a destination */
                             delay?: {
@@ -11474,7 +11474,7 @@ export interface components {
                                  * @description Percentage of requests on which delay will be injected, has to be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                                 /** @description The duration during which the response will be delayed */
                                 value: string;
                             };
@@ -11492,7 +11492,7 @@ export interface components {
                                  * @description Percentage of requests on which response bandwidth limit will be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                             };
                         }[];
                     };
@@ -11568,7 +11568,7 @@ export interface components {
                                  * @description Percentage of requests on which abort will be injected, has to be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                             };
                             /** @description Delay defines configuration of delaying a response from a destination */
                             delay?: {
@@ -11576,7 +11576,7 @@ export interface components {
                                  * @description Percentage of requests on which delay will be injected, has to be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                                 /** @description The duration during which the response will be delayed */
                                 value: string;
                             };
@@ -11594,7 +11594,7 @@ export interface components {
                                  * @description Percentage of requests on which response bandwidth limit will be
                                  *     either int or decimal represented as string.
                                  */
-                                percentage: number | string;
+                                percentage: string;
                             };
                         }[];
                     };
@@ -11775,7 +11775,12 @@ export interface components {
                                 /** @default 1 */
                                 weight: number;
                             }[];
-                            filters?: {
+                            filters?: ({
+                                /** @enum {string} */
+                                type: "RequestHeaderModifier" | "ResponseHeaderModifier" | "RequestRedirect" | "URLRewrite" | "RequestMirror";
+                            } & ({
+                                /** @constant */
+                                type?: "RequestHeaderModifier";
                                 /**
                                  * @description Only one action is supported per header name.
                                  *     Configuration to set or add multiple values for a header must use RFC 7230
@@ -11792,6 +11797,98 @@ export interface components {
                                         value: string;
                                     }[];
                                 };
+                            } | {
+                                /** @constant */
+                                type?: "ResponseHeaderModifier";
+                                /**
+                                 * @description Only one action is supported per header name.
+                                 *     Configuration to set or add multiple values for a header must use RFC 7230
+                                 *     header value formatting, separating each value with a comma.
+                                 */
+                                responseHeaderModifier?: {
+                                    add?: {
+                                        name: string;
+                                        value: string;
+                                    }[];
+                                    remove?: string[];
+                                    set?: {
+                                        name: string;
+                                        value: string;
+                                    }[];
+                                };
+                            } | {
+                                /** @constant */
+                                type?: "RequestRedirect";
+                                requestRedirect?: {
+                                    /**
+                                     * @description PreciseHostname is the fully qualified domain name of a network host. This
+                                     *     matches the RFC 1123 definition of a hostname with 1 notable exception that
+                                     *     numeric IP addresses are not allowed.
+                                     *
+                                     *     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                     *     alphanumeric characters or '-', and must start and end with an alphanumeric
+                                     *     character. No other punctuation is allowed.
+                                     */
+                                    hostname?: string;
+                                    /**
+                                     * @description Path defines parameters used to modify the path of the incoming request.
+                                     *     The modified path is then used to construct the location header.
+                                     *     When empty, the request path is used as-is.
+                                     * @default {
+                                     *       "type": "ReplaceFullPath",
+                                     *       "replaceFullPath": ""
+                                     *     }
+                                     */
+                                    path: {
+                                        /** @enum {string} */
+                                        type: "ReplaceFullPath" | "ReplacePrefixMatch";
+                                    } & ({
+                                        /** @constant */
+                                        type?: "ReplaceFullPath";
+                                        replaceFullPath?: string;
+                                    } | {
+                                        /** @constant */
+                                        type?: "ReplacePrefixMatch";
+                                        replacePrefixMatch?: string;
+                                    });
+                                    /**
+                                     * Format: int32
+                                     * @description Port is the port to be used in the value of the `Location`
+                                     *     header in the response.
+                                     *     When empty, port (if specified) of the request is used.
+                                     */
+                                    port?: number;
+                                    /** @enum {string} */
+                                    scheme?: "http" | "https";
+                                    /**
+                                     * @description StatusCode is the HTTP status code to be used in response.
+                                     * @default 302
+                                     * @enum {integer}
+                                     */
+                                    statusCode: 301 | 302 | 303 | 307 | 308;
+                                };
+                            } | {
+                                /** @constant */
+                                type?: "URLRewrite";
+                                urlRewrite?: {
+                                    /**
+                                     * @description HostToBackendHostname rewrites the hostname to the hostname of the
+                                     *     upstream host. This option is only available when targeting MeshGateways.
+                                     */
+                                    hostToBackendHostname?: boolean;
+                                    /** @description Hostname is the value to be used to replace the host header value during forwarding. */
+                                    hostname?: string;
+                                    /** @description Path defines a path rewrite. */
+                                    path?: {
+                                        replaceFullPath?: string;
+                                        replacePrefixMatch?: string;
+                                        /** @enum {string} */
+                                        type: "ReplaceFullPath" | "ReplacePrefixMatch";
+                                    };
+                                };
+                            } | {
+                                /** @constant */
+                                type?: "RequestMirror";
                                 requestMirror?: {
                                     /** @description BackendRef defines where to forward traffic. */
                                     backendRef: {
@@ -11848,81 +11945,9 @@ export interface components {
                                      * @description Percentage of requests to mirror. If not specified, all requests
                                      *     to the target cluster will be mirrored.
                                      */
-                                    percentage?: number | string;
+                                    percentage?: string;
                                 };
-                                requestRedirect?: {
-                                    /**
-                                     * @description PreciseHostname is the fully qualified domain name of a network host. This
-                                     *     matches the RFC 1123 definition of a hostname with 1 notable exception that
-                                     *     numeric IP addresses are not allowed.
-                                     *
-                                     *     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-                                     *     alphanumeric characters or '-', and must start and end with an alphanumeric
-                                     *     character. No other punctuation is allowed.
-                                     */
-                                    hostname?: string;
-                                    /**
-                                     * @description Path defines parameters used to modify the path of the incoming request.
-                                     *     The modified path is then used to construct the location header.
-                                     *     When empty, the request path is used as-is.
-                                     */
-                                    path?: {
-                                        replaceFullPath?: string;
-                                        replacePrefixMatch?: string;
-                                        /** @enum {string} */
-                                        type: "ReplaceFullPath" | "ReplacePrefixMatch";
-                                    };
-                                    /**
-                                     * Format: int32
-                                     * @description Port is the port to be used in the value of the `Location`
-                                     *     header in the response.
-                                     *     When empty, port (if specified) of the request is used.
-                                     */
-                                    port?: number;
-                                    /** @enum {string} */
-                                    scheme?: "http" | "https";
-                                    /**
-                                     * @description StatusCode is the HTTP status code to be used in response.
-                                     * @default 302
-                                     * @enum {integer}
-                                     */
-                                    statusCode: 301 | 302 | 303 | 307 | 308;
-                                };
-                                /**
-                                 * @description Only one action is supported per header name.
-                                 *     Configuration to set or add multiple values for a header must use RFC 7230
-                                 *     header value formatting, separating each value with a comma.
-                                 */
-                                responseHeaderModifier?: {
-                                    add?: {
-                                        name: string;
-                                        value: string;
-                                    }[];
-                                    remove?: string[];
-                                    set?: {
-                                        name: string;
-                                        value: string;
-                                    }[];
-                                };
-                                /** @enum {string} */
-                                type: "RequestHeaderModifier" | "ResponseHeaderModifier" | "RequestRedirect" | "URLRewrite" | "RequestMirror";
-                                urlRewrite?: {
-                                    /**
-                                     * @description HostToBackendHostname rewrites the hostname to the hostname of the
-                                     *     upstream host. This option is only available when targeting MeshGateways.
-                                     */
-                                    hostToBackendHostname?: boolean;
-                                    /** @description Hostname is the value to be used to replace the host header value during forwarding. */
-                                    hostname?: string;
-                                    /** @description Path defines a path rewrite. */
-                                    path?: {
-                                        replaceFullPath?: string;
-                                        replacePrefixMatch?: string;
-                                        /** @enum {string} */
-                                        type: "ReplaceFullPath" | "ReplacePrefixMatch";
-                                    };
-                                };
-                            }[];
+                            }))[];
                         };
                         /**
                          * @description Matches describes how to match HTTP requests this rule should be applied
@@ -12123,7 +12148,7 @@ export interface components {
                          *     Deprecated: the setting has been moved to MeshCircuitBreaker policy,
                          *     please use MeshCircuitBreaker policy instead.
                          */
-                        healthyPanicThreshold?: number | string;
+                        healthyPanicThreshold?: string;
                         /**
                          * Format: int32
                          * @description Number of consecutive healthy checks before considering a host healthy.
@@ -12391,8 +12416,26 @@ export interface components {
                             /** @enum {string} */
                             type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
                         }[];
-                        /** @description LoadBalancer allows to specify load balancing algorithm. */
-                        loadBalancer?: {
+                        /**
+                         * @description LoadBalancer allows to specify load balancing algorithm.
+                         * @default {
+                         *       "type": "RoundRobin"
+                         *     }
+                         */
+                        loadBalancer: {
+                            /** @enum {string} */
+                            type: "RoundRobin" | "LeastRequest" | "RingHash" | "Random" | "Maglev";
+                        } & ({
+                            /** @constant */
+                            type?: "RoundRobin";
+                            /**
+                             * @description RoundRobin is a load balancing algorithm that distributes requests
+                             *     across available upstream hosts in round-robin order.
+                             */
+                            roundRobin?: Record<string, never>;
+                        } | {
+                            /** @constant */
+                            type?: "LeastRequest";
                             /**
                              * @description LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
                              *     and picks the host which has the fewest active requests
@@ -12405,7 +12448,7 @@ export interface components {
                                  *     value, the more forcefully it reduces the load balancing weight of endpoints that are
                                  *     actively serving requests.
                                  */
-                                activeRequestBias?: number | string;
+                                activeRequestBias?: string;
                                 /**
                                  * Format: int32
                                  * @description ChoiceCount is the number of random healthy hosts from which the host with
@@ -12414,78 +12457,9 @@ export interface components {
                                  */
                                 choiceCount?: number;
                             };
-                            /**
-                             * @description Maglev implements consistent hashing to upstream hosts. Maglev can be used as
-                             *     a drop in replacement for the ring hash load balancer any place in which
-                             *     consistent hashing is desired.
-                             */
-                            maglev?: {
-                                /**
-                                 * @description HashPolicies specify a list of request/connection properties that are used to calculate a hash.
-                                 *     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
-                                 *     set to true, and there is already a hash generated, the hash is returned immediately,
-                                 *     ignoring the rest of the hash policy list.
-                                 */
-                                hashPolicies?: {
-                                    connection?: {
-                                        /** @description Hash on source IP address. */
-                                        sourceIP?: boolean;
-                                    };
-                                    cookie?: {
-                                        /** @description The name of the cookie that will be used to obtain the hash key. */
-                                        name: string;
-                                        /** @description The name of the path for the cookie. */
-                                        path?: string;
-                                        /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
-                                        ttl?: string;
-                                    };
-                                    filterState?: {
-                                        /**
-                                         * @description The name of the Object in the per-request filterState, which is
-                                         *     an Envoy::Hashable object. If there is no data associated with the key,
-                                         *     or the stored object is not Envoy::Hashable, no hash will be produced.
-                                         */
-                                        key: string;
-                                    };
-                                    header?: {
-                                        /** @description The name of the request header that will be used to obtain the hash key. */
-                                        name: string;
-                                    };
-                                    queryParameter?: {
-                                        /**
-                                         * @description The name of the URL query parameter that will be used to obtain the hash key.
-                                         *     If the parameter is not present, no hash will be produced. Query parameter names
-                                         *     are case-sensitive.
-                                         */
-                                        name: string;
-                                    };
-                                    /**
-                                     * @description Terminal is a flag that short-circuits the hash computing. This field provides
-                                     *     a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
-                                     *     to rest of the policy list”, it saves time when the terminal policy works.
-                                     *     If true, and there is already a hash computed, ignore rest of the list of hash polices.
-                                     */
-                                    terminal?: boolean;
-                                    /** @enum {string} */
-                                    type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
-                                }[];
-                                /**
-                                 * Format: int32
-                                 * @description The table size for Maglev hashing. Maglev aims for “minimal disruption”
-                                 *     rather than an absolute guarantee. Minimal disruption means that when
-                                 *     the set of upstream hosts change, a connection will likely be sent
-                                 *     to the same upstream as it was before. Increasing the table size reduces
-                                 *     the amount of disruption. The table size must be prime number limited to 5000011.
-                                 *     If it is not specified, the default is 65537.
-                                 */
-                                tableSize?: number;
-                            };
-                            /**
-                             * @description Random selects a random available host. The random load balancer generally
-                             *     performs better than round-robin if no health checking policy is configured.
-                             *     Random selection avoids bias towards the host in the set that comes after a failed host.
-                             */
-                            random?: Record<string, never>;
+                        } | {
+                            /** @constant */
+                            type?: "RingHash";
                             /**
                              * @description RingHash  implements consistent hashing to upstream hosts. Each host is mapped
                              *     onto a circle (the “ring”) by hashing its address; each request is then routed
@@ -12505,39 +12479,7 @@ export interface components {
                                  *     set to true, and there is already a hash generated, the hash is returned immediately,
                                  *     ignoring the rest of the hash policy list.
                                  */
-                                hashPolicies?: {
-                                    connection?: {
-                                        /** @description Hash on source IP address. */
-                                        sourceIP?: boolean;
-                                    };
-                                    cookie?: {
-                                        /** @description The name of the cookie that will be used to obtain the hash key. */
-                                        name: string;
-                                        /** @description The name of the path for the cookie. */
-                                        path?: string;
-                                        /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
-                                        ttl?: string;
-                                    };
-                                    filterState?: {
-                                        /**
-                                         * @description The name of the Object in the per-request filterState, which is
-                                         *     an Envoy::Hashable object. If there is no data associated with the key,
-                                         *     or the stored object is not Envoy::Hashable, no hash will be produced.
-                                         */
-                                        key: string;
-                                    };
-                                    header?: {
-                                        /** @description The name of the request header that will be used to obtain the hash key. */
-                                        name: string;
-                                    };
-                                    queryParameter?: {
-                                        /**
-                                         * @description The name of the URL query parameter that will be used to obtain the hash key.
-                                         *     If the parameter is not present, no hash will be produced. Query parameter names
-                                         *     are case-sensitive.
-                                         */
-                                        name: string;
-                                    };
+                                hashPolicies?: ({
                                     /**
                                      * @description Terminal is a flag that short-circuits the hash computing. This field provides
                                      *     a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
@@ -12547,7 +12489,54 @@ export interface components {
                                     terminal?: boolean;
                                     /** @enum {string} */
                                     type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
-                                }[];
+                                } & ({
+                                    /** @constant */
+                                    type?: "Header";
+                                    header?: {
+                                        /** @description The name of the request header that will be used to obtain the hash key. */
+                                        name: string;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "Cookie";
+                                    header?: {
+                                        /** @description The name of the cookie that will be used to obtain the hash key. */
+                                        name: string;
+                                        /** @description The name of the path for the cookie. */
+                                        path?: string;
+                                        /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
+                                        ttl?: string;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "Connection";
+                                    connection?: {
+                                        /** @description Hash on source IP address. */
+                                        sourceIP?: boolean;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "QueryParameter";
+                                    queryParameter?: {
+                                        /**
+                                         * @description The name of the URL query parameter that will be used to obtain the hash key.
+                                         *     If the parameter is not present, no hash will be produced. Query parameter names
+                                         *     are case-sensitive.
+                                         */
+                                        name: string;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "FilterState";
+                                    filterState?: {
+                                        /**
+                                         * @description The name of the Object in the per-request filterState, which is
+                                         *     an Envoy::Hashable object. If there is no data associated with the key,
+                                         *     or the stored object is not Envoy::Hashable, no hash will be produced.
+                                         */
+                                        key: string;
+                                    };
+                                }))[];
                                 /**
                                  * Format: int32
                                  * @description Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
@@ -12562,14 +12551,100 @@ export interface components {
                                  */
                                 minRingSize?: number;
                             };
+                        } | {
+                            /** @constant */
+                            type?: "Random";
                             /**
-                             * @description RoundRobin is a load balancing algorithm that distributes requests
-                             *     across available upstream hosts in round-robin order.
+                             * @description Random selects a random available host. The random load balancer generally
+                             *     performs better than round-robin if no health checking policy is configured.
+                             *     Random selection avoids bias towards the host in the set that comes after a failed host.
                              */
-                            roundRobin?: Record<string, never>;
-                            /** @enum {string} */
-                            type: "RoundRobin" | "LeastRequest" | "RingHash" | "Random" | "Maglev";
-                        };
+                            random?: Record<string, never>;
+                        } | {
+                            /** @constant */
+                            type?: "Maglev";
+                            /**
+                             * @description Maglev implements consistent hashing to upstream hosts. Maglev can be used as
+                             *     a drop in replacement for the ring hash load balancer any place in which
+                             *     consistent hashing is desired.
+                             */
+                            maglev?: {
+                                /**
+                                 * @description HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                 *     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                 *     set to true, and there is already a hash generated, the hash is returned immediately,
+                                 *     ignoring the rest of the hash policy list.
+                                 */
+                                hashPolicies?: ({
+                                    /**
+                                     * @description Terminal is a flag that short-circuits the hash computing. This field provides
+                                     *     a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                     *     to rest of the policy list”, it saves time when the terminal policy works.
+                                     *     If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                     */
+                                    terminal?: boolean;
+                                    /** @enum {string} */
+                                    type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
+                                } & ({
+                                    /** @constant */
+                                    type?: "Header";
+                                    header?: {
+                                        /** @description The name of the request header that will be used to obtain the hash key. */
+                                        name: string;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "Cookie";
+                                    header?: {
+                                        /** @description The name of the cookie that will be used to obtain the hash key. */
+                                        name: string;
+                                        /** @description The name of the path for the cookie. */
+                                        path?: string;
+                                        /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
+                                        ttl?: string;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "Connection";
+                                    connection?: {
+                                        /** @description Hash on source IP address. */
+                                        sourceIP?: boolean;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "QueryParameter";
+                                    queryParameter?: {
+                                        /**
+                                         * @description The name of the URL query parameter that will be used to obtain the hash key.
+                                         *     If the parameter is not present, no hash will be produced. Query parameter names
+                                         *     are case-sensitive.
+                                         */
+                                        name: string;
+                                    };
+                                } | {
+                                    /** @constant */
+                                    type?: "FilterState";
+                                    filterState?: {
+                                        /**
+                                         * @description The name of the Object in the per-request filterState, which is
+                                         *     an Envoy::Hashable object. If there is no data associated with the key,
+                                         *     or the stored object is not Envoy::Hashable, no hash will be produced.
+                                         */
+                                        key: string;
+                                    };
+                                }))[];
+                                /**
+                                 * Format: int32
+                                 * @description The table size for Maglev hashing. Maglev aims for “minimal disruption”
+                                 *     rather than an absolute guarantee. Minimal disruption means that when
+                                 *     the set of upstream hosts change, a connection will likely be sent
+                                 *     to the same upstream as it was before. Increasing the table size reduces
+                                 *     the amount of disruption. The table size must be prime number limited to 5000011.
+                                 *     If it is not specified, the default is 65537.
+                                 */
+                                tableSize?: number;
+                            };
+                        });
                         /** @description LocalityAwareness contains configuration for locality aware load balancing. */
                         localityAwareness?: {
                             /**
@@ -12604,7 +12679,7 @@ export interface components {
                                  *     Default 50
                                  */
                                 failoverThreshold?: {
-                                    percentage: number | string;
+                                    percentage: string;
                                 };
                             };
                             /**
@@ -12729,14 +12804,15 @@ export interface components {
                         port: number;
                     }[];
                     /** @description Backends list that will be used to collect metrics. */
-                    backends?: {
-                        /** @description OpenTelemetry backend configuration */
-                        openTelemetry?: {
-                            /** @description Endpoint for OpenTelemetry collector */
-                            endpoint: string;
-                            /** @description RefreshInterval defines how frequent metrics should be pushed to collector */
-                            refreshInterval?: string;
-                        };
+                    backends?: ({
+                        /**
+                         * @description Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
+                         * @enum {string}
+                         */
+                        type: "Prometheus" | "OpenTelemetry";
+                    } & ({
+                        /** @constant */
+                        type?: "Prometheus";
                         /** @description Prometheus backend configuration. */
                         prometheus?: {
                             /** @description ClientId of the Prometheus backend. Needed when using MADS for DP discovery. */
@@ -12762,12 +12838,17 @@ export interface components {
                                 mode: "Disabled" | "ProvidedTLS" | "ActiveMTLSBackend";
                             };
                         };
-                        /**
-                         * @description Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
-                         * @enum {string}
-                         */
-                        type: "Prometheus" | "OpenTelemetry";
-                    }[];
+                    } | {
+                        /** @constant */
+                        type?: "OpenTelemetry";
+                        /** @description OpenTelemetry backend configuration */
+                        openTelemetry?: {
+                            /** @description Endpoint for OpenTelemetry collector */
+                            endpoint: string;
+                            /** @description RefreshInterval defines how frequent metrics should be pushed to collector */
+                            refreshInterval?: string;
+                        };
+                    }))[];
                     /** @description Sidecar metrics collection configuration */
                     sidecar?: {
                         /**
@@ -14740,34 +14821,12 @@ export interface components {
                      *     reasons explained in MADR 009-tracing-policy this has to be a one element
                      *     array for now.
                      */
-                    backends?: {
-                        /** @description Datadog backend configuration. */
-                        datadog?: {
-                            /**
-                             * @description Determines if datadog service name should be split based on traffic
-                             *     direction and destination. For example, with `splitService: true` and a
-                             *     `backend` service that communicates with a couple of databases, you would
-                             *     get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
-                             *     `backend_OUTBOUND_db2` in Datadog.
-                             * @default false
-                             */
-                            splitService: boolean;
-                            /**
-                             * @description Address of Datadog collector, only host and port are allowed (no paths,
-                             *     fragments etc.)
-                             */
-                            url: string;
-                        };
-                        /** @description OpenTelemetry backend configuration. */
-                        openTelemetry?: {
-                            /**
-                             * @description Address of OpenTelemetry collector.
-                             * @example otel-collector:4317
-                             */
-                            endpoint: string;
-                        };
+                    backends?: ({
                         /** @enum {string} */
                         type: "Zipkin" | "Datadog" | "OpenTelemetry";
+                    } & ({
+                        /** @constant */
+                        type?: "Zipkin";
                         /** @description Zipkin backend configuration. */
                         zipkin?: {
                             /**
@@ -14792,7 +14851,38 @@ export interface components {
                             /** @description Address of Zipkin collector. */
                             url: string;
                         };
-                    }[];
+                    } | {
+                        /** @constant */
+                        type?: "Datadog";
+                        /** @description Datadog backend configuration. */
+                        datadog?: {
+                            /**
+                             * @description Determines if datadog service name should be split based on traffic
+                             *     direction and destination. For example, with `splitService: true` and a
+                             *     `backend` service that communicates with a couple of databases, you would
+                             *     get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+                             *     `backend_OUTBOUND_db2` in Datadog.
+                             * @default false
+                             */
+                            splitService: boolean;
+                            /**
+                             * @description Address of Datadog collector, only host and port are allowed (no paths,
+                             *     fragments etc.)
+                             */
+                            url: string;
+                        };
+                    } | {
+                        /** @constant */
+                        type?: "OpenTelemetry";
+                        /** @description OpenTelemetry backend configuration. */
+                        openTelemetry?: {
+                            /**
+                             * @description Address of OpenTelemetry collector.
+                             * @example otel-collector:4317
+                             */
+                            endpoint: string;
+                        };
+                    }))[];
                     /**
                      * @description Sampling configuration.
                      *     Sampling is the process by which a decision is made on whether to
@@ -14806,7 +14896,7 @@ export interface components {
                          *     Either int or decimal represented as string.
                          *     If not specified then the default value is 100.
                          */
-                        client?: number | string;
+                        client?: string;
                         /**
                          * @description Target percentage of requests will be traced
                          *     after all other sampling checks have been applied (client, force tracing,
@@ -14819,7 +14909,7 @@ export interface components {
                          *     Either int or decimal represented as string.
                          *     If not specified then the default value is 100.
                          */
-                        overall?: number | string;
+                        overall?: string;
                         /**
                          * @description Target percentage of requests that will be randomly selected for trace
                          *     generation, if not requested by the client or not forced.
@@ -14828,7 +14918,7 @@ export interface components {
                          *     Either int or decimal represented as string.
                          *     If not specified then the default value is 100.
                          */
-                        random?: number | string;
+                        random?: string;
                     };
                     /**
                      * @description Custom tags configuration. You can add custom tags to traces based on

--- a/packages/kuma-http-api/openapi.overlay.tmpl.yaml
+++ b/packages/kuma-http-api/openapi.overlay.tmpl.yaml
@@ -48,6 +48,13 @@ actions:
   - target: '$..[?(@["x-request"])].properties..[?(@.readOnly)]'
     remove: true
 
+  - target: '$..[?(@["x-request"])].properties..[?(@["x-kubernetes-int-or-string"])]'
+    update:
+      type: string
+  - target: '$..[?(@["x-request"])].properties..[?(@["x-kubernetes-int-or-string"])].anyOf'
+    remove: true
+
+
   # from in any spec/policy is deprecated
   - target: '$..[?(@["x-request"])].properties.spec..from'
     update:

--- a/packages/kuma-http-api/openapi.yaml
+++ b/packages/kuma-http-api/openapi.yaml
@@ -15675,8 +15675,7 @@ components:
                             file:
                               path: ''
                           oneOf:
-                            - title: TCP
-                              type: object
+                            - type: object
                               default:
                                 type: Tcp
                                 tcp:
@@ -15699,8 +15698,7 @@ components:
                                         https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                       type: object
                                       oneOf:
-                                        - title: JSON
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Json
                                             json: []
@@ -15724,8 +15722,7 @@ components:
                                                   value: '%START_TIME%'
                                                 - key: bytes_received
                                                   value: '%BYTES_RECEIVED%'
-                                        - title: Plain
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Plain
                                             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -15748,8 +15745,7 @@ components:
                                         - type
                                   required:
                                     - address
-                            - title: File
-                              type: object
+                            - type: object
                               default:
                                 type: File
                                 file:
@@ -15767,8 +15763,7 @@ components:
                                         https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                       type: object
                                       oneOf:
-                                        - title: JSON
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Json
                                             json: []
@@ -15792,8 +15787,7 @@ components:
                                                   value: '%START_TIME%'
                                                 - key: bytes_received
                                                   value: '%BYTES_RECEIVED%'
-                                        - title: Plain
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Plain
                                             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -15821,8 +15815,7 @@ components:
                                       minLength: 1
                                   required:
                                     - path
-                            - title: OpenTelemetry
-                              type: object
+                            - type: object
                               default:
                                 type: OpenTelemetry
                                 openTelemetry:
@@ -15946,8 +15939,7 @@ components:
                             file:
                               path: ''
                           oneOf:
-                            - title: TCP
-                              type: object
+                            - type: object
                               default:
                                 type: Tcp
                                 tcp:
@@ -15970,8 +15962,7 @@ components:
                                         https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                       type: object
                                       oneOf:
-                                        - title: JSON
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Json
                                             json: []
@@ -15995,8 +15986,7 @@ components:
                                                   value: '%START_TIME%'
                                                 - key: bytes_received
                                                   value: '%BYTES_RECEIVED%'
-                                        - title: Plain
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Plain
                                             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -16019,8 +16009,7 @@ components:
                                         - type
                                   required:
                                     - address
-                            - title: File
-                              type: object
+                            - type: object
                               default:
                                 type: File
                                 file:
@@ -16038,8 +16027,7 @@ components:
                                         https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                       type: object
                                       oneOf:
-                                        - title: JSON
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Json
                                             json: []
@@ -16063,8 +16051,7 @@ components:
                                                   value: '%START_TIME%'
                                                 - key: bytes_received
                                                   value: '%BYTES_RECEIVED%'
-                                        - title: Plain
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Plain
                                             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -16092,8 +16079,7 @@ components:
                                       minLength: 1
                                   required:
                                     - path
-                            - title: OpenTelemetry
-                              type: object
+                            - type: object
                               default:
                                 type: OpenTelemetry
                                 openTelemetry:
@@ -16217,8 +16203,7 @@ components:
                             file:
                               path: ''
                           oneOf:
-                            - title: TCP
-                              type: object
+                            - type: object
                               default:
                                 type: Tcp
                                 tcp:
@@ -16241,8 +16226,7 @@ components:
                                         https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                       type: object
                                       oneOf:
-                                        - title: JSON
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Json
                                             json: []
@@ -16266,8 +16250,7 @@ components:
                                                   value: '%START_TIME%'
                                                 - key: bytes_received
                                                   value: '%BYTES_RECEIVED%'
-                                        - title: Plain
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Plain
                                             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -16290,8 +16273,7 @@ components:
                                         - type
                                   required:
                                     - address
-                            - title: File
-                              type: object
+                            - type: object
                               default:
                                 type: File
                                 file:
@@ -16309,8 +16291,7 @@ components:
                                         https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                       type: object
                                       oneOf:
-                                        - title: JSON
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Json
                                             json: []
@@ -16334,8 +16315,7 @@ components:
                                                   value: '%START_TIME%'
                                                 - key: bytes_received
                                                   value: '%BYTES_RECEIVED%'
-                                        - title: Plain
-                                          type: object
+                                        - type: object
                                           default:
                                             type: Plain
                                             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -16363,8 +16343,7 @@ components:
                                       minLength: 1
                                   required:
                                     - path
-                            - title: OpenTelemetry
-                              type: object
+                            - type: object
                               default:
                                 type: OpenTelemetry
                                 openTelemetry:
@@ -16723,9 +16702,7 @@ components:
                                       deviation of the mean success rate: mean - (standard_deviation *
                                       success_rate_standard_deviation_factor).
                                       Either int or decimal represented as string.
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
+                                    type: string
                                     x-kubernetes-int-or-string: true
                               totalFailures:
                                 description: |-
@@ -16757,9 +16734,7 @@ components:
                               Allows to configure panic threshold for Envoy cluster. If not specified,
                               the default is 50%. To disable panic mode, set to 0%.
                               Either int or decimal represented as string.
-                            anyOf:
-                              - type: integer
-                              - type: string
+                            type: string
                             x-kubernetes-int-or-string: true
                           interval:
                             description: |-
@@ -17018,9 +16993,7 @@ components:
                                       deviation of the mean success rate: mean - (standard_deviation *
                                       success_rate_standard_deviation_factor).
                                       Either int or decimal represented as string.
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
+                                    type: string
                                     x-kubernetes-int-or-string: true
                               totalFailures:
                                 description: |-
@@ -17052,9 +17025,7 @@ components:
                               Allows to configure panic threshold for Envoy cluster. If not specified,
                               the default is 50%. To disable panic mode, set to 0%.
                               Either int or decimal represented as string.
-                            anyOf:
-                              - type: integer
-                              - type: string
+                            type: string
                             x-kubernetes-int-or-string: true
                           interval:
                             description: |-
@@ -17324,9 +17295,7 @@ components:
                                       deviation of the mean success rate: mean - (standard_deviation *
                                       success_rate_standard_deviation_factor).
                                       Either int or decimal represented as string.
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
+                                    type: string
                                     x-kubernetes-int-or-string: true
                               totalFailures:
                                 description: |-
@@ -17358,9 +17327,7 @@ components:
                               Allows to configure panic threshold for Envoy cluster. If not specified,
                               the default is 50%. To disable panic mode, set to 0%.
                               Either int or decimal represented as string.
-                            anyOf:
-                              - type: integer
-                              - type: string
+                            type: string
                             x-kubernetes-int-or-string: true
                           interval:
                             description: |-
@@ -17529,9 +17496,7 @@ components:
                                   description: |-
                                     Percentage of requests on which abort will be injected, has to be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                               required:
                                 - httpStatus
@@ -17544,9 +17509,7 @@ components:
                                   description: |-
                                     Percentage of requests on which delay will be injected, has to be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                                 value:
                                   description: The duration during which the response will be delayed
@@ -17569,9 +17532,7 @@ components:
                                   description: |-
                                     Percentage of requests on which response bandwidth limit will be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                               required:
                                 - limit
@@ -17651,9 +17612,7 @@ components:
                                   description: |-
                                     Percentage of requests on which abort will be injected, has to be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                               required:
                                 - httpStatus
@@ -17666,9 +17625,7 @@ components:
                                   description: |-
                                     Percentage of requests on which delay will be injected, has to be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                                 value:
                                   description: The duration during which the response will be delayed
@@ -17691,9 +17648,7 @@ components:
                                   description: |-
                                     Percentage of requests on which response bandwidth limit will be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                               required:
                                 - limit
@@ -17798,9 +17753,7 @@ components:
                                   description: |-
                                     Percentage of requests on which abort will be injected, has to be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                               required:
                                 - httpStatus
@@ -17813,9 +17766,7 @@ components:
                                   description: |-
                                     Percentage of requests on which delay will be injected, has to be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                                 value:
                                   description: The duration during which the response will be delayed
@@ -17838,9 +17789,7 @@ components:
                                   description: |-
                                     Percentage of requests on which response bandwidth limit will be
                                     either int or decimal represented as string.
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
+                                  type: string
                                   x-kubernetes-int-or-string: true
                               required:
                                 - limit
@@ -18094,250 +18043,11 @@ components:
                                 required:
                                   - kind
                                 type: object
+                                x-kuma-type: TargetRef
                             filters:
                               type: array
                               items:
                                 properties:
-                                  requestHeaderModifier:
-                                    description: |-
-                                      Only one action is supported per header name.
-                                      Configuration to set or add multiple values for a header must use RFC 7230
-                                      header value formatting, separating each value with a comma.
-                                    type: object
-                                    properties:
-                                      add:
-                                        type: array
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                              maxLength: 256
-                                              minLength: 1
-                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        maxItems: 16
-                                        x-kubernetes-list-map-keys:
-                                          - name
-                                        x-kubernetes-list-type: map
-                                      remove:
-                                        type: array
-                                        items:
-                                          type: string
-                                        maxItems: 16
-                                      set:
-                                        type: array
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                              maxLength: 256
-                                              minLength: 1
-                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        maxItems: 16
-                                        x-kubernetes-list-map-keys:
-                                          - name
-                                        x-kubernetes-list-type: map
-                                  requestMirror:
-                                    type: object
-                                    properties:
-                                      backendRef:
-                                        description: BackendRef defines where to forward traffic.
-                                        type: object
-                                        properties:
-                                          kind:
-                                            description: Kind of the referenced resource
-                                            type: string
-                                            enum:
-                                              - Mesh
-                                              - MeshSubset
-                                              - MeshGateway
-                                              - MeshService
-                                              - MeshExternalService
-                                              - MeshMultiZoneService
-                                              - MeshServiceSubset
-                                              - MeshHTTPRoute
-                                              - Dataplane
-                                          labels:
-                                            description: |-
-                                              Labels are used to select group of MeshServices that match labels. Either Labels or
-                                              Name and Namespace can be used.
-                                            type: object
-                                            additionalProperties:
-                                              type: string
-                                          mesh:
-                                            description: Mesh is reserved for future use to identify cross mesh resources.
-                                            type: string
-                                          name:
-                                            description: |-
-                                              Name of the referenced resource. Can only be used with kinds: `MeshService`,
-                                              `MeshServiceSubset` and `MeshGatewayRoute`
-                                            type: string
-                                          namespace:
-                                            description: |-
-                                              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
-                                              will be targeted.
-                                            type: string
-                                          port:
-                                            description: Port is only supported when this ref refers to a real MeshService object
-                                            type: integer
-                                            format: int32
-                                          proxyTypes:
-                                            description: |-
-                                              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                              all data plane types are targeted by the policy.
-                                            type: array
-                                            items:
-                                              enum:
-                                                - Sidecar
-                                                - Gateway
-                                              type: string
-                                          sectionName:
-                                            description: |-
-                                              SectionName is used to target specific section of resource.
-                                              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
-                                            type: string
-                                          tags:
-                                            description: |-
-                                              Tags used to select a subset of proxies by tags. Can only be used with kinds
-                                              `MeshSubset` and `MeshServiceSubset`
-                                            type: object
-                                            additionalProperties:
-                                              type: string
-                                          weight:
-                                            type: integer
-                                            default: 1
-                                            minimum: 0
-                                        required:
-                                          - kind
-                                      percentage:
-                                        description: |-
-                                          Percentage of requests to mirror. If not specified, all requests
-                                          to the target cluster will be mirrored.
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - backendRef
-                                  requestRedirect:
-                                    type: object
-                                    properties:
-                                      hostname:
-                                        description: |-
-                                          PreciseHostname is the fully qualified domain name of a network host. This
-                                          matches the RFC 1123 definition of a hostname with 1 notable exception that
-                                          numeric IP addresses are not allowed.
-
-                                          Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-                                          alphanumeric characters or '-', and must start and end with an alphanumeric
-                                          character. No other punctuation is allowed.
-                                        type: string
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
-                                      path:
-                                        description: |-
-                                          Path defines parameters used to modify the path of the incoming request.
-                                          The modified path is then used to construct the location header.
-                                          When empty, the request path is used as-is.
-                                        type: object
-                                        properties:
-                                          replaceFullPath:
-                                            type: string
-                                          replacePrefixMatch:
-                                            type: string
-                                          type:
-                                            type: string
-                                            enum:
-                                              - ReplaceFullPath
-                                              - ReplacePrefixMatch
-                                        required:
-                                          - type
-                                      port:
-                                        description: |-
-                                          Port is the port to be used in the value of the `Location`
-                                          header in the response.
-                                          When empty, port (if specified) of the request is used.
-                                        type: integer
-                                        format: int32
-                                        maximum: 65535
-                                        minimum: 1
-                                      scheme:
-                                        type: string
-                                        enum:
-                                          - http
-                                          - https
-                                      statusCode:
-                                        description: StatusCode is the HTTP status code to be used in response.
-                                        type: integer
-                                        default: 302
-                                        enum:
-                                          - 301
-                                          - 302
-                                          - 303
-                                          - 307
-                                          - 308
-                                  responseHeaderModifier:
-                                    description: |-
-                                      Only one action is supported per header name.
-                                      Configuration to set or add multiple values for a header must use RFC 7230
-                                      header value formatting, separating each value with a comma.
-                                    type: object
-                                    properties:
-                                      add:
-                                        type: array
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                              maxLength: 256
-                                              minLength: 1
-                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        maxItems: 16
-                                        x-kubernetes-list-map-keys:
-                                          - name
-                                        x-kubernetes-list-type: map
-                                      remove:
-                                        type: array
-                                        items:
-                                          type: string
-                                        maxItems: 16
-                                      set:
-                                        type: array
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                              maxLength: 256
-                                              minLength: 1
-                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
-                                            value:
-                                              type: string
-                                          required:
-                                            - name
-                                            - value
-                                          type: object
-                                        maxItems: 16
-                                        x-kubernetes-list-map-keys:
-                                          - name
-                                        x-kubernetes-list-type: map
                                   type:
                                     type: string
                                     enum:
@@ -18346,38 +18056,332 @@ components:
                                       - RequestRedirect
                                       - URLRewrite
                                       - RequestMirror
-                                  urlRewrite:
-                                    type: object
-                                    properties:
-                                      hostToBackendHostname:
-                                        description: |-
-                                          HostToBackendHostname rewrites the hostname to the hostname of the
-                                          upstream host. This option is only available when targeting MeshGateways.
-                                        type: boolean
-                                      hostname:
-                                        description: Hostname is the value to be used to replace the host header value during forwarding.
-                                        type: string
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
-                                      path:
-                                        description: Path defines a path rewrite.
-                                        type: object
-                                        properties:
-                                          replaceFullPath:
-                                            type: string
-                                          replacePrefixMatch:
-                                            type: string
-                                          type:
-                                            type: string
-                                            enum:
-                                              - ReplaceFullPath
-                                              - ReplacePrefixMatch
-                                        required:
-                                          - type
                                 required:
                                   - type
                                 type: object
+                                default:
+                                  type: RequestHeaderModifier
+                                oneOf:
+                                  - type: object
+                                    default:
+                                      type: RequestHeaderModifier
+                                      roundRobin: {}
+                                    properties:
+                                      type:
+                                        const: RequestHeaderModifier
+                                      requestHeaderModifier:
+                                        description: |-
+                                          Only one action is supported per header name.
+                                          Configuration to set or add multiple values for a header must use RFC 7230
+                                          header value formatting, separating each value with a comma.
+                                        type: object
+                                        properties:
+                                          add:
+                                            type: array
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                                value:
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            maxItems: 16
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          remove:
+                                            type: array
+                                            items:
+                                              type: string
+                                            maxItems: 16
+                                          set:
+                                            type: array
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                                value:
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            maxItems: 16
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                  - type: object
+                                    default:
+                                      type: ResponseHeaderModifier
+                                      responseHeaderModifier: {}
+                                    properties:
+                                      type:
+                                        const: ResponseHeaderModifier
+                                      responseHeaderModifier:
+                                        description: |-
+                                          Only one action is supported per header name.
+                                          Configuration to set or add multiple values for a header must use RFC 7230
+                                          header value formatting, separating each value with a comma.
+                                        type: object
+                                        properties:
+                                          add:
+                                            type: array
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                                value:
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            maxItems: 16
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          remove:
+                                            type: array
+                                            items:
+                                              type: string
+                                            maxItems: 16
+                                          set:
+                                            type: array
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                                value:
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            maxItems: 16
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                  - type: object
+                                    default:
+                                      type: RequestRedirect
+                                      responseHeaderModifier: {}
+                                    properties:
+                                      type:
+                                        const: RequestRedirect
+                                      requestRedirect:
+                                        type: object
+                                        properties:
+                                          hostname:
+                                            description: |-
+                                              PreciseHostname is the fully qualified domain name of a network host. This
+                                              matches the RFC 1123 definition of a hostname with 1 notable exception that
+                                              numeric IP addresses are not allowed.
+
+                                              Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                              alphanumeric characters or '-', and must start and end with an alphanumeric
+                                              character. No other punctuation is allowed.
+                                            type: string
+                                            maxLength: 253
+                                            minLength: 1
+                                            pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                                          path:
+                                            description: |-
+                                              Path defines parameters used to modify the path of the incoming request.
+                                              The modified path is then used to construct the location header.
+                                              When empty, the request path is used as-is.
+                                            type: object
+                                            default:
+                                              type: ReplaceFullPath
+                                              replaceFullPath: ''
+                                            oneOf:
+                                              - type: object
+                                                default:
+                                                  type: ReplaceFullPath
+                                                  replaceFullPath: ''
+                                                properties:
+                                                  type:
+                                                    const: ReplaceFullPath
+                                                  replaceFullPath:
+                                                    type: string
+                                              - type: object
+                                                default:
+                                                  type: ReplacePrefixMatch
+                                                  replacePrefixMatch: ''
+                                                properties:
+                                                  type:
+                                                    const: ReplacePrefixMatch
+                                                  replacePrefixMatch:
+                                                    type: string
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - ReplaceFullPath
+                                                  - ReplacePrefixMatch
+                                            required:
+                                              - type
+                                          port:
+                                            description: |-
+                                              Port is the port to be used in the value of the `Location`
+                                              header in the response.
+                                              When empty, port (if specified) of the request is used.
+                                            type: integer
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                          scheme:
+                                            type: string
+                                            enum:
+                                              - http
+                                              - https
+                                          statusCode:
+                                            description: StatusCode is the HTTP status code to be used in response.
+                                            type: integer
+                                            default: 302
+                                            enum:
+                                              - 301
+                                              - 302
+                                              - 303
+                                              - 307
+                                              - 308
+                                  - type: object
+                                    default:
+                                      type: URLRewrite
+                                      urlRewrite: {}
+                                    properties:
+                                      type:
+                                        const: URLRewrite
+                                      urlRewrite:
+                                        type: object
+                                        properties:
+                                          hostToBackendHostname:
+                                            description: |-
+                                              HostToBackendHostname rewrites the hostname to the hostname of the
+                                              upstream host. This option is only available when targeting MeshGateways.
+                                            type: boolean
+                                          hostname:
+                                            description: Hostname is the value to be used to replace the host header value during forwarding.
+                                            type: string
+                                            maxLength: 253
+                                            minLength: 1
+                                            pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                                          path:
+                                            description: Path defines a path rewrite.
+                                            type: object
+                                            properties:
+                                              replaceFullPath:
+                                                type: string
+                                              replacePrefixMatch:
+                                                type: string
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - ReplaceFullPath
+                                                  - ReplacePrefixMatch
+                                            required:
+                                              - type
+                                  - type: object
+                                    default:
+                                      type: RequestMirror
+                                      requestMirror: {}
+                                    properties:
+                                      type:
+                                        const: RequestMirror
+                                      requestMirror:
+                                        type: object
+                                        properties:
+                                          backendRef:
+                                            description: BackendRef defines where to forward traffic.
+                                            type: object
+                                            properties:
+                                              kind:
+                                                description: Kind of the referenced resource
+                                                type: string
+                                                enum:
+                                                  - Mesh
+                                                  - MeshSubset
+                                                  - MeshGateway
+                                                  - MeshService
+                                                  - MeshExternalService
+                                                  - MeshMultiZoneService
+                                                  - MeshServiceSubset
+                                                  - MeshHTTPRoute
+                                                  - Dataplane
+                                              labels:
+                                                description: |-
+                                                  Labels are used to select group of MeshServices that match labels. Either Labels or
+                                                  Name and Namespace can be used.
+                                                type: object
+                                                additionalProperties:
+                                                  type: string
+                                              mesh:
+                                                description: Mesh is reserved for future use to identify cross mesh resources.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                                  `MeshServiceSubset` and `MeshGatewayRoute`
+                                                type: string
+                                              namespace:
+                                                description: |-
+                                                  Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                                  will be targeted.
+                                                type: string
+                                              port:
+                                                description: Port is only supported when this ref refers to a real MeshService object
+                                                type: integer
+                                                format: int32
+                                              proxyTypes:
+                                                description: |-
+                                                  ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                                  all data plane types are targeted by the policy.
+                                                type: array
+                                                items:
+                                                  enum:
+                                                    - Sidecar
+                                                    - Gateway
+                                                  type: string
+                                              sectionName:
+                                                description: |-
+                                                  SectionName is used to target specific section of resource.
+                                                  For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                                type: string
+                                              tags:
+                                                description: |-
+                                                  Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                                  `MeshSubset` and `MeshServiceSubset`
+                                                type: object
+                                                additionalProperties:
+                                                  type: string
+                                              weight:
+                                                type: integer
+                                                default: 1
+                                                minimum: 0
+                                            required:
+                                              - kind
+                                          percentage:
+                                            description: |-
+                                              Percentage of requests to mirror. If not specified, all requests
+                                              to the target cluster will be mirrored.
+                                            type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - backendRef
                         matches:
                           description: |-
                             Matches describes how to match HTTP requests this rule should be applied
@@ -18676,9 +18680,7 @@ components:
 
                           Deprecated: the setting has been moved to MeshCircuitBreaker policy,
                           please use MeshCircuitBreaker policy instead.
-                        anyOf:
-                          - type: integer
-                          - type: string
+                        type: string
                         x-kubernetes-int-or-string: true
                       healthyThreshold:
                         description: |-
@@ -19075,259 +19077,373 @@ components:
                       loadBalancer:
                         description: LoadBalancer allows to specify load balancing algorithm.
                         type: object
+                        default:
+                          type: RoundRobin
+                        oneOf:
+                          - type: object
+                            default:
+                              type: RoundRobin
+                              roundRobin: {}
+                            properties:
+                              type:
+                                const: RoundRobin
+                              roundRobin:
+                                description: |-
+                                  RoundRobin is a load balancing algorithm that distributes requests
+                                  across available upstream hosts in round-robin order.
+                                type: object
+                          - type: object
+                            default:
+                              type: LeastRequest
+                              leastRequest: {}
+                            properties:
+                              type:
+                                const: LeastRequest
+                              leastRequest:
+                                description: |-
+                                  LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
+                                  and picks the host which has the fewest active requests
+                                type: object
+                                properties:
+                                  activeRequestBias:
+                                    description: |-
+                                      ActiveRequestBias refers to dynamic weights applied when hosts have varying load
+                                      balancing weights. A higher value here aggressively reduces the weight of endpoints
+                                      that are currently handling active requests. In essence, the higher the ActiveRequestBias
+                                      value, the more forcefully it reduces the load balancing weight of endpoints that are
+                                      actively serving requests.
+                                    type: string
+                                    x-kubernetes-int-or-string: true
+                                  choiceCount:
+                                    description: |-
+                                      ChoiceCount is the number of random healthy hosts from which the host with
+                                      the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
+                                      two-choice selection if the field is not set.
+                                    type: integer
+                                    format: int32
+                                    minimum: 2
+                          - type: object
+                            default:
+                              type: RingHash
+                              ringHash: {}
+                            properties:
+                              type:
+                                const: RingHash
+                              ringHash:
+                                description: |-
+                                  RingHash  implements consistent hashing to upstream hosts. Each host is mapped
+                                  onto a circle (the “ring”) by hashing its address; each request is then routed
+                                  to a host by hashing some property of the request, and finding the nearest
+                                  corresponding host clockwise around the ring.
+                                type: object
+                                properties:
+                                  hashFunction:
+                                    description: |-
+                                      HashFunction is a function used to hash hosts onto the ketama ring.
+                                      The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
+                                    type: string
+                                    enum:
+                                      - XXHash
+                                      - MurmurHash2
+                                  hashPolicies:
+                                    description: |-
+                                      HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                      These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                      set to true, and there is already a hash generated, the hash is returned immediately,
+                                      ignoring the rest of the hash policy list.
+                                    type: array
+                                    items:
+                                      properties:
+                                        terminal:
+                                          description: |-
+                                            Terminal is a flag that short-circuits the hash computing. This field provides
+                                            a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                            to rest of the policy list”, it saves time when the terminal policy works.
+                                            If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                          type: boolean
+                                        type:
+                                          type: string
+                                          enum:
+                                            - Header
+                                            - Cookie
+                                            - Connection
+                                            - SourceIP
+                                            - QueryParameter
+                                            - FilterState
+                                      required:
+                                        - type
+                                      type: object
+                                      default:
+                                        type: Header
+                                        header: {}
+                                      oneOf:
+                                        - type: object
+                                          default:
+                                            type: Header
+                                            header: {}
+                                          properties:
+                                            type:
+                                              const: Header
+                                            header:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: The name of the request header that will be used to obtain the hash key.
+                                                  type: string
+                                                  minLength: 1
+                                              required:
+                                                - name
+                                        - type: object
+                                          default:
+                                            type: Cookie
+                                            header: {}
+                                          properties:
+                                            type:
+                                              const: Cookie
+                                            header:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: The name of the cookie that will be used to obtain the hash key.
+                                                  type: string
+                                                  minLength: 1
+                                                path:
+                                                  description: The name of the path for the cookie.
+                                                  type: string
+                                                ttl:
+                                                  description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                                  type: string
+                                              required:
+                                                - name
+                                        - type: object
+                                          default:
+                                            type: Connection
+                                            connection: {}
+                                          properties:
+                                            type:
+                                              const: Connection
+                                            connection:
+                                              type: object
+                                              properties:
+                                                sourceIP:
+                                                  description: Hash on source IP address.
+                                                  type: boolean
+                                        - type: object
+                                          default:
+                                            type: QueryParameter
+                                            queryParameter: {}
+                                          properties:
+                                            type:
+                                              const: QueryParameter
+                                            queryParameter:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The name of the URL query parameter that will be used to obtain the hash key.
+                                                    If the parameter is not present, no hash will be produced. Query parameter names
+                                                    are case-sensitive.
+                                                  type: string
+                                                  minLength: 1
+                                              required:
+                                                - name
+                                        - type: object
+                                          default:
+                                            type: FilterState
+                                            filterState: {}
+                                          properties:
+                                            type:
+                                              const: FilterState
+                                            filterState:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  description: |-
+                                                    The name of the Object in the per-request filterState, which is
+                                                    an Envoy::Hashable object. If there is no data associated with the key,
+                                                    or the stored object is not Envoy::Hashable, no hash will be produced.
+                                                  type: string
+                                                  minLength: 1
+                                              required:
+                                                - key
+                                  maxRingSize:
+                                    description: |-
+                                      Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
+                                      but can be lowered to further constrain resource use.
+                                    type: integer
+                                    format: int32
+                                    maximum: 8000000
+                                    minimum: 1
+                                  minRingSize:
+                                    description: |-
+                                      Minimum hash ring size. The larger the ring is (that is,
+                                      the more hashes there are for each provided host) the better the request distribution
+                                      will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
+                                    type: integer
+                                    format: int32
+                                    maximum: 8000000
+                                    minimum: 1
+                          - type: object
+                            default:
+                              type: Random
+                              random: {}
+                            properties:
+                              type:
+                                const: Random
+                              random:
+                                description: |-
+                                  Random selects a random available host. The random load balancer generally
+                                  performs better than round-robin if no health checking policy is configured.
+                                  Random selection avoids bias towards the host in the set that comes after a failed host.
+                                type: object
+                          - type: object
+                            default:
+                              type: Maglev
+                              maglev: {}
+                            properties:
+                              type:
+                                const: Maglev
+                              maglev:
+                                description: |-
+                                  Maglev implements consistent hashing to upstream hosts. Maglev can be used as
+                                  a drop in replacement for the ring hash load balancer any place in which
+                                  consistent hashing is desired.
+                                type: object
+                                properties:
+                                  hashPolicies:
+                                    description: |-
+                                      HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                      These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                      set to true, and there is already a hash generated, the hash is returned immediately,
+                                      ignoring the rest of the hash policy list.
+                                    type: array
+                                    items:
+                                      properties:
+                                        terminal:
+                                          description: |-
+                                            Terminal is a flag that short-circuits the hash computing. This field provides
+                                            a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                            to rest of the policy list”, it saves time when the terminal policy works.
+                                            If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                          type: boolean
+                                        type:
+                                          type: string
+                                          enum:
+                                            - Header
+                                            - Cookie
+                                            - Connection
+                                            - SourceIP
+                                            - QueryParameter
+                                            - FilterState
+                                      required:
+                                        - type
+                                      type: object
+                                      default:
+                                        type: Header
+                                        header: {}
+                                      oneOf:
+                                        - type: object
+                                          default:
+                                            type: Header
+                                            header: {}
+                                          properties:
+                                            type:
+                                              const: Header
+                                            header:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: The name of the request header that will be used to obtain the hash key.
+                                                  type: string
+                                                  minLength: 1
+                                              required:
+                                                - name
+                                        - type: object
+                                          default:
+                                            type: Cookie
+                                            header: {}
+                                          properties:
+                                            type:
+                                              const: Cookie
+                                            header:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: The name of the cookie that will be used to obtain the hash key.
+                                                  type: string
+                                                  minLength: 1
+                                                path:
+                                                  description: The name of the path for the cookie.
+                                                  type: string
+                                                ttl:
+                                                  description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                                  type: string
+                                              required:
+                                                - name
+                                        - type: object
+                                          default:
+                                            type: Connection
+                                            connection: {}
+                                          properties:
+                                            type:
+                                              const: Connection
+                                            connection:
+                                              type: object
+                                              properties:
+                                                sourceIP:
+                                                  description: Hash on source IP address.
+                                                  type: boolean
+                                        - type: object
+                                          default:
+                                            type: QueryParameter
+                                            queryParameter: {}
+                                          properties:
+                                            type:
+                                              const: QueryParameter
+                                            queryParameter:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The name of the URL query parameter that will be used to obtain the hash key.
+                                                    If the parameter is not present, no hash will be produced. Query parameter names
+                                                    are case-sensitive.
+                                                  type: string
+                                                  minLength: 1
+                                              required:
+                                                - name
+                                        - type: object
+                                          default:
+                                            type: FilterState
+                                            filterState: {}
+                                          properties:
+                                            type:
+                                              const: FilterState
+                                            filterState:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  description: |-
+                                                    The name of the Object in the per-request filterState, which is
+                                                    an Envoy::Hashable object. If there is no data associated with the key,
+                                                    or the stored object is not Envoy::Hashable, no hash will be produced.
+                                                  type: string
+                                                  minLength: 1
+                                              required:
+                                                - key
+                                  tableSize:
+                                    description: |-
+                                      The table size for Maglev hashing. Maglev aims for “minimal disruption”
+                                      rather than an absolute guarantee. Minimal disruption means that when
+                                      the set of upstream hosts change, a connection will likely be sent
+                                      to the same upstream as it was before. Increasing the table size reduces
+                                      the amount of disruption. The table size must be prime number limited to 5000011.
+                                      If it is not specified, the default is 65537.
+                                    type: integer
+                                    format: int32
+                                    maximum: 5000011
+                                    minimum: 1
                         properties:
-                          leastRequest:
-                            description: |-
-                              LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
-                              and picks the host which has the fewest active requests
-                            type: object
-                            properties:
-                              activeRequestBias:
-                                description: |-
-                                  ActiveRequestBias refers to dynamic weights applied when hosts have varying load
-                                  balancing weights. A higher value here aggressively reduces the weight of endpoints
-                                  that are currently handling active requests. In essence, the higher the ActiveRequestBias
-                                  value, the more forcefully it reduces the load balancing weight of endpoints that are
-                                  actively serving requests.
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                              choiceCount:
-                                description: |-
-                                  ChoiceCount is the number of random healthy hosts from which the host with
-                                  the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
-                                  two-choice selection if the field is not set.
-                                type: integer
-                                format: int32
-                                minimum: 2
-                          maglev:
-                            description: |-
-                              Maglev implements consistent hashing to upstream hosts. Maglev can be used as
-                              a drop in replacement for the ring hash load balancer any place in which
-                              consistent hashing is desired.
-                            type: object
-                            properties:
-                              hashPolicies:
-                                description: |-
-                                  HashPolicies specify a list of request/connection properties that are used to calculate a hash.
-                                  These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
-                                  set to true, and there is already a hash generated, the hash is returned immediately,
-                                  ignoring the rest of the hash policy list.
-                                type: array
-                                items:
-                                  properties:
-                                    connection:
-                                      type: object
-                                      properties:
-                                        sourceIP:
-                                          description: Hash on source IP address.
-                                          type: boolean
-                                    cookie:
-                                      type: object
-                                      properties:
-                                        name:
-                                          description: The name of the cookie that will be used to obtain the hash key.
-                                          type: string
-                                          minLength: 1
-                                        path:
-                                          description: The name of the path for the cookie.
-                                          type: string
-                                        ttl:
-                                          description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
-                                          type: string
-                                      required:
-                                        - name
-                                    filterState:
-                                      type: object
-                                      properties:
-                                        key:
-                                          description: |-
-                                            The name of the Object in the per-request filterState, which is
-                                            an Envoy::Hashable object. If there is no data associated with the key,
-                                            or the stored object is not Envoy::Hashable, no hash will be produced.
-                                          type: string
-                                          minLength: 1
-                                      required:
-                                        - key
-                                    header:
-                                      type: object
-                                      properties:
-                                        name:
-                                          description: The name of the request header that will be used to obtain the hash key.
-                                          type: string
-                                          minLength: 1
-                                      required:
-                                        - name
-                                    queryParameter:
-                                      type: object
-                                      properties:
-                                        name:
-                                          description: |-
-                                            The name of the URL query parameter that will be used to obtain the hash key.
-                                            If the parameter is not present, no hash will be produced. Query parameter names
-                                            are case-sensitive.
-                                          type: string
-                                          minLength: 1
-                                      required:
-                                        - name
-                                    terminal:
-                                      description: |-
-                                        Terminal is a flag that short-circuits the hash computing. This field provides
-                                        a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
-                                        to rest of the policy list”, it saves time when the terminal policy works.
-                                        If true, and there is already a hash computed, ignore rest of the list of hash polices.
-                                      type: boolean
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Header
-                                        - Cookie
-                                        - Connection
-                                        - SourceIP
-                                        - QueryParameter
-                                        - FilterState
-                                  required:
-                                    - type
-                                  type: object
-                              tableSize:
-                                description: |-
-                                  The table size for Maglev hashing. Maglev aims for “minimal disruption”
-                                  rather than an absolute guarantee. Minimal disruption means that when
-                                  the set of upstream hosts change, a connection will likely be sent
-                                  to the same upstream as it was before. Increasing the table size reduces
-                                  the amount of disruption. The table size must be prime number limited to 5000011.
-                                  If it is not specified, the default is 65537.
-                                type: integer
-                                format: int32
-                                maximum: 5000011
-                                minimum: 1
-                          random:
-                            description: |-
-                              Random selects a random available host. The random load balancer generally
-                              performs better than round-robin if no health checking policy is configured.
-                              Random selection avoids bias towards the host in the set that comes after a failed host.
-                            type: object
-                          ringHash:
-                            description: |-
-                              RingHash  implements consistent hashing to upstream hosts. Each host is mapped
-                              onto a circle (the “ring”) by hashing its address; each request is then routed
-                              to a host by hashing some property of the request, and finding the nearest
-                              corresponding host clockwise around the ring.
-                            type: object
-                            properties:
-                              hashFunction:
-                                description: |-
-                                  HashFunction is a function used to hash hosts onto the ketama ring.
-                                  The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
-                                type: string
-                                enum:
-                                  - XXHash
-                                  - MurmurHash2
-                              hashPolicies:
-                                description: |-
-                                  HashPolicies specify a list of request/connection properties that are used to calculate a hash.
-                                  These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
-                                  set to true, and there is already a hash generated, the hash is returned immediately,
-                                  ignoring the rest of the hash policy list.
-                                type: array
-                                items:
-                                  properties:
-                                    connection:
-                                      type: object
-                                      properties:
-                                        sourceIP:
-                                          description: Hash on source IP address.
-                                          type: boolean
-                                    cookie:
-                                      type: object
-                                      properties:
-                                        name:
-                                          description: The name of the cookie that will be used to obtain the hash key.
-                                          type: string
-                                          minLength: 1
-                                        path:
-                                          description: The name of the path for the cookie.
-                                          type: string
-                                        ttl:
-                                          description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
-                                          type: string
-                                      required:
-                                        - name
-                                    filterState:
-                                      type: object
-                                      properties:
-                                        key:
-                                          description: |-
-                                            The name of the Object in the per-request filterState, which is
-                                            an Envoy::Hashable object. If there is no data associated with the key,
-                                            or the stored object is not Envoy::Hashable, no hash will be produced.
-                                          type: string
-                                          minLength: 1
-                                      required:
-                                        - key
-                                    header:
-                                      type: object
-                                      properties:
-                                        name:
-                                          description: The name of the request header that will be used to obtain the hash key.
-                                          type: string
-                                          minLength: 1
-                                      required:
-                                        - name
-                                    queryParameter:
-                                      type: object
-                                      properties:
-                                        name:
-                                          description: |-
-                                            The name of the URL query parameter that will be used to obtain the hash key.
-                                            If the parameter is not present, no hash will be produced. Query parameter names
-                                            are case-sensitive.
-                                          type: string
-                                          minLength: 1
-                                      required:
-                                        - name
-                                    terminal:
-                                      description: |-
-                                        Terminal is a flag that short-circuits the hash computing. This field provides
-                                        a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
-                                        to rest of the policy list”, it saves time when the terminal policy works.
-                                        If true, and there is already a hash computed, ignore rest of the list of hash polices.
-                                      type: boolean
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Header
-                                        - Cookie
-                                        - Connection
-                                        - SourceIP
-                                        - QueryParameter
-                                        - FilterState
-                                  required:
-                                    - type
-                                  type: object
-                              maxRingSize:
-                                description: |-
-                                  Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
-                                  but can be lowered to further constrain resource use.
-                                type: integer
-                                format: int32
-                                maximum: 8000000
-                                minimum: 1
-                              minRingSize:
-                                description: |-
-                                  Minimum hash ring size. The larger the ring is (that is,
-                                  the more hashes there are for each provided host) the better the request distribution
-                                  will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
-                                type: integer
-                                format: int32
-                                maximum: 8000000
-                                minimum: 1
-                          roundRobin:
-                            description: |-
-                              RoundRobin is a load balancing algorithm that distributes requests
-                              across available upstream hosts in round-robin order.
-                            type: object
                           type:
                             type: string
                             enum:
@@ -19395,9 +19511,7 @@ components:
                                 type: object
                                 properties:
                                   percentage:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
+                                    type: string
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - percentage
@@ -19576,46 +19690,6 @@ components:
                   type: array
                   items:
                     properties:
-                      openTelemetry:
-                        description: OpenTelemetry backend configuration
-                        type: object
-                        properties:
-                          endpoint:
-                            description: Endpoint for OpenTelemetry collector
-                            type: string
-                          refreshInterval:
-                            description: RefreshInterval defines how frequent metrics should be pushed to collector
-                            type: string
-                        required:
-                          - endpoint
-                      prometheus:
-                        description: Prometheus backend configuration.
-                        type: object
-                        properties:
-                          clientId:
-                            description: ClientId of the Prometheus backend. Needed when using MADS for DP discovery.
-                            type: string
-                          path:
-                            description: Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
-                            type: string
-                            default: /metrics
-                          port:
-                            description: Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
-                            type: integer
-                            format: int32
-                            default: 5670
-                          tls:
-                            description: Configuration of TLS for prometheus listener.
-                            type: object
-                            properties:
-                              mode:
-                                description: Configuration of TLS for Prometheus listener.
-                                type: string
-                                default: Disabled
-                                enum:
-                                  - Disabled
-                                  - ProvidedTLS
-                                  - ActiveMTLSBackend
                       type:
                         description: Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
                         type: string
@@ -19625,6 +19699,63 @@ components:
                     required:
                       - type
                     type: object
+                    default:
+                      type: Prometheus
+                    oneOf:
+                      - type: object
+                        default:
+                          type: Prometheus
+                          prometheus: {}
+                        properties:
+                          type:
+                            const: Prometheus
+                          prometheus:
+                            description: Prometheus backend configuration.
+                            type: object
+                            properties:
+                              clientId:
+                                description: ClientId of the Prometheus backend. Needed when using MADS for DP discovery.
+                                type: string
+                              path:
+                                description: Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                                type: string
+                                default: /metrics
+                              port:
+                                description: Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                                type: integer
+                                format: int32
+                                default: 5670
+                              tls:
+                                description: Configuration of TLS for prometheus listener.
+                                type: object
+                                properties:
+                                  mode:
+                                    description: Configuration of TLS for Prometheus listener.
+                                    type: string
+                                    default: Disabled
+                                    enum:
+                                      - Disabled
+                                      - ProvidedTLS
+                                      - ActiveMTLSBackend
+                      - type: object
+                        default:
+                          type: OpenTelemetry
+                          openTelemetry: {}
+                        properties:
+                          type:
+                            const: OpenTelemetry
+                          openTelemetry:
+                            description: OpenTelemetry backend configuration
+                            type: object
+                            properties:
+                              endpoint:
+                                description: Endpoint for OpenTelemetry collector
+                                type: string
+                              refreshInterval:
+                                description: RefreshInterval defines how frequent metrics should be pushed to collector
+                                type: string
+                            required:
+                              - endpoint
                 sidecar:
                   description: Sidecar metrics collection configuration
                   type: object
@@ -21612,6 +21743,7 @@ components:
                                 required:
                                   - kind
                                 type: object
+                                x-kuma-type: TargetRef
                       required:
                         - default
                       type: object
@@ -22379,75 +22511,104 @@ components:
                   items:
                     description: 'Only one of zipkin, datadog or openTelemetry can be used.'
                     properties:
-                      datadog:
-                        description: Datadog backend configuration.
-                        type: object
-                        properties:
-                          splitService:
-                            description: |-
-                              Determines if datadog service name should be split based on traffic
-                              direction and destination. For example, with `splitService: true` and a
-                              `backend` service that communicates with a couple of databases, you would
-                              get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
-                              `backend_OUTBOUND_db2` in Datadog.
-                            type: boolean
-                            default: false
-                          url:
-                            description: |-
-                              Address of Datadog collector, only host and port are allowed (no paths,
-                              fragments etc.)
-                            type: string
-                        required:
-                          - url
-                      openTelemetry:
-                        description: OpenTelemetry backend configuration.
-                        type: object
-                        properties:
-                          endpoint:
-                            description: Address of OpenTelemetry collector.
-                            type: string
-                            example: 'otel-collector:4317'
-                            minLength: 1
-                        required:
-                          - endpoint
                       type:
                         type: string
                         enum:
                           - Zipkin
                           - Datadog
                           - OpenTelemetry
-                      zipkin:
-                        description: Zipkin backend configuration.
-                        type: object
-                        properties:
-                          apiVersion:
-                            description: |-
-                              Version of the API.
-                              https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
-                            type: string
-                            default: httpJson
-                            enum:
-                              - httpJson
-                              - httpProto
-                          sharedSpanContext:
-                            description: |-
-                              Determines whether client and server spans will share the same span
-                              context.
-                              https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
-                            type: boolean
-                            default: true
-                          traceId128bit:
-                            description: Generate 128bit traces.
-                            type: boolean
-                            default: false
-                          url:
-                            description: Address of Zipkin collector.
-                            type: string
-                        required:
-                          - url
                     required:
                       - type
                     type: object
+                    default:
+                      type: Zipkin
+                      zipkin:
+                        url: ''
+                    oneOf:
+                      - type: object
+                        default:
+                          type: Zipkin
+                          zipkin:
+                            url: ''
+                        properties:
+                          type:
+                            const: Zipkin
+                          zipkin:
+                            description: Zipkin backend configuration.
+                            type: object
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  Version of the API.
+                                  https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
+                                type: string
+                                default: httpJson
+                                enum:
+                                  - httpJson
+                                  - httpProto
+                              sharedSpanContext:
+                                description: |-
+                                  Determines whether client and server spans will share the same span
+                                  context.
+                                  https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
+                                type: boolean
+                                default: true
+                              traceId128bit:
+                                description: Generate 128bit traces.
+                                type: boolean
+                                default: false
+                              url:
+                                description: Address of Zipkin collector.
+                                type: string
+                            required:
+                              - url
+                      - type: object
+                        default:
+                          type: Datadog
+                          datadog:
+                            url: ''
+                        properties:
+                          type:
+                            const: Datadog
+                          datadog:
+                            description: Datadog backend configuration.
+                            type: object
+                            properties:
+                              splitService:
+                                description: |-
+                                  Determines if datadog service name should be split based on traffic
+                                  direction and destination. For example, with `splitService: true` and a
+                                  `backend` service that communicates with a couple of databases, you would
+                                  get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+                                  `backend_OUTBOUND_db2` in Datadog.
+                                type: boolean
+                                default: false
+                              url:
+                                description: |-
+                                  Address of Datadog collector, only host and port are allowed (no paths,
+                                  fragments etc.)
+                                type: string
+                            required:
+                              - url
+                      - type: object
+                        default:
+                          type: OpenTelemetry
+                          openTelemetry:
+                            endpoint: ''
+                        properties:
+                          type:
+                            const: OpenTelemetry
+                          openTelemetry:
+                            description: OpenTelemetry backend configuration.
+                            type: object
+                            properties:
+                              endpoint:
+                                description: Address of OpenTelemetry collector.
+                                type: string
+                                example: 'otel-collector:4317'
+                                minLength: 1
+                            required:
+                              - endpoint
                   maxItems: 1
                 sampling:
                   description: |-
@@ -22463,9 +22624,7 @@ components:
                         https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
                         Either int or decimal represented as string.
                         If not specified then the default value is 100.
-                      anyOf:
-                        - type: integer
-                        - type: string
+                      type: string
                       x-kubernetes-int-or-string: true
                     overall:
                       description: |-
@@ -22479,9 +22638,7 @@ components:
                         https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
                         Either int or decimal represented as string.
                         If not specified then the default value is 100.
-                      anyOf:
-                        - type: integer
-                        - type: string
+                      type: string
                       x-kubernetes-int-or-string: true
                     random:
                       description: |-
@@ -22491,9 +22648,7 @@ components:
                         https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
                         Either int or decimal represented as string.
                         If not specified then the default value is 100.
-                      anyOf:
-                        - type: integer
-                        - type: string
+                      type: string
                       x-kubernetes-int-or-string: true
                 tags:
                   description: |-

--- a/packages/kuma-http-api/src/components/schemas/MeshAccessLogItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshAccessLogItem_Put_RequestBody.overlay.yaml
@@ -41,8 +41,7 @@ actions:
         file:
           path: ''
       oneOf:
-        - title: TCP
-          type: object
+        - type: object
           default:
             type: Tcp
             tcp:
@@ -51,8 +50,7 @@ actions:
             type: { const: Tcp }
             tcp:
               $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshAccessLogItem.yaml#/properties/spec/properties/to/items/properties/default/properties/backends/items/properties/tcp'
-        - title: File
-          type: object
+        - type: object
           default:
             type: File
             file:
@@ -61,9 +59,7 @@ actions:
             type: { const: File }
             file:
               $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshAccessLogItem.yaml#/properties/spec/properties/to/items/properties/default/properties/backends/items/properties/file'
-
-        - title: OpenTelemetry
-          type: object
+        - type: object
           default:
             type: OpenTelemetry
             openTelemetry:
@@ -83,8 +79,7 @@ actions:
     update:
       # plain/json should be oneOf
       oneOf:
-        - title: JSON
-          type: object
+        - type: object
           default:
             type: Json
             json: []
@@ -92,8 +87,7 @@ actions:
             type: { const: Json }
             json:
               $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshAccessLogItem.yaml#/properties/spec/properties/to/items/properties/default/properties/backends/items/properties/tcp/properties/format/properties/json'
-        - title: Plain
-          type: object
+        - type: object
           default:
             type: Plain
             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
@@ -104,8 +98,7 @@ actions:
   - target: '$..backends.items.oneOf[1].properties.file.properties.format'
     update:
       oneOf:
-        - title: JSON
-          type: object
+        - type: object
           default:
             type: Json
             json: []
@@ -113,8 +106,7 @@ actions:
             type: { const: Json }
             json:
               $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshAccessLogItem.yaml#/properties/spec/properties/to/items/properties/default/properties/backends/items/properties/file/properties/format/properties/json'
-        - title: Plain
-          type: object
+        - type: object
           default:
             type: Plain
             plain: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'

--- a/packages/kuma-http-api/src/components/schemas/MeshHTTPRouteItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshHTTPRouteItem_Put_RequestBody.overlay.yaml
@@ -18,3 +18,95 @@ actions:
     update:
       default:
         rules: []
+  # backendRefs are targetRefs
+  - target: '$..backendRefs.items'
+    update:
+      x-kuma-type: TargetRef
+
+  # rules.default.filters should be oneOf
+  - target: '$..filters.items.properties.requestHeaderModifier'
+    remove: true
+  - target: '$..filters.items.properties.requestMirror'
+    remove: true
+  - target: '$..filters.items.properties.requestRedirect'
+    remove: true
+  - target: '$..filters.items.properties.responseHeaderModifier'
+    remove: true
+  - target: '$..filters.items.properties.urlRewrite'
+    remove: true
+
+  - target: '$..filters.items'
+    update:
+      default:
+        type: RequestHeaderModifier
+      oneOf:
+        - type: object
+          default:
+            type: RequestHeaderModifier
+            roundRobin: {}
+          properties:
+            type: { const: RequestHeaderModifier }
+            requestHeaderModifier:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/requestHeaderModifier'
+        - type: object
+          default:
+            type: ResponseHeaderModifier
+            responseHeaderModifier: {}
+          properties:
+            type: { const: ResponseHeaderModifier }
+            responseHeaderModifier:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/responseHeaderModifier'
+        - type: object
+          default:
+            type: RequestRedirect
+            responseHeaderModifier: {}
+          properties:
+            type: { const: RequestRedirect }
+            requestRedirect:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/requestRedirect'
+        - type: object
+          default:
+            type: URLRewrite
+            urlRewrite: {}
+          properties:
+            type: { const: URLRewrite }
+            urlRewrite:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/urlRewrite'
+        - type: object
+          default:
+            type: RequestMirror
+            requestMirror: {}
+          properties:
+            type: { const: RequestMirror }
+            requestMirror:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/requestMirror'
+
+  # rules[].default.filters[].requestRedirect.path should be oneOf
+  - target: '$..filters.items.oneOf[2].properties.requestRedirect.properties.path.properties.replaceFullPath'
+    remove: true
+  - target: '$..filters.items.oneOf[2].properties.requestRedirect.properties.path.properties.replacePrefixMatch'
+    remove: true
+
+  - target: '$..filters.items.oneOf[2].properties.requestRedirect.properties.path'
+    update:
+      default:
+        type: ReplaceFullPath
+        replaceFullPath: ''
+      oneOf:
+        - type: object
+          default:
+            type: ReplaceFullPath
+            replaceFullPath: ''
+          properties:
+            type: { const: ReplaceFullPath }
+            replaceFullPath:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/requestRedirect/properties/path/properties/replaceFullPath'
+        - type: object
+          default:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: ''
+          properties:
+            type: { const: ReplacePrefixMatch }
+            replacePrefixMatch:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshHTTPRouteItem.yaml#/properties/spec/properties/to/items/properties/rules/items/properties/default/properties/filters/items/properties/requestRedirect/properties/path/properties/replaceFullPath'
+

--- a/packages/kuma-http-api/src/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.overlay.yaml
@@ -22,3 +22,122 @@ actions:
         targetRef:
           kind: MeshService
         default: {}
+
+  # loadBalancer.type should be oneOf
+  - target: '$..loadBalancer.properties.roundRobin'
+    remove: true
+  - target: '$..loadBalancer.properties.leastRequest'
+    remove: true
+  - target: '$..loadBalancer.properties.ringHash'
+    remove: true
+  - target: '$..loadBalancer.properties.random'
+    remove: true
+  - target: '$..loadBalancer.properties.maglev'
+    remove: true
+
+  - target: '$..loadBalancer'
+    update:
+      default:
+        type: RoundRobin
+      oneOf:
+        - type: object
+          default:
+            type: RoundRobin
+            roundRobin: {}
+          properties:
+            type: { const: RoundRobin }
+            roundRobin:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/roundRobin'
+        - type: object
+          default:
+            type: LeastRequest
+            leastRequest: {}
+          properties:
+            type: { const: LeastRequest }
+            leastRequest:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/leastRequest'
+        - type: object
+          default:
+            type: RingHash
+            ringHash: {}
+          properties:
+            type: { const: RingHash }
+            ringHash:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/ringHash'
+        - type: object
+          default:
+            type: Random
+            random: {}
+          properties:
+            type: { const: Random }
+            random:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/random'
+        - type: object
+          default:
+            type: Maglev
+            maglev: {}
+          properties:
+            type: { const: Maglev }
+            maglev:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/maglev'
+
+  # rules[].default.filters[].requestRedirect.path should be oneOf
+  # loadBalancer..hashPolicies should be oneOf
+  - target: '$..loadBalancer..hashPolicies.items.properties.header'
+    remove: true
+  - target: '$..loadBalancer..hashPolicies.items.properties.cookie'
+    remove: true
+  - target: '$..loadBalancer..hashPolicies.items.properties.connection'
+    remove: true
+  - target: '$..loadBalancer..hashPolicies.items.properties.queryParameter'
+    remove: true
+  - target: '$..loadBalancer..hashPolicies.items.properties.filterState'
+    remove: true
+
+  - target: '$..loadBalancer..hashPolicies.items'
+    update:
+      default:
+        type: Header
+        header: {}
+      oneOf:
+        - type: object
+          default:
+            type: Header
+            header: {}
+          properties:
+            type: { const: Header }
+            header:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/ringHash/properties/hashPolicies/items/properties/header'
+        - type: object
+          default:
+            type: Cookie
+            header: {}
+          properties:
+            type: { const: Cookie }
+            header:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/ringHash/properties/hashPolicies/items/properties/cookie'
+        - type: object
+          default:
+            type: Connection
+            connection: {}
+          properties:
+            type: { const: Connection }
+            connection:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/ringHash/properties/hashPolicies/items/properties/connection'
+        - type: object
+          default:
+            type: QueryParameter
+            queryParameter: {}
+          properties:
+            type: { const: QueryParameter }
+            queryParameter:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/ringHash/properties/hashPolicies/items/properties/queryParameter'
+        - type: object
+          default:
+            type: FilterState
+            filterState: {}
+          properties:
+            type: { const: FilterState }
+            filterState:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml#/properties/spec/properties/to/items/properties/default/properties/loadBalancer/properties/ringHash/properties/hashPolicies/items/properties/filterState'
+

--- a/packages/kuma-http-api/src/components/schemas/MeshMetricItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshMetricItem_Put_RequestBody.overlay.yaml
@@ -15,3 +15,32 @@ actions:
       default:
         default:
           backends: []
+  # Update all backends.items locations using recursive descent
+  # loadBalancer.type should be oneOf
+  - target: '$..backends.items.properties.prometheus'
+    remove: true
+  - target: '$..backends.items.properties.openTelemetry'
+    remove: true
+
+  - target: '$..backends.items'
+    update:
+      default:
+        type: Prometheus
+      oneOf:
+        - type: object
+          default:
+            type: Prometheus
+            prometheus: {}
+          properties:
+            type: { const: Prometheus }
+            prometheus:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshMetricItem.yaml#/properties/spec/properties/default/properties/backends/items/properties/prometheus'
+        - type: object
+          default:
+            type: OpenTelemetry
+            openTelemetry: {}
+          properties:
+            type: { const: OpenTelemetry }
+            openTelemetry:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshMetricItem.yaml#/properties/spec/properties/default/properties/backends/items/properties/openTelemetry'
+

--- a/packages/kuma-http-api/src/components/schemas/MeshTCPRouteItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTCPRouteItem_Put_RequestBody.overlay.yaml
@@ -22,3 +22,7 @@ actions:
         targetRef:
           kind: MeshService
         rules: []
+
+  - target: '$..backendRefs.items'
+    update:
+      x-kuma-type: TargetRef

--- a/packages/kuma-http-api/src/components/schemas/MeshTraceItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTraceItem_Put_RequestBody.overlay.yaml
@@ -15,3 +15,46 @@ actions:
       default:
         default:
           backends: []
+
+  # backends.type should be oneOf
+  - target: '$..backends.items.properties.zipkin'
+    remove: true
+  - target: '$..backends.items.properties.datadog'
+    remove: true
+  - target: '$..backends.items.properties.openTelemetry'
+    remove: true
+
+  - target: '$..backends.items'
+    update:
+      default:
+        type: Zipkin
+        zipkin:
+          url: ''
+      oneOf:
+        - type: object
+          default:
+            type: Zipkin
+            zipkin:
+              url: ''
+          properties:
+            type: { const: Zipkin }
+            zipkin:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshTraceItem.yaml#/properties/spec/properties/default/properties/backends/items/properties/zipkin'
+        - type: object
+          default:
+            type: Datadog
+            datadog:
+              url: ''
+          properties:
+            type: { const: Datadog }
+            datadog:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshTraceItem.yaml#/properties/spec/properties/default/properties/backends/items/properties/datadog'
+        - type: object
+          default:
+            type: OpenTelemetry
+            openTelemetry:
+              endpoint: ''
+          properties:
+            type: { const: OpenTelemetry }
+            openTelemetry:
+              $ref: !!oas-overlay/dereference '../../../generated/components/schemas/MeshTraceItem.yaml#/properties/spec/properties/default/properties/backends/items/properties/openTelemetry'


### PR DESCRIPTION
Turns all relevant policy non-`oneOf`s into `oneOf`s

Remember that the `.overlay.yaml` files are the amended files here.