### PR TITLE
fix(deps): adds a npm installation step to ensure CI uses our pinned npm

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -12,6 +12,12 @@ runs:
     - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version-file: '.nvmrc'
+    # install npm dependent on the root package engines entry for npm
+    # we always expect that entry to be there and syncs and is synced by with renovate
+    - shell: bash
+      run: |
+        npm install -g npm@$(cat ${{ github.workspace }}/package.json | jq -r '.engines.npm' )
+        npm -v
     - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
       id: cache
       with:


### PR DESCRIPTION
We noticed a little while back that if we wanted to have npm automatically installing itself based on a range, that renovate and CI etc could have differences due to various little details.

The final piece of the puzzle was to make sure that CI installed the version of npm specified in our root package engines struct. If this is a range, then CI will use that for the install.

We did the most straight-forward thing possible which was to add a quick `npm install -g npm` immediately after our node bootstrapping.

I also added a quick `npm -v` so its easy to verify.

---

Whilst it would have been a bit better to have a `npm-version` input to the bootstrap action, we figured it was easier and more pragmatic to just add it here. If at any point we want to change this to be more generic and provide the `engines.npm` value from The Outside I'd also be fine doing that, but I don't see a reason to at the moment.
