### PR TITLE
feat(data-source): add result slot prop

### DIFF
--- a/packages/data/src/vue/components/data-source/DataSource.vue
+++ b/packages/data/src/vue/components/data-source/DataSource.vue
@@ -2,6 +2,7 @@
   <slot
     :data="message"
     :error="error"
+    :result="error ?? message"
     :refresh="refresh"
   />
   <span v-bind="attrs" />


### PR DESCRIPTION
Since the [changes in `DataLoader`](https://github.com/kumahq/kuma-gui/pull/4365) the `:data` prop can also contain an `Error`. This makes it more convenient when passing through the `result` of `DataSource` to components/routes below as we only need to pass down a single prop instead of one for each `data` and `error`. Currently we do this via `:data="error ?? data"`, but this is error prone because it's important to keep the order. It could happen that both `error` and `data` are set, but in this case we want to prioritize the error.

Therefore we thought it'd be good to have this in one place to ensure consistency and reduce the risk. The name is `result` as it's very generic to the context of data fetching and streaming.

This will also be used in https://github.com/kumahq/kuma-gui/pull/4478