### PR TITLE
refactor(x-notification): move toaster from template to watcher

### DIFF
--- a/packages/x/src/components/x-notification/XNotification.vue
+++ b/packages/x/src/components/x-notification/XNotification.vue
@@ -75,9 +75,9 @@ watch(() => {
 watch(() => {
   return provider && props.type === 'toast' && props.notify && toastMessage.value.length > 0
 }, (shouldToast) => {
-  if(!shouldToast) return
+  if(!shouldToast || typeof provider === 'undefined') return
 
-  provider?.toaster.open({
+  provider.toaster.open({
     appearance: props.variant,
     message: toastMessage.value,
   })


### PR DESCRIPTION
Moves the triggering of `toaster` from the template to a watcher.