### PR TITLE
feat(dataplanes): show warning when offline

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
@@ -9,6 +9,7 @@ Feature: mesh / dataplanes / warnings
       | unsupported-envoy-warning       | [data-testid^='notification-data-planes.notifications.envoy-dp-incompatible']           |
       | unsupported-zone-warning        | [data-testid^='notification-data-planes.notifications.dp-zone-cp-incompatible']         |
       | networking-transparent-proxying | [data-testid^='notification-data-planes.notifications.networking-transparent-proxying'] |
+      | dataplane-offline               | [data-testid^='notification-data-planes.notifications.dataplane-offline']               |
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
@@ -136,3 +137,19 @@ Feature: mesh / dataplanes / warnings
       """
     When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$networking-transparent-proxying" element exists
+
+  Scenario: Dataplane offline notification
+    And the URL "/meshes/default/dataplanes/dpp-1/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            outbound: !!js/undefined
+            inbound: !!js/undefined
+        dataplaneInsight:
+          connectedSubscription: !!js/undefined
+          metadata:
+            features: !!js/undefined
+      """
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
+    Then the "$dataplane-offline" element exists

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -26,6 +26,8 @@ data-planes:
       In order to communicate to other services in the mesh, make sure to define <a target="_blank" href="{KUMA_DOCS_URL}/production/dp-config/dpp-on-universal">outbounds</a>.
     abnormal-traffic-stats: !!text/markdown |
       Abnormal traffic stats detected. Investigate the traffic patterns of individually marked inbounds and outbounds.
+    dataplane-offline: !!text/markdown |
+      The dataplane is offline, so we either cannot retrieve any information or the information currently displayed may be out of date.
 
   x-empty-state:
     title: There are no data planes present

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -49,6 +49,15 @@
             {{ t(`http.api.value.${props.data.status}`) }}
           </XBadge>
         </XLayout>
+        <XNotification
+          :notify="props.data.status === 'offline'"
+          data-testid="warning-dataplane-offline"
+          :uri="`data-planes.notifications.dataplane-offline.${props.data.id}`"
+        >
+          <XI18n
+            path="data-planes.notifications.dataplane-offline"
+          />
+        </XNotification>
       </template>
       <template
         #actions


### PR DESCRIPTION
When the dataplane is offline most of the dataplane related endpoints will return an error. Adding the warning informs the user why this is the case and also that the information we still display might be outdated.

Closes https://github.com/kumahq/kuma-gui/issues/4302