### PR TITLE
chore(deps): replace @modyfi/vite-plugin-yaml with our own loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,21 +2495,6 @@
       "resolved": "packages/x",
       "link": true
     },
-    "node_modules/@modyfi/vite-plugin-yaml": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@modyfi/vite-plugin-yaml/-/vite-plugin-yaml-1.1.1.tgz",
-      "integrity": "sha512-rEbfFNlMGLKpAYs2RsfLAhxCHFa6M4QKHHk0A4EYcCJAUwFtFO6qiEdLjUGUTtnRUxAC7GxxCa+ZbeUILSDvqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "5.1.0",
-        "js-yaml": "4.1.0",
-        "tosource": "2.0.0-alpha.3"
-      },
-      "peerDependencies": {
-        "vite": ">=3.2.7"
-      }
-    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.40.0.tgz",
@@ -3004,29 +2989,6 @@
       "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
-      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.55.1",
@@ -14669,15 +14631,6 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "license": "MIT"
     },
-    "node_modules/tosource": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/tosource/-/tosource-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -16343,7 +16296,6 @@
         "@kumahq/config": "*",
         "@kumahq/fake-api": "*",
         "@kumahq/kuma-http-api": "*",
-        "@modyfi/vite-plugin-yaml": "^1.1.1",
         "@types/js-yaml": "^4.0.9",
         "@types/semver": "^7.7.1",
         "@vitejs/plugin-vue": "^6.0.4",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,6 +21,9 @@
     "./vite": {
       "import": "./src/vite/index.ts"
     },
+    "./vite/modules": {
+      "types": "./src/vite/plugins/modules.d.ts"
+    },
     "./utils": {
       "import": "./src/utils/index.ts"
     },

--- a/packages/config/src/vite/plugins/modules.d.ts
+++ b/packages/config/src/vite/plugins/modules.d.ts
@@ -1,0 +1,9 @@
+declare module '*.yaml' {
+  const value: Record<string, any>
+  export default value
+}
+declare module '*.yml' {
+  const value: Record<string, any>
+  export default value
+}
+

--- a/packages/config/src/vite/plugins/plugins.ts
+++ b/packages/config/src/vite/plugins/plugins.ts
@@ -1,31 +1,45 @@
-import { DEFAULT_SCHEMA, Type } from 'js-yaml'
+import { load, DEFAULT_SCHEMA, Type } from 'js-yaml'
 import markdown from 'markdown-it'
 
-export const yamlLoaderPluginConfig = () => {
+import type { Plugin } from 'vite'
+
+
+export const yamlLoader = (): Plugin => {
   const md = markdown(
     {
       html: true,
     },
   )
-  return { 
-    schema: DEFAULT_SCHEMA.extend(
-      new Type('tag:yaml.org,2002:text/markdown', {
-        kind: 'scalar',
-        construct: (data) => {
+  const schema = DEFAULT_SCHEMA.extend(
+    new Type('tag:yaml.org,2002:text/markdown', {
+      kind: 'scalar',
+      construct: (data) => {
         // We only currently use !!text/markdown within yaml for out locales/i18n text
         // for which we use FormatJS under the hood. FormatJS requires you to escape any XML/HTML looking
         // things, plus ICU '{' and '}', hence this replace.
         // If we ever need !!text/markdown for anything else we should do something like !!text/icu+markdown
-          const str = md.render(data)
+        const str = md.render(data)
 
-          return str.replace(/</g, "'<'")
-            .replace(/%7B/g, '{')
-            .replace(/%7D/g, '}')
-        },
-      }),
-    ),
+        return str.replace(/</g, "'<'")
+          .replace(/%7B/g, '{')
+          .replace(/%7D/g, '}')
+      },
+    }),
+  )
+  return {
+    name: 'yamlLoader',
+    transform: async (code, filename) => {
+      if (/\.ya?ml$/.test(filename)) {
+        const json = load(code, { schema, filename, onWarning: (warning) => console.warn(warning.toString())})
+        return {
+          code: `export default ${JSON.stringify(json)};`,
+          map: { mappings: '' },
+        }
+      }
+    },
   }
 }
+
 
 export const vuePluginConfig = () => ({
   template: {

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -36,7 +36,6 @@
     "@kumahq/config": "*",
     "@kumahq/fake-api": "*",
     "@kumahq/kuma-http-api": "*",
-    "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
     "@types/semver": "^7.7.1",
     "@vitejs/plugin-vue": "^6.0.4",

--- a/packages/kuma-gui/src/shims-vite.d.ts
+++ b/packages/kuma-gui/src/shims-vite.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vite/client" />
-/// <reference types="@modyfi/vite-plugin-yaml/modules" />
+/// <reference types="@kumahq/config/vite/modules" />
+

--- a/packages/kuma-gui/vite.config.production.ts
+++ b/packages/kuma-gui/vite.config.production.ts
@@ -1,7 +1,6 @@
-import { replicateKumaServer, defineConfig as defineBaseConfig, yamlLoaderPluginConfig, vuePluginConfig } from '@kumahq/config/vite'
+import { replicateKumaServer, defineConfig as defineBaseConfig, yamlLoader, vuePluginConfig } from '@kumahq/config/vite'
 import fakeApi from '@kumahq/fake-api/vite'
 import { fs, dependencies } from '@kumahq/kuma-http-api/mocks'
-import yamlLoader from '@modyfi/vite-plugin-yaml'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig, mergeConfig } from 'vite'
 import svgLoader from 'vite-svg-loader'
@@ -13,7 +12,7 @@ export const config: UserConfigFn = () => {
   return {
     plugins: [
       vue(vuePluginConfig()),
-      yamlLoader(yamlLoaderPluginConfig()),
+      yamlLoader(),
       svgLoader(),
       replicateKumaServer(),
       fakeApi({ dependencies, fs }),


### PR DESCRIPTION
We found that this package wasn't being properly maintained to our standards, and also that its basically this line:

```ts
const json = load(code, { schema, filename, onWarning: (warning) => console.warn(warning.toString())})
```

So we've replaced it with our own.