### PR TITLE
chore(renovate): use default prCreation, schedule:daily

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "kumahq/kuma-gui//packages/config/src/renovate/base"
-  ],
-  "schedule": [
-    "before 4am on monday"
+    "kumahq/kuma-gui//packages/config/src/renovate/base",
+    "schedule:daily"
   ]
 }

--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -25,7 +25,6 @@
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "prCreation": "not-pending",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "enabled": true


### PR DESCRIPTION
We are missing renovate creating PRs and I've investigated why it doesn't create the PRs.
I think the problematic setting is `prCreation: "not-pending"` as it waits for status checks to pass. We are not running any checks on branches (except `master` and `release` branches) and it seems that it waits forever.

Example: https://developer.mend.io/github/kumahq/kuma-gui/-/job/019baf93-147c-7c28-b62c-1285a6a6e9c3 (Jan 12, 2026, 01:27:38) (search/filter for `renovate/msw-2.x`)

```
DEBUG: Checking 1 schedule(s) (branch="renovate/msw-2.x")
{
  "baseBranch": "master"
}

DEBUG: Checking schedule "before 4am on monday" (branch="renovate/msw-2.x")
{
  "baseBranch": "master",
  "parsedSchedule": {
    "schedules": [
      {
        "t_b": [
          14400
        ],
        "d": [
          2
        ]
      }
    ],
    "exceptions": [],
    "error": -1
  }
}

DEBUG: Matches schedule before 4am on monday (branch="renovate/msw-2.x")
{
  "baseBranch": "master"
}

... doing all the update work ...

DEBUG: Setting branch status (branch="renovate/msw-2.x")
{
  "baseBranch": "master",
  "context": "renovate/stability-days",
  "state": "green"
}

DEBUG: http cache: saving https://api.github.com/repos/kumahq/kuma-gui/commits/renovate/msw-2.x/status (etag=W/"4bfe6bbb89144ed41a7b7f8834852c43d769453fc69d7f832ce35b8b19a33040", lastModified=undefined) (branch="renovate/msw-2.x")
{
  "baseBranch": "master"
}

DEBUG: Branch status pending, current sha: 67b8f9c44950f07d643ced2d46efb2ee995d1967 (branch="renovate/msw-2.x")
{
  "baseBranch": "master"
}

... other logs ...

DEBUG: branches info extended
...
{
      "branchName": "renovate/msw-2.x",
      "prNo": null,
      "prTitle": "fix(deps): update dependency msw to ^2.12.7",
      "result": "pending", <------------------------------------------- `prCreation: not-pending` prevents PR creation
      "upgrades": [
        {
          "datasource": "npm",
          "depName": "msw",
          "displayPending": "",
          "currentVersion": "2.12.4",
          "currentValue": "^2.12.4",
          "newValue": "^2.12.7",
          "newVersion": "2.12.7",
          "packageFile": "packages/kuma-gui/package.json",
          "updateType": "patch",
          "packageName": "msw"
        },
        {
          "datasource": "npm",
          "depName": "msw",
          "displayPending": "",
          "currentVersion": "2.12.4",
          "currentValue": "^2.12.4",
          "newValue": "^2.12.7",
          "newVersion": "2.12.7",
          "packageFile": "packages/fake-api/package.json",
          "updateType": "patch",
          "packageName": "msw"
        }
      ]
    },
```

so even the schedule was met the branch status `pending` prevented the PR to be created. The next run of renovate was after 4am and the schedule wasn't met anymore.

#### Summary

When removing `prCreation: "not-pending"` we are using the following settings:
- `prCreation: "immediate"` -> immediately create a PR after the branch is created
- `internalChecksFilter: "strict"` -> only creates branches when `minimumReleaseAge` is met
- `minimumReleaseAge: "12 days"`

I also think that the weekly schedule together with `minimumReleaseAge` of 12 days is too long and we can change it to daily. This would also speed up the feedback loop of the changes in the renovate config. I'd be fine to slow it down in the future after we're good with the config.