### PR TITLE
chore(deps): exact pin @kong-ui-public/app-layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16251,7 +16251,7 @@
       "name": "@kumahq/x",
       "version": "0.1.0",
       "dependencies": {
-        "@kong-ui-public/app-layout": "^4.10.21",
+        "@kong-ui-public/app-layout": "4.10.21",
         "@kong/icons": "^1.43.0",
         "@kong/kongponents": "^9.50.5",
         "@vue/shared": "^3.5.28",

--- a/packages/config/src/package.schema.json
+++ b/packages/config/src/package.schema.json
@@ -22,6 +22,10 @@
     "rangeOnlyVersion": {
       "type": "string",
       "pattern": "^(?!\\d+\\.\\d+\\.\\d+).*"
+    },
+    "exactOnlyVersion": {
+      "type": "string",
+      "pattern": "(?!\\d+\\.\\d+\\.\\d+).*"
     }
   },
   "properties": {
@@ -41,6 +45,9 @@
       "patternProperties": {
         "@kumahq/ignored-example": {
           "type": "string"
+        },
+        "@kong-ui-public/app-layout": {
+          "$ref": "#/definitions/exactOnlyVersion"
         }
       },
       "additionalProperties": {

--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -12,7 +12,7 @@
     "help": "make help"
   },
   "dependencies": {
-    "@kong-ui-public/app-layout": "^4.10.21",
+    "@kong-ui-public/app-layout": "4.10.21",
     "@kong/kongponents": "^9.50.5",
     "@kong/icons": "^1.43.0",
     "shiki": "^3.22.0",


### PR DESCRIPTION
We've decided to exact pin `@kong-ui-public/app-layout` because one of our consumers requires a single exact version of this package be installed, so we have decided to follow the exact version they use and only upgrade when they do.

Whilst using the following would work (as in the existing example):
```json
"@kong-ui-public/app-layout": {
  "type": "string"
}
```

I wanted to be more explicit and also, it must be an exact version contraint and not just any `string` / ignored. So I added a new `exactOnlyVersion` definition to express this:

```json
"@kong-ui-public/app-layout": {
  "$ref": "#/definitions/exactOnlyVersion"
}
```