### PR TITLE
chore(renovate): group node and npm by update types

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -39,17 +39,9 @@
     },
     {
       "matchPackageNames": [
-        "npm",
         "escape-string-regexp"
       ],
       "enabled": false
-    },
-    {
-      "groupName": "node",
-      "matchPackageNames": [
-        "node"
-      ],
-      "dependencyDashboardApproval": true
     },
     {
       "description": [
@@ -79,6 +71,29 @@
       ],
       "minimumReleaseAge": "2 hours",
       "minimumReleaseAgeBehaviour": "timestamp-optional"
+    },
+    {
+      "groupName": "node minors and patches",
+      "matchPackageNames": [
+        "node",
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "groupName": "node majors",
+      "matchPackageNames": [
+        "node",
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
     },
     {
       "matchCategories": [


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/4459 the CI was failing until I manually bumped npm. In the past we said that we just want to use the version of npm that is being shipped with the respective node version. Unfortunately this now caused the CI to fail because of the low version of npm in the engines field.
This is an attempt to let renovate also bump npm together with node. I've split it up by update types such that we don't end up with too high npm versions and have the npm version at least similar to what is being shipped with the respective node version.

If this doesn't satisfy us and still requires manual efforts we are happy to disable node and npm upgrades and do it manually after releases.