### PR TITLE
chore(container): reset container on build

### DIFF
--- a/packages/container/index.ts
+++ b/packages/container/index.ts
@@ -49,7 +49,8 @@ export type ServiceConfigurator<T = Record<string, Token>> = ($: T) => ServiceDe
 export type Alias<T extends (...args: never[]) => unknown> = (...rest: Parameters<T>) => ReturnType<T>
 export type Decorator<T extends TokenValue> = TokenType<T>
 export type ReturnDecorated<T extends TokenValue> = () => TokenType<T>
-export const container = createContainer()
+export let container = createContainer()
+let labelMap = new WeakMap()
 
 //
 export const merge = (...definitions: Array<ServiceDefinition[]>): ServiceDefinition[] => {
@@ -102,6 +103,8 @@ export const get = <T extends TokenValue>(token: T): TokenType<T> => {
   }
 }
 export const build = (...entries: Array<ServiceDefinition[]>): typeof get => {
+  container = createContainer()
+  labelMap = new WeakMap()
   const merged = decorate(merge(...entries))
   merged.forEach(item => service(...item))
   return get
@@ -113,7 +116,6 @@ export const createInjections = <T extends TokenValue[]>(
   tokens.map((token) => () => get(token)) as InjectionHooks<T>
 //
 
-const labelMap = new WeakMap()
 export const service = (t: Token, config: DependencyDefinition): void => {
   const bound = container.bind(t)
   switch (true) {


### PR DESCRIPTION
Way way back when we started with our container, we decided to have one single container and all functions within this file would act on that. The container would stick around for the lifetime of the app and would never need tearing down/destroying - you just navigate away from our app.

We have a use case where we might like to unmount our app and mount it again in the same execution context. This means _mostly_ the container needs tearing down / destroying and then rebuilding from scratch again when we remount.

Whilst not ideal, for the moment I'm just recreating a new container when you call `build`. This means if you call `build` multiple times during an apps lifetime, the container is thrown away and recreated fresh and empty and then rebuilt with whatever you pass to `build`.

We've always used the idea of a single "wiring root" / main file for our apps (and the different environments that we use our service container in) where we build _once_ and use the returned `get` function to retrieve services, so this shouldn't be a problem - but its something to be aware of short term.

Ideally this would be re-jigged so we take into account that we now have this new use case for unmounting and remounting our app in the same execution context - whether we'll get to re-jigg this or not is another question.