### PR TITLE
chore(docs): comment to explain safeness of the only place we use v-html

### DIFF
--- a/packages/x/src/components/x-i18n/XI18n.vue
+++ b/packages/x/src/components/x-i18n/XI18n.vue
@@ -2,6 +2,10 @@
   <template
     v-if="props.path.length > 0"
   >
+    <!-- only text from `safeT` is passed to v-html -->
+    <!-- text from `safeT` is pre-escaped using Vue's escapeHtml -->
+    <!-- and is therefore safe enough to pass to v-html  -->
+
     <!-- eslint-disable vue/no-v-html -->
     <div
       class="x-i18n"


### PR DESCRIPTION
Adds a comment to explain that we are using Vue's `escapeHtml` in the only place we ever use `v-html` in the application.

I decided to do this in code, right next to where we use `v-html`, so its more discoverable in future.