### PR TITLE
chore(renovate): only disable npm major minor

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -76,13 +76,11 @@
       "description": [
         " Disable:",
         " - `@kong-ui-public/app-layout`: downstream conflicts due to pinned versions",
-        " - `escape-string-regexp`: need to stick with current version because of esm vs cjs",
-        " - `npm`: handled separately below"
+        " - `escape-string-regexp`: need to stick with current version because of esm vs cjs"
       ],
       "matchPackageNames": [
         "@kong-ui-public/app-layout",
-        "escape-string-regexp",
-        "npm"
+        "escape-string-regexp"
       ],
       "enabled": false
     },
@@ -91,9 +89,10 @@
         "npm"
       ],
       "matchUpdateTypes": [
-        "patch"
+        "major",
+        "minor"
       ],
-      "enabled": true
+      "enabled": false
     },
     {
       "matchCategories": [


### PR DESCRIPTION
After https://github.com/kumahq/kuma-gui/pull/4560 we were expecting to receive patch updates for `npm`, but it seems like the config was slightly incorrect. This is another attempt and not totally sure if it'll work out 🤞 

```
DEBUG: packageFiles with updates
...
         {
            "commitMessageTopic": "npm",
            "currentValue": "~11.6.2",
            "datasource": "npm",
            "depName": "npm",
            "depType": "engines",
            "packageName": "npm",
            "prettyDepType": "engine",
            "skipReason": "disabled",
            "updates": []
          },
....
```

This now removes the general disabling of `npm` updates and then re-enable patches and instead just disables majors and minors.