### PR TITLE
fix(deps): fix npm version check

### DIFF
--- a/packages/config/src/mk/check.mk
+++ b/packages/config/src/mk/check.mk
@@ -25,10 +25,10 @@ check/node:
 		echo "https://nodejs.org/en/download" ; \
 		exit 1; \
 	)
-	@if npm ls -g "npm@$(NPM_VERSION)" | grep "empty" > /dev/null; then \
-		echo "Make sure npm@$(NPM_VERSION) is installed. Try npm install -g npm@$(NPM_VERSION)"; \
-		exit 1; \
-	fi
+	@npm ls -g "npm@$(NPM_VERSION)" > /dev/null 2>&1 || ( \
+			echo "Make sure npm@$(NPM_VERSION) is installed. Try npm install -g npm@$(NPM_VERSION)"; \
+			exit 1; \
+	)
 
 
 .PHONY: .lint


### PR DESCRIPTION
We noticed this check we have to make sure you have the correct npm version installed wasn't quite working as expected.

Still not entirely sure why as it seems a little random.

We asked AI and it made us realize an empty npm ls results in  an error, so we simplified a little and things seem to be more reliable now.