### PR TITLE
chore(agents): add very basic AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# GUI and related packages for Kuma Service Mesh
+
+## Commands
+
+### Development
+
+We use `make` for development. Running `make help` will provide you with the
+majority available targets.
+
+Each package has its own `make` targets. These can be run either by entering
+the package directory and running, or by using `make`s `-C` flag e.g. `make -C
+packages/package-name`. Each package also has its own `make help` that give you
+the majority of available targets.
+
+### Git & PRs
+
+**PRs:** We squash merge PRs and use the PR description as the final commit
+message. Therefore, when writing final PRs descriptions on multi-commit PRs
+write it as if there was one atomic commit in the PR.
+
+---


### PR DESCRIPTION
Adds a very basic AGENTS.md file.

I've purposefully kept this very minimal for the moment because:

1. Its the root `AGENTS.md` file, more specific ones should probably go into the sub packages in our repo.
2. I want to be careful/thoughtful about what goes in these
3. I wanted to reflect (and attempt to solve) the worse thing I found when working with the GH UIs Copilot (well apart from the fact that using a the GH web GUI/PR comments is not great for interacting with an agent), which was to stop it from writing the PR description including all the detail of what it rolled back within the PR etc etc.

I added a tiny bit on our `make` usage seeing as thats probably useful also and also tried to follow https://github.com/kumahq/kuma/blob/master/.github/copilot-instructions.md a little 

All in all I guess we will expand on this at some point.

On the `AGENTS.md` naming: Apart from Anthropic/Claude, everyone seems to be on board with this "pseudo-standard" name. I'm hoping Anthropic get onboard soon also, but you can also direct claude to use this file either via a prompting or other approach (symlinking/docker mounting/CLAUDE.md file referencing etc).

I'd be keen _not_ to add a file for every single product out there, so lets push back as far as we can on that.

---

I want to experiment with this before being happy with it, at the very least I'm hoping the GH GUI agent uses it (I saw docs a while back saying it would)
