### PR TITLE
fix(mesh): flake in service-count

### DIFF
--- a/packages/kuma-gui/features/mesh/Item.feature
+++ b/packages/kuma-gui/features/mesh/Item.feature
@@ -48,6 +48,10 @@ Feature: mesh / item
         resources:
           MeshService:
             total: 11
+          MeshExternalService:
+            total: 0
+          MeshMultiZoneService:
+            total: 0
         services:
           total: 10
       """

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -243,7 +243,7 @@
                     </ResourceStatus>
                     <ResourceStatus
                       v-else
-                      :total="data?.resources.MeshService.total ?? 0"
+                      :total="data?.resources.MeshServiceGeneric.total ?? 0"
                       data-testid="mesh-services-status"
                     >
                       <template #title>
@@ -251,18 +251,18 @@
                       </template>
 
                       <template
-                        v-if="data?.resources.MeshService.total && data?.services.total > 0"
+                        v-if="data?.resources.MeshServiceGeneric.total && data?.services.total > 0"
                         #description
                       >
                         {{ t('meshes.detail.mesh_services') }}
                       </template>
 
                       <template
-                        v-if="data?.resources.MeshServiceGeneric.total && data?.services.internal > 0"
+                        v-if="data?.resources.MeshServiceGeneric.total && data?.services.total > 0"
                         #body
                       >
                         <ResourceStatus
-                          :total="data?.services.total"
+                          :total="data?.services.total ?? 0"
                           data-testid="services-status"
                         >
                           <template #description>


### PR DESCRIPTION
I've noticed that with https://github.com/kumahq/kuma-gui/pull/4573 I introduced a flake and a mistake in which data we use/display. This should be now corrected.
In any case we use `MeshServiceGeneric` as the count of the different variants of `Mesh*Service` (`MeshService`, `MeshExternalService`, `MeshMultizoneService`). `MeshServiceGeneric.total` is the sum of all of these and therefore we only use this information in conditions and the number we display.
Additionally I mistakenly used `data.services.internal` in a condition and similarly to `MeshServiceGeneric` we should only use `data.services.total` in conditions and the number we display because this is the sum of old-style `internal` and `external` services.
Furthermore the flake was mainly about not having `MeshExternalService.total` and `MeshMultizoneService.total` in the fixture, which caused random numbers for these and assertions for the count unpredictable.