### PR TITLE
chore(renovate): set time-stamp optional for internals minimumReleaseAge

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -76,7 +76,8 @@
         "@kong**/**",
         "kumahq/**"
       ],
-      "minimumReleaseAge": "2 hours"
+      "minimumReleaseAge": "2 hours",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     }
   ]
 }


### PR DESCRIPTION
Sets `minimumReleaseAgeBehaviour: "timestamp-optional"` because `kumahq/.github` has no timestamp on releases.
If there is no behaviour defined the default is `timestamp-required` which treats the version as unstable forever if there is no timestamp associated with the release.