### PR TITLE
chore(e2e): externalizes/moves client.waitForVisit

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,6 +9,9 @@
     ".": {
       "default": "./src/index.ts"
     },
+    "./cypress": {
+      "import": "./src/cypress/index.ts"
+    },
     "./cypress/e2e": {
       "import": "./src/cypress/e2e.ts"
     },

--- a/packages/config/src/cypress/client.ts
+++ b/packages/config/src/cypress/client.ts
@@ -51,10 +51,39 @@ const equals = (request: Request, item: HistoryEntry) => {
     },
   )
 }
-export default () => {
+export const getClient = () => {
   let history: HistoryEntry[] = []
   let listeners: Listener[] = []
   return {
+    waitForVisit: (_path: string, cookies: { name: string, value: string }[], cy: Cypress.cy) => {
+      // TODO: ideally we don't want to use cy.get here
+      cy.get('#kuma-config').then((obj) => {
+        const node = obj.get(0)
+        if (node === null || node.textContent === null) {
+          throw new Error('#kuma-config not found')
+        }
+        const config = JSON.parse(node.textContent)
+        cookies.forEach(item => {
+          switch (item.name) {
+            case 'KUMA_VERSION':
+              config.version = item.value
+              break
+            case 'KUMA_MODE':
+              config.mode = item.value
+              break
+            case 'KUMA_ENVIRONMENT':
+              config.environment = item.value
+              break
+            case 'KUMA_STORE_TYPE':
+              config.storeType = item.value
+              break
+          }
+        })
+        node.textContent = JSON.stringify(config)
+      })
+      // currently use this to denote "the page has initially rendered"
+      return '[data-testid-root="mesh-app"]'
+    },
     reset: () => {
       history = []
       listeners = []

--- a/packages/config/src/cypress/index.ts
+++ b/packages/config/src/cypress/index.ts
@@ -1,0 +1,1 @@
+export * from './client'

--- a/packages/config/src/cypress/steps/index.ts
+++ b/packages/config/src/cypress/steps/index.ts
@@ -15,6 +15,7 @@ type Request = {
 }
 
 type BaseClient = {
+  waitForVisit: (path: string, cookies: { name: string, value: string }[], cy: Cypress.cy) => string
   waitForRequest: (request: Request) => Promise<unknown>
   reset: () => unknown
   request: (request: { url: URL, request: Omit<Request, 'url' | 'searchParams'> }) => unknown
@@ -173,38 +174,15 @@ export async function setupSteps<TMock extends BaseMock, TClient extends BaseCli
   // act
 
   When('I visit the {string} URL', function (path: string) {
-  // turn off MSW in dev environments so we can use cy.intercept
+    // turn off MSW in dev environments so we can use cy.intercept
     cy.setCookie('KUMA_MOCK_API_ENABLED', 'false')
     //
-
     cy.getAllCookies().then((cookies) => {
       cy.visit(`${path}`)
-      cy.get('#kuma-config').then((obj) => {
-        const node = obj.get(0)
-        if (node === null || node.textContent === null) {
-          throw new Error('#kuma-config not found')
-        }
-        const config = JSON.parse(node.textContent)
-        cookies.forEach(item => {
-          switch (item.name) {
-            case 'KUMA_VERSION':
-              config.version = item.value
-              break
-            case 'KUMA_MODE':
-              config.mode = item.value
-              break
-            case 'KUMA_ENVIRONMENT':
-              config.environment = item.value
-              break
-            case 'KUMA_STORE_TYPE':
-              config.storeType = item.value
-              break
-          }
-        })
-        node.textContent = JSON.stringify(config)
-      })
-      // currently use this to denote "the page has initially rendered"
-      cy.get('[data-testid-root="mesh-app"]').should('be.visible')
+      const sel = client.waitForVisit(`${path}`, cookies, cy)
+      if(sel.length > 0) {
+        cy.get(sel).should('be.visible')
+      }
     })
   })
 

--- a/packages/kuma-gui/cypress/services.ts
+++ b/packages/kuma-gui/cypress/services.ts
@@ -1,8 +1,8 @@
+import { getClient } from '@kumahq/config/cypress'
 import { token, createInjections } from '@kumahq/container'
 import { mocker } from '@kumahq/fake-api/cypress'
 import env from '@kumahq/settings/env'
 
-import getClient from '@/test-support/client'
 import type { ServiceDefinition } from '@kumahq/container'
 import type { Middleware, Options } from '@kumahq/fake-api'
 


### PR DESCRIPTION
Moves the `client` we use for Cypress/e2e into `@kumahq/config` and adds `waitForVisit`

There are still a few Kuma specific thigns in our steps files, but I think its just env var access, which I would love to remove at a later date.

Also, ideally in `waitForVisit` we wouldn't need to pass `cy` through, but for now I'm happy that this externalizes the setting of the HTML vars from your cookies.