### PR TITLE
fix(deps): remove unnecessary glob dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "packages/*"
   ],
   "overrides": {
-    "js-yaml": "^4.1.1",
-    "glob": "^13.0.1"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@kumahq/config": "*"


### PR DESCRIPTION
We no longer need this override (note `package-lock.json` has no changes here)