### PR TITLE
chore(gh/actions/bootstrap): include package.json-files in cache key hash

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -21,7 +21,7 @@ runs:
         # if you ever want to ignore or rebuild the cache you can temporarily
         # remove the restore-keys related comments here also see
         # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-        key: ${{ runner.os }}-bootstrap-cache-${{ hashFiles('**/package-lock.json') }} #-${{ github.run_id }}
+        key: ${{ runner.os }}-bootstrap-cache-${{ hashFiles('**/package-lock.json', '**/package.json') }} #-${{ github.run_id }}
         # restore-keys: |
         #   ${{ runner.os }}-bootstrap-cache-${{ hashFiles('**/package-lock.json') }}
 


### PR DESCRIPTION
While https://github.com/kumahq/kuma-gui/pull/4565 was failing and https://github.com/kumahq/kuma-gui/pull/4568 was passing I noticed that we haven't included the manifest (`package.json`) files into the hash for the cache key yet.

This is required because any change in the manifest that is not reflected in the lock-file should invalidate the cache and eventually causes `npm ci` to fail.

Follows https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#examples-with-multiple-patterns