### PR TITLE
chore: adds `:card` prop to AccordionItem

### DIFF
--- a/packages/kuma-gui/src/app/common/AccordionItem.vue
+++ b/packages/kuma-gui/src/app/common/AccordionItem.vue
@@ -3,30 +3,34 @@
     class="accordion-item"
     :class="{ active: visible }"
   >
-    <button
-      class="accordion-item-header"
-      type="button"
-      :aria-expanded="visible ? 'true' : 'false'"
-      data-testid="accordion-item-button"
-      @click="open"
+    <component
+      :is="props.card ? `x-card` : `xanonymous`"
     >
-      <slot name="accordion-header" />
-    </button>
-
-    <transition
-      name="accordion"
-      @enter="start"
-      @after-enter="end"
-      @before-leave="start"
-    >
-      <div
-        v-if="visible"
-        class="accordion-item-content"
-        data-testid="accordion-item-content"
+      <button
+        class="accordion-item-header"
+        type="button"
+        :aria-expanded="visible ? 'true' : 'false'"
+        data-testid="accordion-item-button"
+        @click="open"
       >
-        <slot name="accordion-content" />
-      </div>
-    </transition>
+        <slot name="accordion-header" />
+      </button>
+
+      <transition
+        name="accordion"
+        @enter="start"
+        @after-enter="end"
+        @before-leave="start"
+      >
+        <div
+          v-if="visible"
+          class="accordion-item-content"
+          data-testid="accordion-item-content"
+        >
+          <slot name="accordion-content" />
+        </div>
+      </transition>
+    </component>
   </li>
 </template>
 
@@ -34,6 +38,12 @@
 import { computed, inject, ref } from 'vue'
 
 import type { Ref } from 'vue'
+
+const props = withDefaults(defineProps<{
+  card?: boolean
+}>(), {
+  card: false,
+})
 
 const parentAccordion = inject<{
   multipleOpen: boolean

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -113,72 +113,72 @@
                       v-for="({ rules, kind }) in policiesData?.policies || []"
                       :key="kind"
                     >
-                      <XCard>
-                        <AccordionItem>
-                          <template #accordion-header>
-                            <span
-                              v-icon-start="{name: kind, size: '60', default: 'policy'}"
+                      <AccordionItem
+                        :card="true"
+                      >
+                        <template #accordion-header>
+                          <span
+                            v-icon-start="{name: kind, size: '60', default: 'policy'}"
+                          >
+                            {{ kind }} ({{ rules!.length }})
+                          </span>
+                        </template>
+                        <template #accordion-content>
+                          <XLayout variant="y-stack">
+                            <XTable
+                              v-for="item in rules"
+                              :key="item.kri"
+                              variant="kv"
                             >
-                              {{ kind }} ({{ rules!.length }})
-                            </span>
-                          </template>
-                          <template #accordion-content>
-                            <XLayout variant="y-stack">
-                              <XTable
-                                v-for="item in rules"
-                                :key="item.kri"
-                                variant="kv"
-                              >
-                                <tr>
-                                  <th scope="row">
-                                    Policy origin
-                                  </th>
-                                  <td>
+                              <tr>
+                                <th scope="row">
+                                  Policy origin
+                                </th>
+                                <td>
+                                  <template
+                                    v-for="kri in [Kri.fromString(item.kri)]"
+                                    :key="typeof kri"
+                                  >
+                                    <XAction
+                                      v-if="policyTypes[kind] && Kri.isKriString(item.kri)"
+                                      :to="{
+                                        name: 'policy-detail-view',
+                                        params: {
+                                          mesh: kri.mesh,
+                                          policyPath: policyTypes[kind]![0].path,
+                                          policy: item.kri,
+                                        },
+                                      }"
+                                    >
+                                      {{ item.kri }}
+                                    </XAction>
                                     <template
-                                      v-for="kri in [Kri.fromString(item.kri)]"
-                                      :key="typeof kri"
+                                      v-else
                                     >
-                                      <XAction
-                                        v-if="policyTypes[kind] && Kri.isKriString(item.kri)"
-                                        :to="{
-                                          name: 'policy-detail-view',
-                                          params: {
-                                            mesh: kri.mesh,
-                                            policyPath: policyTypes[kind]![0].path,
-                                            policy: item.kri,
-                                          },
-                                        }"
-                                      >
-                                        {{ item.kri }}
-                                      </XAction>
-                                      <template
-                                        v-else
-                                      >
-                                        {{ item.kri }}
-                                      </template>
+                                      {{ item.kri }}
                                     </template>
-                                  </td>
-                                </tr>
-                                <tr>
-                                  <td colspan="2">
-                                    <XLayout
-                                      variant="y-stack"
-                                      size="small"
-                                    >
-                                      <span>Config</span>
-                                      <XCodeBlock
-                                        :code="YAML.stringify(item.conf)"
-                                        language="yaml"
-                                        :show-copy-button="false"
-                                      />
-                                    </XLayout>
-                                  </td>
-                                </tr>
-                              </XTable>
-                            </XLayout>
-                          </template>
-                        </AccordionItem>
-                      </XCard>
+                                  </template>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td colspan="2">
+                                  <XLayout
+                                    variant="y-stack"
+                                    size="small"
+                                  >
+                                    <span>Config</span>
+                                    <XCodeBlock
+                                      :code="YAML.stringify(item.conf)"
+                                      language="yaml"
+                                      :show-copy-button="false"
+                                    />
+                                  </XLayout>
+                                </td>
+                              </tr>
+                            </XTable>
+                          </XLayout>
+                        </template>
+                      </AccordionItem>
                     </template>
                   </AccordionList>
                 </template>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -109,76 +109,76 @@
                       v-for="({ conf, kind, origins }) in policiesData?.policies || []"
                       :key="kind"
                     >
-                      <XCard>
-                        <AccordionItem>
-                          <template #accordion-header>
-                            <span
-                              v-icon-start="{name: kind, size: '60', default: 'policy'}"
-                            >
-                              {{ kind }}
-                            </span>
-                          </template>
-                          <template #accordion-content>
-                            <XTable
-                              v-if="origins.length > 0"
-                              variant="kv"
-                            >
-                              <tr>
-                                <th scope="row">
-                                  Origin policies
-                                </th>
-                                <td>
-                                  <ul>
-                                    <li
-                                      v-for="origin in origins"
-                                      :key="origin.kri"
-                                    >
-                                      <template
-                                        v-for="kri in [Kri.fromString(origin.kri)]"
-                                        :key="typeof kri"
-                                      >
-                                        <XAction
-                                          v-if="policyTypes[kind]"
-                                          :to="{
-                                            name: 'policy-detail-view',
-                                            params: {
-                                              mesh: kri.mesh,
-                                              policyPath: policyTypes[kind]![0].path,
-                                              policy: origin.kri,
-                                            },
-                                          }"
-                                        >
-                                          {{ origin.kri }}
-                                        </XAction>
-                                        <template
-                                          v-else
-                                        >
-                                          {{ origin.kri }}
-                                        </template>
-                                      </template>
-                                    </li>
-                                  </ul>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td colspan="2">
-                                  <XLayout
-                                    variant="y-stack"
-                                    size="small"
+                      <AccordionItem
+                        :card="true"
+                      >
+                        <template #accordion-header>
+                          <span
+                            v-icon-start="{name: kind, size: '60', default: 'policy'}"
+                          >
+                            {{ kind }}
+                          </span>
+                        </template>
+                        <template #accordion-content>
+                          <XTable
+                            v-if="origins.length > 0"
+                            variant="kv"
+                          >
+                            <tr>
+                              <th scope="row">
+                                Origin policies
+                              </th>
+                              <td>
+                                <ul>
+                                  <li
+                                    v-for="origin in origins"
+                                    :key="origin.kri"
                                   >
-                                    <span>Config</span>
-                                    <XCodeBlock
-                                      :code="YAML.stringify(conf)"
-                                      language="yaml"
-                                      :show-copy-button="false"
-                                    />
-                                  </XLayout>
-                                </td>
-                              </tr>
-                            </XTable>
-                          </template>
-                        </AccordionItem>
-                      </XCard>
+                                    <template
+                                      v-for="kri in [Kri.fromString(origin.kri)]"
+                                      :key="typeof kri"
+                                    >
+                                      <XAction
+                                        v-if="policyTypes[kind]"
+                                        :to="{
+                                          name: 'policy-detail-view',
+                                          params: {
+                                            mesh: kri.mesh,
+                                            policyPath: policyTypes[kind]![0].path,
+                                            policy: origin.kri,
+                                          },
+                                        }"
+                                      >
+                                        {{ origin.kri }}
+                                      </XAction>
+                                      <template
+                                        v-else
+                                      >
+                                        {{ origin.kri }}
+                                      </template>
+                                    </template>
+                                  </li>
+                                </ul>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td colspan="2">
+                                <XLayout
+                                  variant="y-stack"
+                                  size="small"
+                                >
+                                  <span>Config</span>
+                                  <XCodeBlock
+                                    :code="YAML.stringify(conf)"
+                                    language="yaml"
+                                    :show-copy-button="false"
+                                  />
+                                </XLayout>
+                              </td>
+                            </tr>
+                          </XTable>
+                        </template>
+                      </AccordionItem>
                     </template>
                   </AccordionList>
                 </template>

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -113,87 +113,87 @@
                           v-for="(rules, key) in Object.groupBy(items, item => item.type)"
                           :key="key"
                         >
-                          <XCard>
-                            <AccordionItem>
-                              <template #accordion-header>
-                                <span
-                                  v-icon-start="{name: key, size: '60', default: 'policy'}"
+                          <AccordionItem
+                            :card="true"
+                          >
+                            <template #accordion-header>
+                              <span
+                                v-icon-start="{name: key, size: '60', default: 'policy'}"
+                              >
+                                {{ key }} ({{ rules!.length }})
+                              </span>
+                            </template>
+                            <template #accordion-content>
+                              <XTable
+                                variant="kv"
+                              >
+                                <template
+                                  v-for="item in rules"
+                                  :key="item"
                                 >
-                                  {{ key }} ({{ rules!.length }})
-                                </span>
-                              </template>
-                              <template #accordion-content>
-                                <XTable
-                                  variant="kv"
-                                >
-                                  <template
-                                    v-for="item in rules"
-                                    :key="item"
+                                  <tr
+                                    v-if="item.matchers.length > 0"
                                   >
-                                    <tr
-                                      v-if="item.matchers.length > 0"
-                                    >
-                                      <th scope="row">
-                                        From
-                                      </th>
-                                      <td>
-                                        <p><RuleMatchers :items="item.matchers" /></p>
-                                      </td>
-                                    </tr>
-                                    <tr
-                                      v-if="item.origins.length > 0"
-                                    >
-                                      <th scope="row">
-                                        Origin policies
-                                      </th>
-                                      <td>
-                                        <ul>
-                                          <li
-                                            v-for="origin in item.origins"
-                                            :key="`${origin.mesh}-${origin.name}`"
-                                          >
-                                            <XAction
-                                              v-if="policyTypes[origin.type]"
-                                              :to="{
-                                                name: 'policy-detail-view',
-                                                params: {
-                                                  mesh: origin.mesh,
-                                                  policyPath: policyTypes[origin.type]![0].path,
-                                                  policy: origin.name,
-                                                },
-                                              }"
-                                            >
-                                              {{ origin.name }}
-                                            </XAction>
-                                            <template
-                                              v-else
-                                            >
-                                              {{ origin.name }}
-                                            </template>
-                                          </li>
-                                        </ul>
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td colspan="2">
-                                        <XLayout
-                                          variant="y-stack"
-                                          size="small"
+                                    <th scope="row">
+                                      From
+                                    </th>
+                                    <td>
+                                      <p><RuleMatchers :items="item.matchers" /></p>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    v-if="item.origins.length > 0"
+                                  >
+                                    <th scope="row">
+                                      Origin policies
+                                    </th>
+                                    <td>
+                                      <ul>
+                                        <li
+                                          v-for="origin in item.origins"
+                                          :key="`${origin.mesh}-${origin.name}`"
                                         >
-                                          <span>Config</span>
-                                          <XCodeBlock
-                                            :code="YAML.stringify(item.raw)"
-                                            language="yaml"
-                                            :show-copy-button="false"
-                                          />
-                                        </XLayout>
-                                      </td>
-                                    </tr>
-                                  </template>
-                                </XTable>
-                              </template>
-                            </AccordionItem>
-                          </XCard>
+                                          <XAction
+                                            v-if="policyTypes[origin.type]"
+                                            :to="{
+                                              name: 'policy-detail-view',
+                                              params: {
+                                                mesh: origin.mesh,
+                                                policyPath: policyTypes[origin.type]![0].path,
+                                                policy: origin.name,
+                                              },
+                                            }"
+                                          >
+                                            {{ origin.name }}
+                                          </XAction>
+                                          <template
+                                            v-else
+                                          >
+                                            {{ origin.name }}
+                                          </template>
+                                        </li>
+                                      </ul>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <td colspan="2">
+                                      <XLayout
+                                        variant="y-stack"
+                                        size="small"
+                                      >
+                                        <span>Config</span>
+                                        <XCodeBlock
+                                          :code="YAML.stringify(item.raw)"
+                                          language="yaml"
+                                          :show-copy-button="false"
+                                        />
+                                      </XLayout>
+                                    </td>
+                                  </tr>
+                                </template>
+                              </XTable>
+                            </template>
+                          </AccordionItem>
                         </template>
                       </AccordionList>
                     </div>

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -167,87 +167,87 @@
                             v-for="(rules, key) in Object.groupBy(items, item => item.type)"
                             :key="key"
                           >
-                            <XCard>
-                              <AccordionItem>
-                                <template #accordion-header>
-                                  <span
-                                    v-icon-start="{name: key, size: '60', default: 'policy'}"
+                            <AccordionItem
+                              :card="true"
+                            >
+                              <template #accordion-header>
+                                <span
+                                  v-icon-start="{name: key, size: '60', default: 'policy'}"
+                                >
+                                  {{ key }} ({{ rules!.length }})
+                                </span>
+                              </template>
+                              <template #accordion-content>
+                                <XTable
+                                  variant="kv"
+                                >
+                                  <template
+                                    v-for="item in rules"
+                                    :key="item"
                                   >
-                                    {{ key }} ({{ rules!.length }})
-                                  </span>
-                                </template>
-                                <template #accordion-content>
-                                  <XTable
-                                    variant="kv"
-                                  >
-                                    <template
-                                      v-for="item in rules"
-                                      :key="item"
+                                    <tr
+                                      v-if="item.matchers.length > 0"
                                     >
-                                      <tr
-                                        v-if="item.matchers.length > 0"
-                                      >
-                                        <th scope="row">
-                                          From
-                                        </th>
-                                        <td>
-                                          <p><RuleMatchers :items="item.matchers" /></p>
-                                        </td>
-                                      </tr>
-                                      <tr
-                                        v-if="item.origins.length > 0"
-                                      >
-                                        <th scope="row">
-                                          Origin policies
-                                        </th>
-                                        <td>
-                                          <ul>
-                                            <li
-                                              v-for="origin in item.origins"
-                                              :key="`${origin.mesh}-${origin.name}`"
-                                            >
-                                              <XAction
-                                                v-if="types[origin.type]"
-                                                :to="{
-                                                  name: 'policy-detail-view',
-                                                  params: {
-                                                    mesh: origin.mesh,
-                                                    policyPath: types[origin.type]![0].path,
-                                                    policy: origin.name,
-                                                  },
-                                                }"
-                                              >
-                                                {{ origin.name }}
-                                              </XAction>
-                                              <template
-                                                v-else
-                                              >
-                                                {{ origin.name }}
-                                              </template>
-                                            </li>
-                                          </ul>
-                                        </td>
-                                      </tr>
-                                      <tr>
-                                        <td colspan="2">
-                                          <XLayout
-                                            variant="y-stack"
-                                            size="small"
+                                      <th scope="row">
+                                        From
+                                      </th>
+                                      <td>
+                                        <p><RuleMatchers :items="item.matchers" /></p>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      v-if="item.origins.length > 0"
+                                    >
+                                      <th scope="row">
+                                        Origin policies
+                                      </th>
+                                      <td>
+                                        <ul>
+                                          <li
+                                            v-for="origin in item.origins"
+                                            :key="`${origin.mesh}-${origin.name}`"
                                           >
-                                            <span>Config</span>
-                                            <XCodeBlock
-                                              :code="YAML.stringify(item.raw)"
-                                              language="yaml"
-                                              :show-copy-button="false"
-                                            />
-                                          </XLayout>
-                                        </td>
-                                      </tr>
-                                    </template>
-                                  </XTable>
-                                </template>
-                              </AccordionItem>
-                            </XCard>
+                                            <XAction
+                                              v-if="types[origin.type]"
+                                              :to="{
+                                                name: 'policy-detail-view',
+                                                params: {
+                                                  mesh: origin.mesh,
+                                                  policyPath: types[origin.type]![0].path,
+                                                  policy: origin.name,
+                                                },
+                                              }"
+                                            >
+                                              {{ origin.name }}
+                                            </XAction>
+                                            <template
+                                              v-else
+                                            >
+                                              {{ origin.name }}
+                                            </template>
+                                          </li>
+                                        </ul>
+                                      </td>
+                                    </tr>
+                                    <tr>
+                                      <td colspan="2">
+                                        <XLayout
+                                          variant="y-stack"
+                                          size="small"
+                                        >
+                                          <span>Config</span>
+                                          <XCodeBlock
+                                            :code="YAML.stringify(item.raw)"
+                                            language="yaml"
+                                            :show-copy-button="false"
+                                          />
+                                        </XLayout>
+                                      </td>
+                                    </tr>
+                                  </template>
+                                </XTable>
+                              </template>
+                            </AccordionItem>
                           </template>
                         </AccordionList>
                       </div>


### PR DESCRIPTION
Whilst working on https://github.com/kumahq/kuma-gui/issues/3817 I noticed that our usage of AccordionItem with XCard produces incorrect HTML (`ul > div > div li`)

This PR adds a `:card` prop to avoid this temporarily. But this will be the reason to finally take a look at our Accordion implementation longer term, get it improved and moved into `x`