### PR TITLE
fix(mocks): fixes to mesh/mesh-insights mocks

### DIFF
--- a/packages/kuma-http-api/mocks/src/meshes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_.ts
@@ -5,7 +5,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
     _mesh,
     _zone,
     _namespace,
-    name = req.params.name as string,
+    name = req.params.mesh as string,
   ] = kri?.split('_') ?? ''
 
   const isMtlsEnabledOverride = env('KUMA_MTLS_ENABLED', '')


### PR DESCRIPTION
I noticed that the stats that we get from MeshInsights were the wrong shape.

A little while back I made our own OpenAPI types for MeshInsights and we now have those available here so I used that to prevent any future regressions here. I still think its worth finishing up our OpenAPI based types from a maintenance perspective so we have this sort of safety if things change moving forwards.

---

Separately I'd noticed that Mesh was using the wrong route param. We don't currently have similar route param type safety to what we have in RouteView, and whilst it would be nice to add similar (our mocks are pretty much the same thing/interface as RouteView) I guess thats unlikely to happen.