### PR TITLE
feat(workloads): add linking to displayed zone elements

### DIFF
--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
@@ -41,7 +41,17 @@
               <div v-if="props.data.zone.length">
                 <dt>{{ t('http.api.property.zone') }}</dt>
                 <dd>
-                  <XBadge>{{ props.data.zone }}</XBadge>
+                  <XAction
+                    v-if="props.data.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: props.data.zone,
+                      },
+                    }"
+                  >
+                    <XBadge>{{ props.data.zone }}</XBadge>
+                  </XAction>
                 </dd>
               </div>
 

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
@@ -94,6 +94,20 @@
                   <template #namespace="{ row: item }">
                     {{ item.namespace }}
                   </template>
+                  <template #zone="{ row: item }">
+                    <XAction
+                      v-if="item.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: item.zone,
+                        },
+                      }"
+                    >
+                      {{ item.zone }}
+                    </XAction>
+                    <span v-else>—</span>
+                  </template>
                   <template #dpps="{ row: item }">
                     {{ item.status.dataplaneProxies.connected }} /
                     {{ item.status.dataplaneProxies.healthy }} /


### PR DESCRIPTION
I noticed that in the new workloads sections I missed to add linking to the respective zone in two places:
- zone column in `WorkloadListView`
- zone badge in `WorkloadDetailView`