### PR TITLE
fix(x/x-error-state): show text of native JS errors

### DIFF
--- a/packages/x/src/components/x-error-state/XErrorState.vue
+++ b/packages/x/src/components/x-error-state/XErrorState.vue
@@ -19,10 +19,12 @@
           </slot>
         </template>
 
-        <XLayout class="detail">
+        <XLayout
+          class="detail"
+        >
           <slot name="message">
             <p>{{ props.error.detail || t('common.error_state.detail') }}</p>
-        
+
             <XDl variant="x-stack">
               <div v-if="props.error.status">
                 <dt>{{ t('http.api.property.status') }}</dt>
@@ -63,7 +65,7 @@
           >
             <slot>
               <p>
-                {{ t('common.error_state.api_error', { status: (props.error.status ?? 0).toString(), title: props.error.detail }) }}
+                {{ typeof props.error.status !== 'undefined' ? t('common.error_state.api_error', { status: props.error.status.toString(), title: props.error.detail}) : props.error.toString() }}
               </p>
               <ul
                 v-if="props.error.invalid_parameters?.length"


### PR DESCRIPTION
If we throw native JS Errors these aren't shown correctly in an "prompt/model" style or error display.

## Before

<img width="843" height="126" alt="Screenshot 2026-01-07 at 12 16 13" src="https://github.com/user-attachments/assets/7328c92a-cf11-4403-b413-3a422cacea7f" />

## After

<img width="855" height="120" alt="Screenshot 2026-01-07 at 12 16 31" src="https://github.com/user-attachments/assets/6455060f-1753-44d1-9181-80c8f850c9ee" />



