### PR TITLE
chore: remove the majority of old class="stack"

### DIFF
--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
@@ -12,89 +12,108 @@
     v-slot="{ route, t, uri }"
   >
     <AppView>
-      <div
-        class="stack"
+      <DataLoader
+        :src="uri(sources, `/meshes/:mesh/external-services/:name`, {
+          mesh: route.params.mesh,
+          name: route.params.service,
+        })"
+        v-slot="{ data: [data] }"
       >
-        <DataLoader
-          :src="uri(sources, `/meshes/:mesh/external-services/:name`, {
-            mesh: route.params.mesh,
-            name: route.params.service,
-          })"
-          v-slot="{ data: [data] }"
+        <XAboutCard
+          data-testid="external-service-details"
+          :title="t('external-services.detail.about.title')"
+          :created="data.creationTime"
+          :modified="data.modificationTime"
         >
-          <XAboutCard
-            data-testid="external-service-details"
-            :title="t('external-services.detail.about.title')"
-            :created="data.creationTime"
-            :modified="data.modificationTime"
-          >
-            <XDl variant="x-stack">
-              <div>
-                <dt>
-                  {{ t('http.api.property.address') }}
-                </dt>
-                <dd>
-                  <XCopyButton
-                    variant="badge"
-                    format="default"
-                    :text="data.networking.address"
-                  />
-                </dd>
-              </div>
-              <div
-                v-if="data.tags"
-              >
-                <dt>
-                  {{ t('http.api.property.tags') }}
-                </dt>
-                <dd>
-                  <TagList
-                    :tags="data.tags"
-                    should-truncate
-                  />
-                </dd>
-              </div>
-            </XDl>
-          </XAboutCard>
+          <XDl variant="x-stack">
+            <div>
+              <dt>
+                {{ t('http.api.property.address') }}
+              </dt>
+              <dd>
+                <XCopyButton
+                  variant="badge"
+                  format="default"
+                  :text="data.networking.address"
+                />
+              </dd>
+            </div>
+            <div
+              v-if="data.tags"
+            >
+              <dt>
+                {{ t('http.api.property.tags') }}
+              </dt>
+              <dd>
+                <TagList
+                  :tags="data.tags"
+                  should-truncate
+                />
+              </dd>
+            </div>
+          </XDl>
+        </XAboutCard>
 
-          <XCard>
-            <template #title>
-              <h3>{{ t('external-services.detail.config') }}</h3>
+        <XCard>
+          <template #title>
+            <h3>{{ t('external-services.detail.config') }}</h3>
+          </template>
+
+          <XLayout variant="y-stack">
+            <XLayout
+              variant="separated"
+              justify="end"
+            >
+              <div
+                v-for="options in [['universal', 'k8s']]"
+                :key="typeof options"
+              >
+                <XSelect
+                  :label="t('external-services.routes.item.format')"
+                  :selected="route.params.environment"
+                  @change="(value) => {
+                    route.update({ environment: value })
+                  }"
+                  @vue:before-mount="$event?.props?.selected && options.includes($event.props.selected) && $event.props.selected !== route.params.environment && route.update({ environment: $event.props.selected })"
+                >
+                  <template
+                    v-for="value in options"
+                    :key="value"
+                    #[`${value}-option`]
+                  >
+                    {{ t(`external-services.routes.item.formats.${value}`) }}
+                  </template>
+                </XSelect>
+              </div>
+            </XLayout>
+
+            <template v-if="route.params.environment === 'universal'">
+              <XCodeBlock
+                data-testid="codeblock-yaml-universal"
+                language="yaml"
+                :code="YAML.stringify(data.config)"
+                is-searchable
+                :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter"
+                :is-reg-exp-mode="route.params.codeRegExp"
+                @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+              />
             </template>
 
-            <XLayout variant="y-stack">
-              <XLayout
-                variant="separated"
-                justify="end"
+            <template v-else>
+              <DataLoader
+                :src="uri(sources, `/meshes/:mesh/external-services/:name/as/kubernetes`, {
+                  mesh: route.params.mesh,
+                  name: route.params.service,
+                })"
+                v-slot="{ data: [k8sConfig] }"
               >
-                <div
-                  v-for="options in [['universal', 'k8s']]"
-                  :key="typeof options"
-                >
-                  <XSelect
-                    :label="t('external-services.routes.item.format')"
-                    :selected="route.params.environment"
-                    @change="(value) => {
-                      route.update({ environment: value })
-                    }"
-                    @vue:before-mount="$event?.props?.selected && options.includes($event.props.selected) && $event.props.selected !== route.params.environment && route.update({ environment: $event.props.selected })"
-                  >
-                    <template
-                      v-for="value in options"
-                      :key="value"
-                      #[`${value}-option`]
-                    >
-                      {{ t(`external-services.routes.item.formats.${value}`) }}
-                    </template>
-                  </XSelect>
-                </div>
-              </XLayout>
-
-              <template v-if="route.params.environment === 'universal'">
                 <XCodeBlock
-                  data-testid="codeblock-yaml-universal"
+                  data-testid="codeblock-yaml-k8s"
                   language="yaml"
-                  :code="YAML.stringify(data.config)"
+                  :code="YAML.stringify(k8sConfig)"
                   is-searchable
                   :query="route.params.codeSearch"
                   :is-filter-mode="route.params.codeFilter"
@@ -103,34 +122,11 @@
                   @filter-mode-change="route.update({ codeFilter: $event })"
                   @reg-exp-mode-change="route.update({ codeRegExp: $event })"
                 />
-              </template>
-
-              <template v-else>
-                <DataLoader
-                  :src="uri(sources, `/meshes/:mesh/external-services/:name/as/kubernetes`, {
-                    mesh: route.params.mesh,
-                    name: route.params.service,
-                  })"
-                  v-slot="{ data: [k8sConfig] }"
-                >
-                  <XCodeBlock
-                    data-testid="codeblock-yaml-k8s"
-                    language="yaml"
-                    :code="YAML.stringify(k8sConfig)"
-                    is-searchable
-                    :query="route.params.codeSearch"
-                    :is-filter-mode="route.params.codeFilter"
-                    :is-reg-exp-mode="route.params.codeRegExp"
-                    @query-change="route.update({ codeSearch: $event })"
-                    @filter-mode-change="route.update({ codeFilter: $event })"
-                    @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-                  />
-                </DataLoader>
-              </template>
-            </XLayout>
-          </XCard>
-        </DataLoader>
-      </div>
+              </DataLoader>
+            </template>
+          </XLayout>
+        </XCard>
+      </DataLoader>
     </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceListView.vue
@@ -61,6 +61,7 @@
                 <template #name="{ row: item }">
                   <XCopyButton :text="item.name">
                     <XAction
+                      data-action
                       :to="{
                         name: 'external-service-detail-view',
                         params: {

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -13,202 +13,198 @@
     v-slot="{ can, route, t, me, uri }"
   >
     <AppView>
-      <div
-        class="stack"
-      >
-        <XCard>
-          <search>
-            <form
-              class="search-form"
-              @submit.prevent
-            >
-              <XSearch
-                class="search-field"
-                :keys="['name', 'tag', 'label', ...(can('use zones') ? ['zone'] : []), 'namespace']"
-                :value="route.params.s"
-                @change="(s) => route.update({ page: 1, s })"
-              />
-            </form>
-          </search>
-          <DataLoader
-            :src="uri(dataplaneSources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
-              mesh: route.params.mesh,
-              service: props.gateway.selectors[0].match['kuma.io/service'],
-            }, {
-              page: route.params.page,
-              size: route.params.size,
-              search: [
-                route.params.s,
-                ...(props.gateway.origin === 'zone' && props.gateway.zone.length ? [ `zone:${props.gateway.zone}` ] : []),
-              ].join(' '),
-            })"
-            variant="list"
-            v-slot="{ data: [dataplanesData] }"
+      <XCard>
+        <search>
+          <form
+            class="search-form"
+            @submit.prevent
           >
-            <DataCollection
-              type="data-planes"
+            <XSearch
+              class="search-field"
+              :keys="['name', 'tag', 'label', ...(can('use zones') ? ['zone'] : []), 'namespace']"
+              :value="route.params.s"
+              @change="(s) => route.update({ page: 1, s })"
+            />
+          </form>
+        </search>
+        <DataLoader
+          :src="uri(dataplaneSources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
+            mesh: route.params.mesh,
+            service: props.gateway.selectors[0].match['kuma.io/service'],
+          }, {
+            page: route.params.page,
+            size: route.params.size,
+            search: [
+              route.params.s,
+              ...(props.gateway.origin === 'zone' && props.gateway.zone.length ? [ `zone:${props.gateway.zone}` ] : []),
+            ].join(' '),
+          })"
+          variant="list"
+          v-slot="{ data: [dataplanesData] }"
+        >
+          <DataCollection
+            type="data-planes"
+            :items="dataplanesData.items"
+            :total="dataplanesData.total"
+            :page="route.params.page"
+            :page-size="route.params.size"
+            @change="route.update"
+          >
+            <AppCollection
+              class="data-plane-collection"
+              data-testid="data-plane-collection"
+              :headers="[
+                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
+                { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
               :items="dataplanesData.items"
-              :total="dataplanesData.total"
-              :page="route.params.page"
-              :page-size="route.params.size"
-              @change="route.update"
+              :is-selected-row="(row) => row.name === route.params.proxy"
+              @resize="me.set"
             >
-              <AppCollection
-                class="data-plane-collection"
-                data-testid="data-plane-collection"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                  { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
-                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="dataplanesData.items"
-                :is-selected-row="(row) => row.name === route.params.proxy"
-                @resize="me.set"
-              >
-                <template #namespace="{ row }">
-                  {{ row.namespace }}
-                </template>
+              <template #namespace="{ row }">
+                {{ row.namespace }}
+              </template>
 
-                <template #name="{ row }">
-                  <XAction
-                    data-action
-                    class="name-link"
-                    :title="row.name"
-                    :to="{
-                      name: 'builtin-gateway-data-plane-summary-view',
-                      params: {
-                        mesh: row.mesh,
-                        proxy: row.id,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    }"
-                  >
-                    {{ row.name }}
-                  </XAction>
-                </template>
-
-                <template #zone="{ row }">
-                  <XAction
-                    v-if="row.zone"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.zone,
-                      },
-                    }"
-                  >
-                    {{ row.zone }}
-                  </XAction>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #certificate="{ row }">
-                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                  </template>
-
-                  <template v-else>
-                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                  </template>
-                </template>
-
-                <template #status="{ row }">
-                  <StatusBadge :status="row.status" />
-                </template>
-
-                <template #warnings="{ row: item }">
-                  <template
-                    v-for="warnings in [[
-                      {
-                        bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                        key: 'dp-cp-incompatible',
-                      },
-                      {
-                        bool: item.isCertExpiresSoon,
-                        key: 'certificate-expires-soon',
-                      },
-                      {
-                        bool: item.isCertExpired,
-                        key: 'certificate-expired',
-                      },
-                    ].filter(({ bool }) => bool)]"
-                    :key="typeof warnings"
-                  >
-                    <XIcon
-                      v-if="warnings.length > 0"
-                      name="warning"
-                      data-testid="warning"
-                    >
-                      <ul>
-                        <li
-                          v-for="{ key } in warnings"
-                          :key="key"
-                          :data-testid="`warning-${key}`"
-                        >
-                          {{ t(`data-planes.routes.items.warnings.${key}`) }}
-                        </li>
-                      </ul>
-                    </XIcon>
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          proxy: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-              <RouterView
-                v-if="route.params.proxy"
-                v-slot="child"
-              >
-                <XDrawer
-                  @close="route.replace({
-                    name: route.name,
+              <template #name="{ row }">
+                <XAction
+                  data-action
+                  class="name-link"
+                  :title="row.name"
+                  :to="{
+                    name: 'builtin-gateway-data-plane-summary-view',
                     params: {
-                      mesh: route.params.mesh,
+                      mesh: row.mesh,
+                      proxy: row.id,
                     },
                     query: {
                       page: route.params.page,
                       size: route.params.size,
                       s: route.params.s,
                     },
-                  })"
+                  }"
                 >
-                  <component
-                    :is="child.Component"
-                    v-if="typeof dataplanesData !== 'undefined'"
-                    :items="dataplanesData.items"
-                  />
-                </XDrawer>
-              </RouterView>
-            </DataCollection>
-          </DataLoader>
-        </XCard>
-      </div>
+                  {{ row.name }}
+                </XAction>
+              </template>
+
+              <template #zone="{ row }">
+                <XAction
+                  v-if="row.zone"
+                  :to="{
+                    name: 'zone-cp-detail-view',
+                    params: {
+                      zone: row.zone,
+                    },
+                  }"
+                >
+                  {{ row.zone }}
+                </XAction>
+
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
+              </template>
+
+              <template #certificate="{ row }">
+                <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                  {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                </template>
+
+                <template v-else>
+                  {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                </template>
+              </template>
+
+              <template #status="{ row }">
+                <StatusBadge :status="row.status" />
+              </template>
+
+              <template #warnings="{ row: item }">
+                <template
+                  v-for="warnings in [[
+                    {
+                      bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                      key: 'dp-cp-incompatible',
+                    },
+                    {
+                      bool: item.isCertExpiresSoon,
+                      key: 'certificate-expires-soon',
+                    },
+                    {
+                      bool: item.isCertExpired,
+                      key: 'certificate-expired',
+                    },
+                  ].filter(({ bool }) => bool)]"
+                  :key="typeof warnings"
+                >
+                  <XIcon
+                    v-if="warnings.length > 0"
+                    name="warning"
+                    data-testid="warning"
+                  >
+                    <ul>
+                      <li
+                        v-for="{ key } in warnings"
+                        :key="key"
+                        :data-testid="`warning-${key}`"
+                      >
+                        {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                      </li>
+                    </ul>
+                  </XIcon>
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+              </template>
+
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        proxy: item.id,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
+              </template>
+            </AppCollection>
+            <RouterView
+              v-if="route.params.proxy"
+              v-slot="child"
+            >
+              <XDrawer
+                @close="route.replace({
+                  name: route.name,
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                  query: {
+                    page: route.params.page,
+                    size: route.params.size,
+                    s: route.params.s,
+                  },
+                })"
+              >
+                <component
+                  :is="child.Component"
+                  v-if="typeof dataplanesData !== 'undefined'"
+                  :items="dataplanesData.items"
+                />
+              </XDrawer>
+            </RouterView>
+          </DataCollection>
+        </DataLoader>
+      </XCard>
     </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
@@ -10,50 +10,48 @@
       :render="false"
       :title="t(`${route.child()?.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)"
     />
-    <div class="stack">
-      <AppView>
-        <template #actions>
-          <DataCollection
-            :items="route.children"
-            :empty="false"
-            v-slot="{ items }"
-          >
-            <XActionGroup
-              :expanded="true"
-            >
-              <XAction
-                v-for="{ name } in items"
-                :key="`${name}`"
-                :class="{
-                  'active': route.child()?.name === name,
-                }"
-                :to="{
-                  name: name,
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                }"
-                :data-testid="`${name}-sub-tab`"
-              >
-                {{ t(`gateways.routes.items.navigation.${name}.label`) }}
-              </XAction>
-            </XActionGroup>
-          </DataCollection>
-        </template>
-
-        <XI18n
-          :path="`gateways.routes.items.navigation.${route.child()?.name}.description`"
-          default-path="common.i18n.ignore-error"
-        />
-
-        <RouterView
-          v-slot="{ Component}"
+    <AppView>
+      <template #actions>
+        <DataCollection
+          :items="route.children"
+          :empty="false"
+          v-slot="{ items }"
         >
-          <component
-            :is="Component"
-          />
-        </RouterView>
-      </AppView>
-    </div>
+          <XActionGroup
+            :expanded="true"
+          >
+            <XAction
+              v-for="{ name } in items"
+              :key="`${name}`"
+              :class="{
+                'active': route.child()?.name === name,
+              }"
+              :to="{
+                name: name,
+                params: {
+                  mesh: route.params.mesh,
+                },
+              }"
+              :data-testid="`${name}-sub-tab`"
+            >
+              {{ t(`gateways.routes.items.navigation.${name}.label`) }}
+            </XAction>
+          </XActionGroup>
+        </DataCollection>
+      </template>
+
+      <XI18n
+        :path="`gateways.routes.items.navigation.${route.child()?.name}.description`"
+        default-path="common.i18n.ignore-error"
+      />
+
+      <RouterView
+        v-slot="{ Component}"
+      >
+        <component
+          :is="Component"
+        />
+      </RouterView>
+    </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -73,8 +73,9 @@
             </td>
           </tr>
         </XTable>
-        <div
+        <XLayout
           v-if="props.data"
+          variant="y-stack"
         >
           <h3>Rules</h3>
           <DataSource
@@ -103,106 +104,104 @@
                     :items="[...rulesData!.rules, ...rulesData!.inboundRules]"
                     v-slot="{ items }"
                   >
-                    <div class="mt-4">
-                      <AccordionList
-                        :initially-open="0"
-                        multiple-open
-                        class="stack"
+                    <AccordionList
+                      :initially-open="0"
+                      multiple-open
+                      class="stack"
+                    >
+                      <template
+                        v-for="(rules, key) in Object.groupBy(items, item => item.type)"
+                        :key="key"
                       >
-                        <template
-                          v-for="(rules, key) in Object.groupBy(items, item => item.type)"
-                          :key="key"
+                        <AccordionItem
+                          :card="true"
                         >
-                          <AccordionItem
-                            :card="true"
-                          >
-                            <template #accordion-header>
-                              <span
-                                v-icon-start="{name: key, size: '60', default: 'policy'}"
+                          <template #accordion-header>
+                            <span
+                              v-icon-start="{name: key, size: '60', default: 'policy'}"
+                            >
+                              {{ key }} ({{ rules!.length }})
+                            </span>
+                          </template>
+                          <template #accordion-content>
+                            <XTable
+                              variant="kv"
+                            >
+                              <template
+                                v-for="item in rules"
+                                :key="item"
                               >
-                                {{ key }} ({{ rules!.length }})
-                              </span>
-                            </template>
-                            <template #accordion-content>
-                              <XTable
-                                variant="kv"
-                              >
-                                <template
-                                  v-for="item in rules"
-                                  :key="item"
+                                <tr
+                                  v-if="item.matchers.length > 0"
                                 >
-                                  <tr
-                                    v-if="item.matchers.length > 0"
-                                  >
-                                    <th scope="row">
-                                      From
-                                    </th>
-                                    <td>
-                                      <p><RuleMatchers :items="item.matchers" /></p>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    v-if="item.origins.length > 0"
-                                  >
-                                    <th scope="row">
-                                      Origin policies
-                                    </th>
-                                    <td>
-                                      <ul>
-                                        <li
-                                          v-for="origin in item.origins"
-                                          :key="`${origin.mesh}-${origin.name}`"
-                                        >
-                                          <XAction
-                                            v-if="policyTypes[origin.type]"
-                                            :to="{
-                                              name: 'policy-detail-view',
-                                              params: {
-                                                mesh: origin.mesh,
-                                                policyPath: policyTypes[origin.type]![0].path,
-                                                policy: origin.name,
-                                              },
-                                            }"
-                                          >
-                                            {{ origin.name }}
-                                          </XAction>
-                                          <template
-                                            v-else
-                                          >
-                                            {{ origin.name }}
-                                          </template>
-                                        </li>
-                                      </ul>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td colspan="2">
-                                      <XLayout
-                                        variant="y-stack"
-                                        size="small"
+                                  <th scope="row">
+                                    From
+                                  </th>
+                                  <td>
+                                    <p><RuleMatchers :items="item.matchers" /></p>
+                                  </td>
+                                </tr>
+                                <tr
+                                  v-if="item.origins.length > 0"
+                                >
+                                  <th scope="row">
+                                    Origin policies
+                                  </th>
+                                  <td>
+                                    <ul>
+                                      <li
+                                        v-for="origin in item.origins"
+                                        :key="`${origin.mesh}-${origin.name}`"
                                       >
-                                        <span>Config</span>
-                                        <XCodeBlock
-                                          :code="YAML.stringify(item.raw)"
-                                          language="yaml"
-                                          :show-copy-button="false"
-                                        />
-                                      </XLayout>
-                                    </td>
-                                  </tr>
-                                </template>
-                              </XTable>
-                            </template>
-                          </AccordionItem>
-                        </template>
-                      </AccordionList>
-                    </div>
+                                        <XAction
+                                          v-if="policyTypes[origin.type]"
+                                          :to="{
+                                            name: 'policy-detail-view',
+                                            params: {
+                                              mesh: origin.mesh,
+                                              policyPath: policyTypes[origin.type]![0].path,
+                                              policy: origin.name,
+                                            },
+                                          }"
+                                        >
+                                          {{ origin.name }}
+                                        </XAction>
+                                        <template
+                                          v-else
+                                        >
+                                          {{ origin.name }}
+                                        </template>
+                                      </li>
+                                    </ul>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td colspan="2">
+                                    <XLayout
+                                      variant="y-stack"
+                                      size="small"
+                                    >
+                                      <span>Config</span>
+                                      <XCodeBlock
+                                        :code="YAML.stringify(item.raw)"
+                                        language="yaml"
+                                        :show-copy-button="false"
+                                      />
+                                    </XLayout>
+                                  </td>
+                                </tr>
+                              </template>
+                            </XTable>
+                          </template>
+                        </AccordionItem>
+                      </template>
+                    </AccordionList>
                   </DataCollection>
                 </template>
               </DataLoader>
             </DataSource>
           </DataSource>
-        </div>
+        </XLayout>
       </XLayout>
     </AppView>
   </RouteView>

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -32,8 +32,9 @@
               </td>
             </tr>
           </XTable>
-          <div
+          <XLayout
             v-if="props.data"
+            variant="y-stack"
           >
             <h3>Rules</h3>
 
@@ -63,7 +64,7 @@
                       v-slot="{ items }"
                     >
                       <div
-                        class="stack-with-borders mt-4"
+                        class="stack-with-borders"
                       >
                         <template
                           v-for="(rules, key) in Object.groupBy(items, item => item.type)"
@@ -256,7 +257,7 @@
                 </DataLoader>
               </template>
             </DataSource>
-          </div>
+          </XLayout>
         </XLayout>
       </template>
     </AppView>

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -22,242 +22,240 @@
       </template>
       <template #item="{ item: type }">
         <AppView>
-          <div class="stack">
-            <XCard>
-              <header>
-                <div>
-                  <XBadge
-                    v-if="type.policy.hasFromTargetRef"
-                    appearance="neutral"
-                  >
-                    {{ t('policies.collection.inbound') }}
-                  </XBadge>
-
-                  <XBadge
-                    v-if="type.policy.hasToTargetRef"
-                    appearance="neutral"
-                  >
-                    {{ t('policies.collection.outbound') }}
-                  </XBadge>
-
-                  <XAction
-                    action="docs"
-                    :href="t('policies.href.docs', { name: type.name })"
-                    data-testid="policy-documentation-link"
-                  >
-                    <span class="visually-hidden">{{ t('common.documentation') }}</span>
-                  </XAction>
-                </div>
-                <h3
-                  v-icon-start="{name: type.name, size: '60', default: 'policy'}"
+          <XCard>
+            <header>
+              <div>
+                <XBadge
+                  v-if="type.policy.hasFromTargetRef"
+                  appearance="neutral"
                 >
-                  {{ t('policies.collection.title', { name: type.name }) }}
-                </h3>
-              </header>
-              <XI18n
-                :path="`policies.type.${type.name}.description`"
-                default-path="policies.collection.description"
-              />
-            </XCard>
+                  {{ t('policies.collection.inbound') }}
+                </XBadge>
 
-            <XCard>
-              <search>
-                <form
-                  @submit.prevent
+                <XBadge
+                  v-if="type.policy.hasToTargetRef"
+                  appearance="neutral"
                 >
-                  <XSearch
-                    class="search-field"
-                    :keys="['name', 'namespace', ...(can('use zones') && type.policy.isTargetRef ? ['zone'] : []), 'label']"
-                    :value="route.params.s"
-                    @change="(s) => route.update({ s })"
-                  />
-                </form>
-              </search>
-              <DataLoader
-                :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
-                  mesh: route.params.mesh,
-                  path: route.params.policyPath,
-                }, {
-                  page: route.params.page,
-                  size: route.params.size,
-                  search: route.params.s,
-                })"
-                variant="list"
-                v-slot="{ data: [data], refresh }"
+                  {{ t('policies.collection.outbound') }}
+                </XBadge>
+
+                <XAction
+                  action="docs"
+                  :href="t('policies.href.docs', { name: type.name })"
+                  data-testid="policy-documentation-link"
+                >
+                  <span class="visually-hidden">{{ t('common.documentation') }}</span>
+                </XAction>
+              </div>
+              <h3
+                v-icon-start="{name: type.name, size: '60', default: 'policy'}"
               >
-                <DataCollection
-                  :items="data.items"
-                  :page="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data.total"
-                  @change="route.update"
-                >
-                  <template
-                    #empty
-                  >
-                    <DataEmptyState
-                      type="policies"
-                    >
-                      <template #title>
-                        <h3>
-                          {{ t('policies.x-empty-state.title') }}
-                        </h3>
-                      </template>
-                      <XI18n
-                        path="policies.x-empty-state.body"
-                        :params="{
-                          type: type.name,
-                          suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '',
-                        }"
-                      />
-                      <template
-                        #action
-                      >
-                        <XAction
-                          action="docs"
-                          :href="t('policies.href.docs', { name: type.name })"
-                        >
-                          {{ t('common.documentation') }}
-                        </XAction>
-                      </template>
-                    </DataEmptyState>
-                  </template>
-                  <template
-                    #default
-                  >
-                    <AppCollection
-                      :headers="[
-                        { ...me.get('headers.role'), label: 'Role', key: 'role', hideLabel: true },
-                        { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                        { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                        ...(can('use zones') && type.policy.isTargetRef ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                        ...(type.policy.isTargetRef ? [{ ...me.get('headers.targetRef'), label: 'Target ref', key: 'targetRef' }] : []),
-                        { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                      ]"
-                      :items="data.items"
-                      :is-selected-row="(row) => row.id === route.params.policy"
-                      @resize="me.set"
-                    >
-                      <template
-                        #role="{ row: item }"
-                      >
-                        <template
-                          v-if="['producer', 'consumer', 'system', 'workload-owner'].includes(item.role)"
-                        >
-                          <XIcon
-                            :name="`policy-role-${item.role}`"
-                          >
-                            Role: {{ item.role }}
-                          </XIcon>
-                        </template>
-                        <template
-                          v-else
-                        >
-                            &nbsp;
-                        </template>
-                      </template>
+                {{ t('policies.collection.title', { name: type.name }) }}
+              </h3>
+            </header>
+            <XI18n
+              :path="`policies.type.${type.name}.description`"
+              default-path="policies.collection.description"
+            />
+          </XCard>
 
-                      <template #name="{ row }">
+          <XCard>
+            <search>
+              <form
+                @submit.prevent
+              >
+                <XSearch
+                  class="search-field"
+                  :keys="['name', 'namespace', ...(can('use zones') && type.policy.isTargetRef ? ['zone'] : []), 'label']"
+                  :value="route.params.s"
+                  @change="(s) => route.update({ s })"
+                />
+              </form>
+            </search>
+            <DataLoader
+              :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
+                mesh: route.params.mesh,
+                path: route.params.policyPath,
+              }, {
+                page: route.params.page,
+                size: route.params.size,
+                search: route.params.s,
+              })"
+              variant="list"
+              v-slot="{ data: [data], refresh }"
+            >
+              <DataCollection
+                :items="data.items"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data.total"
+                @change="route.update"
+              >
+                <template
+                  #empty
+                >
+                  <DataEmptyState
+                    type="policies"
+                  >
+                    <template #title>
+                      <h3>
+                        {{ t('policies.x-empty-state.title') }}
+                      </h3>
+                    </template>
+                    <XI18n
+                      path="policies.x-empty-state.body"
+                      :params="{
+                        type: type.name,
+                        suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '',
+                      }"
+                    />
+                    <template
+                      #action
+                    >
+                      <XAction
+                        action="docs"
+                        :href="t('policies.href.docs', { name: type.name })"
+                      >
+                        {{ t('common.documentation') }}
+                      </XAction>
+                    </template>
+                  </DataEmptyState>
+                </template>
+                <template
+                  #default
+                >
+                  <AppCollection
+                    :headers="[
+                      { ...me.get('headers.role'), label: 'Role', key: 'role', hideLabel: true },
+                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                      ...(can('use zones') && type.policy.isTargetRef ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                      ...(type.policy.isTargetRef ? [{ ...me.get('headers.targetRef'), label: 'Target ref', key: 'targetRef' }] : []),
+                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                    ]"
+                    :items="data.items"
+                    :is-selected-row="(row) => row.id === route.params.policy"
+                    @resize="me.set"
+                  >
+                    <template
+                      #role="{ row: item }"
+                    >
+                      <template
+                        v-if="['producer', 'consumer', 'system', 'workload-owner'].includes(item.role)"
+                      >
+                        <XIcon
+                          :name="`policy-role-${item.role}`"
+                        >
+                          Role: {{ item.role }}
+                        </XIcon>
+                      </template>
+                      <template
+                        v-else
+                      >
+                          &nbsp;
+                      </template>
+                    </template>
+
+                    <template #name="{ row }">
+                      <XAction
+                        data-action
+                        :to="{
+                          name: 'policy-summary-view',
+                          params: {
+                            mesh: row.mesh,
+                            policyPath: type.path,
+                            policy: row.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                            s: route.params.s,
+                          },
+                        }"
+                      >
+                        {{ row.name }}
+                      </XAction>
+                    </template>
+                    <template #namespace="{ row: item }">
+                      {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
+                    </template>
+
+                    <template #targetRef="{ row: item }">
+                      <KumaTargetRef
+                        :target-ref="item.spec?.targetRef"
+                      />
+                    </template>
+
+                    <template #zone="{ row }">
+                      <template v-if="row.zone">
                         <XAction
-                          data-action
                           :to="{
-                            name: 'policy-summary-view',
+                            name: 'zone-cp-detail-view',
                             params: {
-                              mesh: row.mesh,
-                              policyPath: type.path,
-                              policy: row.id,
-                            },
-                            query: {
-                              page: route.params.page,
-                              size: route.params.size,
-                              s: route.params.s,
+                              zone: row.zone,
                             },
                           }"
                         >
-                          {{ row.name }}
+                          {{ row.zone }}
                         </XAction>
                       </template>
-                      <template #namespace="{ row: item }">
-                        {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
+
+                      <template v-else>
+                        {{ t('common.detail.none') }}
                       </template>
+                    </template>
 
-                      <template #targetRef="{ row: item }">
-                        <KumaTargetRef
-                          :target-ref="item.spec?.targetRef"
-                        />
-                      </template>
-
-                      <template #zone="{ row }">
-                        <template v-if="row.zone">
-                          <XAction
-                            :to="{
-                              name: 'zone-cp-detail-view',
-                              params: {
-                                zone: row.zone,
-                              },
-                            }"
-                          >
-                            {{ row.zone }}
-                          </XAction>
-                        </template>
-
-                        <template v-else>
-                          {{ t('common.detail.none') }}
-                        </template>
-                      </template>
-
-                      <template #actions="{ row: item }">
-                        <PolicyActionGroup
-                          :item="item"
-                          :type="type"
-                          @change="refresh"
+                    <template #actions="{ row: item }">
+                      <PolicyActionGroup
+                        :item="item"
+                        :type="type"
+                        @change="refresh"
+                      >
+                        <XAction
+                          :to="{
+                            name: 'policy-detail-view',
+                            params: {
+                              mesh: item.mesh,
+                              policyPath: type.path,
+                              policy: item.id,
+                            },
+                          }"
                         >
-                          <XAction
-                            :to="{
-                              name: 'policy-detail-view',
-                              params: {
-                                mesh: item.mesh,
-                                policyPath: type.path,
-                                policy: item.id,
-                              },
-                            }"
-                          >
-                            {{ t('common.collection.actions.view') }}
-                          </XAction>
-                        </PolicyActionGroup>
-                      </template>
-                    </AppCollection>
-                  </template>
-                </DataCollection>
-                <RouterView
-                  v-if="route.params.policy"
-                  v-slot="{ Component }"
+                          {{ t('common.collection.actions.view') }}
+                        </XAction>
+                      </PolicyActionGroup>
+                    </template>
+                  </AppCollection>
+                </template>
+              </DataCollection>
+              <RouterView
+                v-if="route.params.policy"
+                v-slot="{ Component }"
+              >
+                <XDrawer
+                  @close="route.replace({
+                    name: 'policy-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                      policyPath: route.params.policyPath,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                      s: route.params.s,
+                    },
+                  })"
                 >
-                  <XDrawer
-                    @close="route.replace({
-                      name: 'policy-list-view',
-                      params: {
-                        mesh: route.params.mesh,
-                        policyPath: route.params.policyPath,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    })"
-                  >
-                    <component
-                      :is="Component"
-                      v-if="typeof data !== 'undefined'"
-                      :items="data.items"
-                      :policy-type="type"
-                    />
-                  </XDrawer>
-                </RouterView>
-              </DataLoader>
-            </XCard>
-          </div>
+                  <component
+                    :is="Component"
+                    v-if="typeof data !== 'undefined'"
+                    :items="data.items"
+                    :policy-type="type"
+                  />
+                </XDrawer>
+              </RouterView>
+            </DataLoader>
+          </XCard>
         </AppView>
       </template>
     </DataCollection>

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -15,261 +15,257 @@
     v-slot="{ can, route, t, me, uri }"
   >
     <AppView>
-      <div
-        class="stack"
+      <DataLoader
+        :src="uri(sources, `/meshes/:mesh/service-insights/:name`, {
+          mesh: route.params.mesh,
+          name: route.params.service,
+        })"
+        v-slot="{ data: [data] }"
       >
+        <XAboutCard
+          :title="t('services.internal-service.about.title')"
+          :created="data.creationTime"
+          :modified="data.modificationTime"
+        >
+          <XDl variant="x-stack">
+            <div>
+              <dt>
+                {{ t('http.api.property.status') }}
+              </dt>
+              <dd>
+                <StatusBadge :status="data.status" />
+              </dd>
+            </div>
+            <div>
+              <dt>
+                {{ t('http.api.property.address') }}
+              </dt>
+              <dd>
+                <template v-if="data.addressPort">
+                  <XCopyButton
+                    variant="badge"
+                    format="default"
+                    :text="data.addressPort"
+                  />
+                </template>
+
+                <template v-else>
+                  {{ t('common.detail.none') }}
+                </template>
+              </dd>
+            </div>
+            <div>
+              <dt>
+                {{ t('http.api.property.dataPlaneProxies') }}
+              </dt>
+              <dd
+                v-for="[online, total] in [[data.dataplanes?.online ?? 0, data.dataplanes?.total ?? 0]]"
+                :key="typeof online"
+              >
+                <XBadge
+                  :appearance="online === 0 ? 'danger' : online !== total ? 'warning' : 'success'"
+                >
+                  {{ online ?? 0 }}/{{ total ?? 0 }}
+                </XBadge>
+              </dd>
+            </div>
+          </XDl>
+        </XAboutCard>
+      </DataLoader>
+
+      <XCard>
+        <template #title>
+          <h3>{{ t('services.detail.data_plane_proxies') }}</h3>
+        </template>
+
+        <search>
+          <form
+            class="search-form"
+            @submit.prevent
+          >
+            <XSearch
+              class="search-field"
+              :keys="['name', 'tag', ...(can('use zones') ? ['zone'] : []), 'namespace', 'label']"
+              :value="route.params.s"
+              @change="(s) => route.update({ page: 1, s })"
+            />
+          </form>
+        </search>
         <DataLoader
-          :src="uri(sources, `/meshes/:mesh/service-insights/:name`, {
+          :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
             mesh: route.params.mesh,
-            name: route.params.service,
+            service: route.params.service,
+          }, {
+            page: route.params.page,
+            size: route.params.size,
+            search: route.params.s,
           })"
+          variant="list"
           v-slot="{ data: [data] }"
         >
-          <XAboutCard
-            :title="t('services.internal-service.about.title')"
-            :created="data.creationTime"
-            :modified="data.modificationTime"
+          <DataCollection
+            type="data-planes"
+            :items="data.items"
+            :page="route.params.page"
+            :page-size="route.params.size"
+            :total="data.total"
+            @change="route.update"
           >
-            <XDl variant="x-stack">
-              <div>
-                <dt>
-                  {{ t('http.api.property.status') }}
-                </dt>
-                <dd>
-                  <StatusBadge :status="data.status" />
-                </dd>
-              </div>
-              <div>
-                <dt>
-                  {{ t('http.api.property.address') }}
-                </dt>
-                <dd>
-                  <template v-if="data.addressPort">
-                    <XCopyButton
-                      variant="badge"
-                      format="default"
-                      :text="data.addressPort"
-                    />
-                  </template>
-
-                  <template v-else>
-                    {{ t('common.detail.none') }}
-                  </template>
-                </dd>
-              </div>
-              <div>
-                <dt>
-                  {{ t('http.api.property.dataPlaneProxies') }}
-                </dt>
-                <dd
-                  v-for="[online, total] in [[data.dataplanes?.online ?? 0, data.dataplanes?.total ?? 0]]"
-                  :key="typeof online"
-                >
-                  <XBadge
-                    :appearance="online === 0 ? 'danger' : online !== total ? 'warning' : 'success'"
-                  >
-                    {{ online ?? 0 }}/{{ total ?? 0 }}
-                  </XBadge>
-                </dd>
-              </div>
-            </XDl>
-          </XAboutCard>
-        </DataLoader>
-
-        <XCard>
-          <template #title>
-            <h3>{{ t('services.detail.data_plane_proxies') }}</h3>
-          </template>
-
-          <search>
-            <form
-              class="search-form"
-              @submit.prevent
-            >
-              <XSearch
-                class="search-field"
-                :keys="['name', 'tag', ...(can('use zones') ? ['zone'] : []), 'namespace', 'label']"
-                :value="route.params.s"
-                @change="(s) => route.update({ page: 1, s })"
-              />
-            </form>
-          </search>
-          <DataLoader
-            :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
-              mesh: route.params.mesh,
-              service: route.params.service,
-            }, {
-              page: route.params.page,
-              size: route.params.size,
-              search: route.params.s,
-            })"
-            variant="list"
-            v-slot="{ data: [data] }"
-          >
-            <DataCollection
-              type="data-planes"
+            <AppCollection
+              class="data-plane-collection"
+              data-testid="data-plane-collection"
+              :headers="[
+                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
+                { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
               :items="data.items"
-              :page="route.params.page"
-              :page-size="route.params.size"
-              :total="data.total"
-              @change="route.update"
+              :is-selected-row="(row) => row.name === route.params.proxy"
+              @resize="me.set"
             >
-              <AppCollection
-                class="data-plane-collection"
-                data-testid="data-plane-collection"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                  { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
-                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="data.items"
-                :is-selected-row="(row) => row.name === route.params.proxy"
-                @resize="me.set"
-              >
-                <template #name="{ row: item }">
-                  <XAction
-                    data-action
-                    class="name-link"
-                    :to="{
-                      name: 'service-data-plane-summary-view',
-                      params: {
-                        mesh: item.mesh,
-                        proxy: item.id,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </XAction>
-                </template>
-
-                <template #namespace="{ row: item }">
-                  {{ item.namespace }}
-                </template>
-
-                <template #zone="{ row }">
-                  <XAction
-                    v-if="row.zone"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.zone,
-                      },
-                    }"
-                  >
-                    {{ row.zone }}
-                  </XAction>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #certificate="{ row }">
-                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                  </template>
-
-                  <template v-else>
-                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                  </template>
-                </template>
-
-                <template #status="{ row }">
-                  <StatusBadge :status="row.status" />
-                </template>
-
-                <template #warnings="{ row: item }">
-                  <template
-                    v-for="warnings in [[
-                      {
-                        bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                        key: 'dp-cp-incompatible',
-                      },
-                      {
-                        bool: item.isCertExpiresSoon,
-                        key: 'certificate-expires-soon',
-                      },
-                      {
-                        bool: item.isCertExpired,
-                        key: 'certificate-expired',
-                      },
-                    ].filter(({ bool }) => bool)]"
-                    :key="typeof warnings"
-                  >
-                    <XIcon
-                      v-if="warnings.length > 0"
-                      name="warning"
-                      data-testid="warning"
-                    >
-                      <ul>
-                        <li
-                          v-for="{ key } in warnings"
-                          :key="key"
-                          :data-testid="`warning-${key}`"
-                        >
-                          {{ t(`data-planes.routes.items.warnings.${key}`) }}
-                        </li>
-                      </ul>
-                    </XIcon>
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          proxy: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-
-              <RouterView
-                v-slot="{ Component }"
-              >
-                <XDrawer
-                  v-if="route.child()"
-                  @close="route.replace({
-                    name: route.name,
+              <template #name="{ row: item }">
+                <XAction
+                  data-action
+                  class="name-link"
+                  :to="{
+                    name: 'service-data-plane-summary-view',
                     params: {
-                      mesh: route.params.mesh,
+                      mesh: item.mesh,
+                      proxy: item.id,
                     },
                     query: {
                       page: route.params.page,
                       size: route.params.size,
                       s: route.params.s,
                     },
-                  })"
+                  }"
                 >
-                  <component
-                    :is="Component"
-                    v-if="typeof data !== 'undefined'"
-                    :items="data.items"
-                  />
-                </XDrawer>
-              </RouterView>
-            </DataCollection>
-          </DataLoader>
-        </XCard>
-      </div>
+                  {{ item.name }}
+                </XAction>
+              </template>
+
+              <template #namespace="{ row: item }">
+                {{ item.namespace }}
+              </template>
+
+              <template #zone="{ row }">
+                <XAction
+                  v-if="row.zone"
+                  :to="{
+                    name: 'zone-cp-detail-view',
+                    params: {
+                      zone: row.zone,
+                    },
+                  }"
+                >
+                  {{ row.zone }}
+                </XAction>
+
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
+              </template>
+
+              <template #certificate="{ row }">
+                <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                  {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                </template>
+
+                <template v-else>
+                  {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                </template>
+              </template>
+
+              <template #status="{ row }">
+                <StatusBadge :status="row.status" />
+              </template>
+
+              <template #warnings="{ row: item }">
+                <template
+                  v-for="warnings in [[
+                    {
+                      bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                      key: 'dp-cp-incompatible',
+                    },
+                    {
+                      bool: item.isCertExpiresSoon,
+                      key: 'certificate-expires-soon',
+                    },
+                    {
+                      bool: item.isCertExpired,
+                      key: 'certificate-expired',
+                    },
+                  ].filter(({ bool }) => bool)]"
+                  :key="typeof warnings"
+                >
+                  <XIcon
+                    v-if="warnings.length > 0"
+                    name="warning"
+                    data-testid="warning"
+                  >
+                    <ul>
+                      <li
+                        v-for="{ key } in warnings"
+                        :key="key"
+                        :data-testid="`warning-${key}`"
+                      >
+                        {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                      </li>
+                    </ul>
+                  </XIcon>
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+              </template>
+
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        proxy: item.id,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
+              </template>
+            </AppCollection>
+
+            <RouterView
+              v-slot="{ Component }"
+            >
+              <XDrawer
+                v-if="route.child()"
+                @close="route.replace({
+                  name: route.name,
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                  query: {
+                    page: route.params.page,
+                    size: route.params.size,
+                    s: route.params.s,
+                  },
+                })"
+              >
+                <component
+                  :is="Component"
+                  v-if="typeof data !== 'undefined'"
+                  :items="data.items"
+                />
+              </XDrawer>
+            </RouterView>
+          </DataCollection>
+        </DataLoader>
+      </XCard>
     </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
@@ -6,52 +6,48 @@
     }"
     v-slot="{ route, t }"
   >
-    <div
-      class="stack"
-    >
-      <AppView>
-        <template #actions>
-          <XActionGroup
-            :expanded="true"
-          >
-            <template
-              v-for="{ name } in route.children"
-              :key="name"
-            >
-              <XAction
-                v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
-                :class="{
-                  'active': route.child()?.name === name,
-                }"
-                :to="{
-                  name,
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                }"
-                :data-testid="`${name}-sub-tab`"
-              >
-                {{ t(`services.routes.items.navigation.${name}.label`) }}
-              </XAction>
-            </template>
-          </XActionGroup>
-        </template>
-
-        <XI18n
-          :path="`services.routes.items.navigation.${route.child()?.name}.description`"
-          default-path="common.i18n.ignore-error"
-        />
-
-        <RouterView
-          v-slot="{ Component }"
+    <AppView>
+      <template #actions>
+        <XActionGroup
+          :expanded="true"
         >
-          <component
-            :is="Component"
-            :mesh="props.mesh"
-          />
-        </RouterView>
-      </AppView>
-    </div>
+          <template
+            v-for="{ name } in route.children"
+            :key="name"
+          >
+            <XAction
+              v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
+              :class="{
+                'active': route.child()?.name === name,
+              }"
+              :to="{
+                name,
+                params: {
+                  mesh: route.params.mesh,
+                },
+              }"
+              :data-testid="`${name}-sub-tab`"
+            >
+              {{ t(`services.routes.items.navigation.${name}.label`) }}
+            </XAction>
+          </template>
+        </XActionGroup>
+      </template>
+
+      <XI18n
+        :path="`services.routes.items.navigation.${route.child()?.name}.description`"
+        default-path="common.i18n.ignore-error"
+      />
+
+      <RouterView
+        v-slot="{ Component }"
+      >
+        <component
+          :is="Component"
+          :mesh="props.mesh"
+        />
+      </RouterView>
+    </AppView>
   </RouteView>
 </template>
 <script lang="ts" setup>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -101,59 +101,55 @@
                 </XLayout>
               </header>
               <template v-if="route.params.format === 'structured'">
-                <div
-                  class="stack-with-borders"
+                <XTable
                   data-testid="structured-view"
+                  variant="kv"
                 >
-                  <XTable
-                    variant="kv"
+                  <tr
+                    v-if="item.namespace.length > 0"
                   >
-                    <tr
-                      v-if="item.namespace.length > 0"
-                    >
-                      <th scope="row">
-                        {{ t('data-planes.routes.item.namespace') }}
-                      </th>
-                      <td>{{ item.namespace }}</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">
-                        {{ t('http.api.property.address') }}
-                      </th>
-                      <td>
-                        <template
-                          v-if="item.zoneIngress.socketAddress.length > 0"
-                        >
-                          <XCopyButton
-                            :text="item.zoneIngress.socketAddress"
-                          />
-                        </template>
+                    <th scope="row">
+                      {{ t('data-planes.routes.item.namespace') }}
+                    </th>
+                    <td>{{ item.namespace }}</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">
+                      {{ t('http.api.property.address') }}
+                    </th>
+                    <td>
+                      <template
+                        v-if="item.zoneIngress.socketAddress.length > 0"
+                      >
+                        <XCopyButton
+                          :text="item.zoneIngress.socketAddress"
+                        />
+                      </template>
 
-                        <template v-else>
-                          {{ t('common.detail.none') }}
-                        </template>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">
-                        {{ t('http.api.property.advertisedAddress') }}
-                      </th>
-                      <td>
-                        <template
-                          v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
-                        >
-                          <XCopyButton
-                            :text="item.zoneIngress.advertisedSocketAddress"
-                          />
-                        </template>
+                      <template v-else>
+                        {{ t('common.detail.none') }}
+                      </template>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">
+                      {{ t('http.api.property.advertisedAddress') }}
+                    </th>
+                    <td>
+                      <template
+                        v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
+                      >
+                        <XCopyButton
+                          :text="item.zoneIngress.advertisedSocketAddress"
+                        />
+                      </template>
 
-                        <template v-else>
-                          {{ t('common.detail.none') }}
-                        </template>
-                      </td>
-                    </tr>
-                  </XTable>
-                </div>
+                      <template v-else>
+                        {{ t('common.detail.none') }}
+                      </template>
+                    </td>
+                  </tr>
+                </XTable>
               </template>
 
               <template v-else-if="route.params.format === 'universal'">


### PR DESCRIPTION
As part of our effort to reduce global CSS I found a bunch of places that use our old `stack` class and didn't need to or I could change to use `XLayout` instead.

Note there are still a few more places but its in code I am not at all familiar with (mainly `ListenerRoutes`), so I've PRed this first with an eye to spedning a little more time doing the same in the places I'm not familiar with a little later.

There are two other places I found which need addressing:

1. It seems like Accordions only use class="stack" when using `:card="true"` so I'm thinking of moving that fact into the Accordion itself, so if its using `:card`, the card wouldn't be spaced correctly automatically. I still have a vague plan to refactor Accordion anyway, so I'm not sure which will happen first.
2. `stack-with-borders` is still a thing, and I'm currently considering/thinking about `<XLayout separator="true" />`. Still very much on the fence about that right now, some other solution might appear 🤔 