### PR TITLE
fix(workflows/release): not using bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,11 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+
+      - uses: ./.github/actions/bootstrap/
         with:
-          node-version-file: '.nvmrc'
+          install-cmd: |
+            make install
 
       - run: |
           make -C ${{ matrix.package.path }} build


### PR DESCRIPTION
The release workflow didn't use `actions/bootstrap` yet and therefore didn't use the correct `npm` version.

I've also checked if there are more workflows that didn't use `actions/bootstrap` yet, but seems like they are all up to date.