### PR TITLE
fix(x-action): allow fallthrough of click-handlers

### DIFF
--- a/packages/x/src/components/x-action/XAction.vue
+++ b/packages/x/src/components/x-action/XAction.vue
@@ -15,7 +15,6 @@
         },
       }"
       :danger="props.appearance === 'danger' ? true : false"
-      @click="emit('click')"
     >
       <slot name="default" />
     </KDropdownItem>
@@ -133,7 +132,6 @@
       v-bind="$attrs"
       :appearance="props.appearance as ButtonAppearance"
       :size="props.size"
-      @click="emit('click')"
     >
       <template
         v-if="['create', 'refresh', 'progress'].includes(props.action)"
@@ -157,7 +155,6 @@
       :class="`x-action-appearance-${props.appearance}`"
       data-testid="x-action"
       v-bind="$attrs"
-      @click="emit('click')"
     >
       <template
         v-if="['docs'].includes(props.action)"
@@ -194,9 +191,6 @@ type BooleanLocationQueryRaw = Record<string | number, BooleanLocationQueryValue
 type RouteLocationRawWithBooleanQuery = Omit<RouteLocationNamedRaw, 'query'> & {
   query?: BooleanLocationQueryRaw
 }
-const emit = defineEmits<{
-  (event: 'click'): Event
-}>()
 
 defineSlots<{
   default(props: {


### PR DESCRIPTION
As of https://vuejs.org/guide/components/attrs.html#nested-component-inheritance `defineEmits` prevents fallthrough of defined event-handlers. For the case of `XAction` this meant that any `@click` (`v-on:click`) handlers would be consumed by `XAction` and removed from the `$attrs` object, so we could not check for the presence of `$attrs.onClick` in the template to determine which type of action it should render.
Since we are already binding all `$attrs` in the different cases, I think we can safely remove `defineEmits` and just let `onClick`-handlers fall through.