### PR TITLE
fix(x): better way to pass through modelValue

### DIFF
--- a/packages/x/src/components/x-radio/XRadio.vue
+++ b/packages/x/src/components/x-radio/XRadio.vue
@@ -1,6 +1,6 @@
 <template>
   <KRadio
-    v-model="modelValue"
+    v-model="model"
     :class="{
       'variant-card': props.card,
     }"
@@ -27,14 +27,14 @@ import { useAttrs } from 'vue'
 
 import type { RadioModelValue } from '@kong/kongponents'
 
+
+const model = defineModel<RadioModelValue>({ required: true })
 const props = withDefaults(defineProps<{
-  modelValue: RadioModelValue
   selectedValue: RadioModelValue
   card?: boolean
 }>(), {
   card: false,
 })
-const { modelValue } = props
 const slots = defineSlots()
 const attrs = useAttrs()
 


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/4586

You have to be careful passing through modelValue from a parent component through to a child component as you can get the following error

```
error  Unexpected mutation of "modelValue" prop  vue/no-mutating-props
```

I'd seen folks just destructuring so I'd used that (whilst wondering how Vue was keeping hold of the reactive reference)

I tried it out downstream and missed that this wasn't actually working correctly.

---

I found another way to pass these values through by using `defineModel` which seems to be the recommended way to do this:

https://vuejs.org/guide/components/v-model.html#basic-usage


