### PR TITLE
feat(workloads): align name of config tab to YAML

### DIFF
--- a/packages/kuma-gui/src/app/workloads/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/workloads/locales/en-us/index.yaml
@@ -8,7 +8,7 @@ workloads:
       title: "{name}"
       navigation:
         workload-detail-view: Overview
-        workload-config-view: Config
+        workload-config-view: YAML
       about:
         title: About this Workload
         labels: Labels


### PR DESCRIPTION
In other places we use the name `YAML` for the config tab. This aligns workloads with the other places to also use `YAML` as the name.