### PR TITLE
Revert "chore(renovate): group node and npm by update types"

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -39,9 +39,17 @@
     },
     {
       "matchPackageNames": [
+        "npm",
         "escape-string-regexp"
       ],
       "enabled": false
+    },
+    {
+      "groupName": "node",
+      "matchPackageNames": [
+        "node"
+      ],
+      "dependencyDashboardApproval": true
     },
     {
       "description": [
@@ -71,29 +79,6 @@
       ],
       "minimumReleaseAge": "2 hours",
       "minimumReleaseAgeBehaviour": "timestamp-optional"
-    },
-    {
-      "groupName": "node minors and patches",
-      "matchPackageNames": [
-        "node",
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "dependencyDashboardApproval": true
-    },
-    {
-      "groupName": "node majors",
-      "matchPackageNames": [
-        "node",
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "dependencyDashboardApproval": true
     },
     {
       "matchCategories": [


### PR DESCRIPTION
Reverts kumahq/kuma-gui#4464

Looking at https://github.com/kumahq/kuma-gui/pull/4465 this doesn't work as hoped and therefore I'm just reverting this. So we stay with manually updating npm to the version that is being shipped with the respective node version.