### PR TITLE
refactor(x-search): reduce custom layout efforts

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -346,10 +346,6 @@ search {
 
 .search-field {
   flex-basis: 310px;
-  flex-grow: 1;
-}
-
-.search-field {
   flex: 1;
 }
 

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceListView.vue
@@ -21,7 +21,6 @@
           <search>
             <form @submit.prevent>
               <XSearch
-                class="search-field"
                 :keys="['name', 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -118,8 +117,3 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -14,196 +14,196 @@
   >
     <AppView>
       <XCard>
-        <search>
-          <form
-            class="search-form"
-            @submit.prevent
-          >
-            <XSearch
-              class="search-field"
-              :keys="['name', 'tag', 'label', ...(can('use zones') ? ['zone'] : []), 'namespace']"
-              :value="route.params.s"
-              @change="(s) => route.update({ page: 1, s })"
-            />
-          </form>
-        </search>
-        <DataLoader
-          :src="uri(dataplaneSources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
-            mesh: route.params.mesh,
-            service: props.gateway.selectors[0].match['kuma.io/service'],
-          }, {
-            page: route.params.page,
-            size: route.params.size,
-            search: [
-              route.params.s,
-              ...(props.gateway.origin === 'zone' && props.gateway.zone.length ? [ `zone:${props.gateway.zone}` ] : []),
-            ].join(' '),
-          })"
-          variant="list"
-          v-slot="{ data: [dataplanesData] }"
+        <XLayout
+          variant="y-stack"
         >
-          <DataCollection
-            type="data-planes"
-            :items="dataplanesData.items"
-            :total="dataplanesData.total"
-            :page="route.params.page"
-            :page-size="route.params.size"
-            @change="route.update"
+          <search>
+            <form @submit.prevent>
+              <XSearch
+                :keys="['name', 'tag', 'label', ...(can('use zones') ? ['zone'] : []), 'namespace']"
+                :value="route.params.s"
+                @change="(s) => route.update({ page: 1, s })"
+              />
+            </form>
+          </search>
+          <DataLoader
+            :src="uri(dataplaneSources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
+              mesh: route.params.mesh,
+              service: props.gateway.selectors[0].match['kuma.io/service'],
+            }, {
+              page: route.params.page,
+              size: route.params.size,
+              search: [
+                route.params.s,
+                ...(props.gateway.origin === 'zone' && props.gateway.zone.length ? [ `zone:${props.gateway.zone}` ] : []),
+              ].join(' '),
+            })"
+            variant="list"
+            v-slot="{ data: [dataplanesData] }"
           >
-            <AppCollection
-              class="data-plane-collection"
-              data-testid="data-plane-collection"
-              :headers="[
-                { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
-                { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
+            <DataCollection
+              type="data-planes"
               :items="dataplanesData.items"
-              :is-selected-row="(row) => row.name === route.params.proxy"
-              @resize="me.set"
+              :total="dataplanesData.total"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              @change="route.update"
             >
-              <template #namespace="{ row }">
-                {{ row.namespace }}
-              </template>
+              <AppCollection
+                class="data-plane-collection"
+                data-testid="data-plane-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
+                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :items="dataplanesData.items"
+                :is-selected-row="(row) => row.name === route.params.proxy"
+                @resize="me.set"
+              >
+                <template #namespace="{ row }">
+                  {{ row.namespace }}
+                </template>
 
-              <template #name="{ row }">
-                <XAction
-                  data-action
-                  class="name-link"
-                  :title="row.name"
-                  :to="{
-                    name: 'builtin-gateway-data-plane-summary-view',
+                <template #name="{ row }">
+                  <XAction
+                    data-action
+                    class="name-link"
+                    :title="row.name"
+                    :to="{
+                      name: 'builtin-gateway-data-plane-summary-view',
+                      params: {
+                        mesh: row.mesh,
+                        proxy: row.id,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    }"
+                  >
+                    {{ row.name }}
+                  </XAction>
+                </template>
+
+                <template #zone="{ row }">
+                  <XAction
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </XAction>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #certificate="{ row }">
+                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                  </template>
+
+                  <template v-else>
+                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  </template>
+                </template>
+
+                <template #status="{ row }">
+                  <StatusBadge :status="row.status" />
+                </template>
+
+                <template #warnings="{ row: item }">
+                  <template
+                    v-for="warnings in [[
+                      {
+                        bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                        key: 'dp-cp-incompatible',
+                      },
+                      {
+                        bool: item.isCertExpiresSoon,
+                        key: 'certificate-expires-soon',
+                      },
+                      {
+                        bool: item.isCertExpired,
+                        key: 'certificate-expired',
+                      },
+                    ].filter(({ bool }) => bool)]"
+                    :key="typeof warnings"
+                  >
+                    <XIcon
+                      v-if="warnings.length > 0"
+                      name="warning"
+                      data-testid="warning"
+                    >
+                      <ul>
+                        <li
+                          v-for="{ key } in warnings"
+                          :key="key"
+                          :data-testid="`warning-${key}`"
+                        >
+                          {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                        </li>
+                      </ul>
+                    </XIcon>
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'data-plane-detail-view',
+                        params: {
+                          proxy: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="route.params.proxy"
+                v-slot="child"
+              >
+                <XDrawer
+                  @close="route.replace({
+                    name: route.name,
                     params: {
-                      mesh: row.mesh,
-                      proxy: row.id,
+                      mesh: route.params.mesh,
                     },
                     query: {
                       page: route.params.page,
                       size: route.params.size,
                       s: route.params.s,
                     },
-                  }"
+                  })"
                 >
-                  {{ row.name }}
-                </XAction>
-              </template>
-
-              <template #zone="{ row }">
-                <XAction
-                  v-if="row.zone"
-                  :to="{
-                    name: 'zone-cp-detail-view',
-                    params: {
-                      zone: row.zone,
-                    },
-                  }"
-                >
-                  {{ row.zone }}
-                </XAction>
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #certificate="{ row }">
-                <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                  {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                </template>
-
-                <template v-else>
-                  {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                </template>
-              </template>
-
-              <template #status="{ row }">
-                <StatusBadge :status="row.status" />
-              </template>
-
-              <template #warnings="{ row: item }">
-                <template
-                  v-for="warnings in [[
-                    {
-                      bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                      key: 'dp-cp-incompatible',
-                    },
-                    {
-                      bool: item.isCertExpiresSoon,
-                      key: 'certificate-expires-soon',
-                    },
-                    {
-                      bool: item.isCertExpired,
-                      key: 'certificate-expired',
-                    },
-                  ].filter(({ bool }) => bool)]"
-                  :key="typeof warnings"
-                >
-                  <XIcon
-                    v-if="warnings.length > 0"
-                    name="warning"
-                    data-testid="warning"
-                  >
-                    <ul>
-                      <li
-                        v-for="{ key } in warnings"
-                        :key="key"
-                        :data-testid="`warning-${key}`"
-                      >
-                        {{ t(`data-planes.routes.items.warnings.${key}`) }}
-                      </li>
-                    </ul>
-                  </XIcon>
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'data-plane-detail-view',
-                      params: {
-                        proxy: item.id,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-            <RouterView
-              v-if="route.params.proxy"
-              v-slot="child"
-            >
-              <XDrawer
-                @close="route.replace({
-                  name: route.name,
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                  query: {
-                    page: route.params.page,
-                    size: route.params.size,
-                    s: route.params.s,
-                  },
-                })"
-              >
-                <component
-                  :is="child.Component"
-                  v-if="typeof dataplanesData !== 'undefined'"
-                  :items="dataplanesData.items"
-                />
-              </XDrawer>
-            </RouterView>
-          </DataCollection>
-        </DataLoader>
+                  <component
+                    :is="child.Component"
+                    v-if="typeof dataplanesData !== 'undefined'"
+                    :items="dataplanesData.items"
+                  />
+                </XDrawer>
+              </RouterView>
+            </DataCollection>
+          </DataLoader>
+        </XLayout>
       </XCard>
     </AppView>
   </RouteView>
@@ -220,26 +220,6 @@ const props = defineProps<{
 </script>
 
 <style lang="scss" scoped>
-search {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: var(--x-space-70);
-  margin-bottom: var(--x-space-70);
-}
-
-.search-form {
-  display: flex;
-  flex-basis: 350px;
-  flex-grow: 1;
-}
-
-.search-field {
-  flex: 1;
-}
-
 .name-link {
   display: inline-block;
   width: 100%;

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -20,7 +20,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', ...(can('use zones') ? ['zone'] : []), 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -153,8 +152,3 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -75,191 +75,192 @@
           <template #title>
             <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
           </template>
-
-          <search>
-            <form
-              class="search-form"
-              @submit.prevent
-            >
-              <XSearch
-                class="search-field"
-                :keys="['name', 'tag', ...(can('use zones') ? ['zone'] : []), 'namespace', 'label']"
-                :value="route.params.s"
-                @change="(s) => route.update({ page: 1, s })"
-              />
-            </form>
-          </search>
-          <DataLoader
-            :src="uri(sources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
-              mesh: route.params.mesh,
-              service: route.params.service,
-            }, {
-              page: route.params.page,
-              size: route.params.size,
-            })"
-            variant="list"
-            v-slot="{ data: [dataplanesData] }"
+          <XLayout
+            variant="y-stack"
           >
-            <DataCollection
-              type="data-planes"
-              :items="dataplanesData.items"
-              :page="route.params.page"
-              :page-size="route.params.size"
-              :total="dataplanesData.total"
-              @change="route.update"
-            >
-              <AppCollection
-                class="data-plane-collection"
-                data-testid="data-plane-collection"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                  { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
-                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="dataplanesData.items"
-                :is-selected-row="(row) => row.name === route.params.proxy"
-                @resize="me.set"
+            <search>
+              <form
+                @submit.prevent
               >
-                <template #name="{ row: item }">
-                  <XAction
-                    data-action
-                    class="name-link"
-                    :to="{
-                      name: 'delegated-gateway-data-plane-summary-view',
+                <XSearch
+                  :keys="['name', 'tag', ...(can('use zones') ? ['zone'] : []), 'namespace', 'label']"
+                  :value="route.params.s"
+                  @change="(s) => route.update({ page: 1, s })"
+                />
+              </form>
+            </search>
+            <DataLoader
+              :src="uri(sources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
+                mesh: route.params.mesh,
+                service: route.params.service,
+              }, {
+                page: route.params.page,
+                size: route.params.size,
+              })"
+              variant="list"
+              v-slot="{ data: [dataplanesData] }"
+            >
+              <DataCollection
+                type="data-planes"
+                :items="dataplanesData.items"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="dataplanesData.total"
+                @change="route.update"
+              >
+                <AppCollection
+                  class="data-plane-collection"
+                  data-testid="data-plane-collection"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
+                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="dataplanesData.items"
+                  :is-selected-row="(row) => row.name === route.params.proxy"
+                  @resize="me.set"
+                >
+                  <template #name="{ row: item }">
+                    <XAction
+                      data-action
+                      class="name-link"
+                      :to="{
+                        name: 'delegated-gateway-data-plane-summary-view',
+                        params: {
+                          mesh: item.mesh,
+                          proxy: item.id,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                          s: route.params.s,
+                        },
+                      }"
+                    >
+                      {{ item.name }}
+                    </XAction>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
+                  </template>
+
+                  <template #zone="{ row }">
+                    <XAction
+                      v-if="row.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: row.zone,
+                        },
+                      }"
+                    >
+                      {{ row.zone }}
+                    </XAction>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #certificate="{ row }">
+                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                    </template>
+
+                    <template v-else>
+                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                    </template>
+                  </template>
+
+                  <template #status="{ row }">
+                    <StatusBadge :status="row.status" />
+                  </template>
+
+                  <template #warnings="{ row: item }">
+                    <template
+                      v-for="warnings in [[
+                        {
+                          bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                          key: 'dp-cp-incompatible',
+                        },
+                        {
+                          bool: item.isCertExpiresSoon,
+                          key: 'certificate-expires-soon',
+                        },
+                        {
+                          bool: item.isCertExpired,
+                          key: 'certificate-expired',
+                        },
+                      ].filter(({ bool }) => bool)]"
+                      :key="typeof warnings"
+                    >
+                      <XIcon
+                        v-if="warnings.length > 0"
+                        name="warning"
+                        data-testid="warning"
+                      >
+                        <ul>
+                          <li
+                            v-for="{ key } in warnings"
+                            :key="key"
+                            :data-testid="`warning-${key}`"
+                          >
+                            {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                          </li>
+                        </ul>
+                      </XIcon>
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            proxy: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+                <RouterView
+                  v-if="route.params.proxy"
+                  v-slot="child"
+                >
+                  <XDrawer
+                    @close="route.replace({
+                      name: route.name,
                       params: {
-                        mesh: item.mesh,
-                        proxy: item.id,
+                        mesh: route.params.mesh,
                       },
                       query: {
                         page: route.params.page,
                         size: route.params.size,
                         s: route.params.s,
                       },
-                    }"
+                    })"
                   >
-                    {{ item.name }}
-                  </XAction>
-                </template>
-
-                <template #namespace="{ row: item }">
-                  {{ item.namespace }}
-                </template>
-
-                <template #zone="{ row }">
-                  <XAction
-                    v-if="row.zone"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.zone,
-                      },
-                    }"
-                  >
-                    {{ row.zone }}
-                  </XAction>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #certificate="{ row }">
-                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                  </template>
-
-                  <template v-else>
-                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                  </template>
-                </template>
-
-                <template #status="{ row }">
-                  <StatusBadge :status="row.status" />
-                </template>
-
-                <template #warnings="{ row: item }">
-                  <template
-                    v-for="warnings in [[
-                      {
-                        bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                        key: 'dp-cp-incompatible',
-                      },
-                      {
-                        bool: item.isCertExpiresSoon,
-                        key: 'certificate-expires-soon',
-                      },
-                      {
-                        bool: item.isCertExpired,
-                        key: 'certificate-expired',
-                      },
-                    ].filter(({ bool }) => bool)]"
-                    :key="typeof warnings"
-                  >
-                    <XIcon
-                      v-if="warnings.length > 0"
-                      name="warning"
-                      data-testid="warning"
-                    >
-                      <ul>
-                        <li
-                          v-for="{ key } in warnings"
-                          :key="key"
-                          :data-testid="`warning-${key}`"
-                        >
-                          {{ t(`data-planes.routes.items.warnings.${key}`) }}
-                        </li>
-                      </ul>
-                    </XIcon>
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          proxy: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-              <RouterView
-                v-if="route.params.proxy"
-                v-slot="child"
-              >
-                <XDrawer
-                  @close="route.replace({
-                    name: route.name,
-                    params: {
-                      mesh: route.params.mesh,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                      s: route.params.s,
-                    },
-                  })"
-                >
-                  <component
-                    :is="child.Component"
-                    :items="dataplanesData.items"
-                  />
-                </XDrawer>
-              </RouterView>
-            </DataCollection>
-          </DataLoader>
+                    <component
+                      :is="child.Component"
+                      :items="dataplanesData.items"
+                    />
+                  </XDrawer>
+                </RouterView>
+              </DataCollection>
+            </DataLoader>
+          </XLayout>
         </XCard>
       </XLayout>
     </AppView>
@@ -274,26 +275,6 @@ import { sources as serviceSources } from '@/app/services/sources'
 </script>
 
 <style lang="scss" scoped>
-search {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: var(--x-space-70);
-  margin-bottom: var(--x-space-70);
-}
-
-.search-form {
-  display: flex;
-  flex-basis: 350px;
-  flex-grow: 1;
-}
-
-.search-field {
-  flex: 1;
-}
-
 .name-link {
   display: inline-block;
   width: 100%;

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -19,7 +19,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -135,8 +134,3 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import { sources } from '@/app/services/sources'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -30,7 +30,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ s, page: 1 })"
@@ -140,8 +139,3 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -45,7 +45,6 @@
             <search>
               <form @submit.prevent>
                 <XSearch
-                  class="search-field"
                   :keys="['name']"
                   :value="route.params.s"
                   @change="(s) => route.update({ page: 1, s })"
@@ -140,8 +139,3 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 const MeshActionGroup = useMeshActionGroup()
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -60,201 +60,205 @@
           </XCard>
 
           <XCard>
-            <search>
-              <form
-                @submit.prevent
-              >
-                <XSearch
-                  class="search-field"
-                  :keys="['name', 'namespace', ...(can('use zones') && type.policy.isTargetRef ? ['zone'] : []), 'label']"
-                  :value="route.params.s"
-                  @change="(s) => route.update({ s })"
-                />
-              </form>
-            </search>
-            <DataLoader
-              :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
-                mesh: route.params.mesh,
-                path: route.params.policyPath,
-              }, {
-                page: route.params.page,
-                size: route.params.size,
-                search: route.params.s,
-              })"
-              variant="list"
-              v-slot="{ data: [data], refresh }"
+            <XLayout
+              variant="y-stack"
             >
-              <DataCollection
-                :items="data.items"
-                :page="route.params.page"
-                :page-size="route.params.size"
-                :total="data.total"
-                @change="route.update"
-              >
-                <template
-                  #empty
+              <search>
+                <form
+                  @submit.prevent
                 >
-                  <DataEmptyState
-                    type="policies"
-                  >
-                    <template #title>
-                      <h3>
-                        {{ t('policies.x-empty-state.title') }}
-                      </h3>
-                    </template>
-                    <XI18n
-                      path="policies.x-empty-state.body"
-                      :params="{
-                        type: type.name,
-                        suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '',
-                      }"
-                    />
-                    <template
-                      #action
-                    >
-                      <XAction
-                        action="docs"
-                        :href="t('policies.href.docs', { name: type.name })"
-                      >
-                        {{ t('common.documentation') }}
-                      </XAction>
-                    </template>
-                  </DataEmptyState>
-                </template>
-                <template
-                  #default
-                >
-                  <AppCollection
-                    :headers="[
-                      { ...me.get('headers.role'), label: 'Role', key: 'role', hideLabel: true },
-                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                      ...(can('use zones') && type.policy.isTargetRef ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                      ...(type.policy.isTargetRef ? [{ ...me.get('headers.targetRef'), label: 'Target ref', key: 'targetRef' }] : []),
-                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                    ]"
-                    :items="data.items"
-                    :is-selected-row="(row) => row.id === route.params.policy"
-                    @resize="me.set"
-                  >
-                    <template
-                      #role="{ row: item }"
-                    >
-                      <template
-                        v-if="['producer', 'consumer', 'system', 'workload-owner'].includes(item.role)"
-                      >
-                        <XIcon
-                          :name="`policy-role-${item.role}`"
-                        >
-                          Role: {{ item.role }}
-                        </XIcon>
-                      </template>
-                      <template
-                        v-else
-                      >
-                          &nbsp;
-                      </template>
-                    </template>
-
-                    <template #name="{ row }">
-                      <XAction
-                        data-action
-                        :to="{
-                          name: 'policy-summary-view',
-                          params: {
-                            mesh: row.mesh,
-                            policyPath: type.path,
-                            policy: row.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                            s: route.params.s,
-                          },
-                        }"
-                      >
-                        {{ row.name }}
-                      </XAction>
-                    </template>
-                    <template #namespace="{ row: item }">
-                      {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
-                    </template>
-
-                    <template #targetRef="{ row: item }">
-                      <KumaTargetRef
-                        :target-ref="item.spec?.targetRef"
-                      />
-                    </template>
-
-                    <template #zone="{ row }">
-                      <template v-if="row.zone">
-                        <XAction
-                          :to="{
-                            name: 'zone-cp-detail-view',
-                            params: {
-                              zone: row.zone,
-                            },
-                          }"
-                        >
-                          {{ row.zone }}
-                        </XAction>
-                      </template>
-
-                      <template v-else>
-                        {{ t('common.detail.none') }}
-                      </template>
-                    </template>
-
-                    <template #actions="{ row: item }">
-                      <PolicyActionGroup
-                        :item="item"
-                        :type="type"
-                        @change="refresh"
-                      >
-                        <XAction
-                          :to="{
-                            name: 'policy-detail-view',
-                            params: {
-                              mesh: item.mesh,
-                              policyPath: type.path,
-                              policy: item.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.actions.view') }}
-                        </XAction>
-                      </PolicyActionGroup>
-                    </template>
-                  </AppCollection>
-                </template>
-              </DataCollection>
-              <RouterView
-                v-if="route.params.policy"
-                v-slot="{ Component }"
-              >
-                <XDrawer
-                  @close="route.replace({
-                    name: 'policy-list-view',
-                    params: {
-                      mesh: route.params.mesh,
-                      policyPath: route.params.policyPath,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                      s: route.params.s,
-                    },
-                  })"
-                >
-                  <component
-                    :is="Component"
-                    v-if="typeof data !== 'undefined'"
-                    :items="data.items"
-                    :policy-type="type"
+                  <XSearch
+                    class="search-field"
+                    :keys="['name', 'namespace', ...(can('use zones') && type.policy.isTargetRef ? ['zone'] : []), 'label']"
+                    :value="route.params.s"
+                    @change="(s) => route.update({ s })"
                   />
-                </XDrawer>
-              </RouterView>
-            </DataLoader>
+                </form>
+              </search>
+              <DataLoader
+                :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
+                  mesh: route.params.mesh,
+                  path: route.params.policyPath,
+                }, {
+                  page: route.params.page,
+                  size: route.params.size,
+                  search: route.params.s,
+                })"
+                variant="list"
+                v-slot="{ data: [data], refresh }"
+              >
+                <DataCollection
+                  :items="data.items"
+                  :page="route.params.page"
+                  :page-size="route.params.size"
+                  :total="data.total"
+                  @change="route.update"
+                >
+                  <template
+                    #empty
+                  >
+                    <DataEmptyState
+                      type="policies"
+                    >
+                      <template #title>
+                        <h3>
+                          {{ t('policies.x-empty-state.title') }}
+                        </h3>
+                      </template>
+                      <XI18n
+                        path="policies.x-empty-state.body"
+                        :params="{
+                          type: type.name,
+                          suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '',
+                        }"
+                      />
+                      <template
+                        #action
+                      >
+                        <XAction
+                          action="docs"
+                          :href="t('policies.href.docs', { name: type.name })"
+                        >
+                          {{ t('common.documentation') }}
+                        </XAction>
+                      </template>
+                    </DataEmptyState>
+                  </template>
+                  <template
+                    #default
+                  >
+                    <AppCollection
+                      :headers="[
+                        { ...me.get('headers.role'), label: 'Role', key: 'role', hideLabel: true },
+                        { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                        { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                        ...(can('use zones') && type.policy.isTargetRef ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                        ...(type.policy.isTargetRef ? [{ ...me.get('headers.targetRef'), label: 'Target ref', key: 'targetRef' }] : []),
+                        { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                      ]"
+                      :items="data.items"
+                      :is-selected-row="(row) => row.id === route.params.policy"
+                      @resize="me.set"
+                    >
+                      <template
+                        #role="{ row: item }"
+                      >
+                        <template
+                          v-if="['producer', 'consumer', 'system', 'workload-owner'].includes(item.role)"
+                        >
+                          <XIcon
+                            :name="`policy-role-${item.role}`"
+                          >
+                            Role: {{ item.role }}
+                          </XIcon>
+                        </template>
+                        <template
+                          v-else
+                        >
+                          &nbsp;
+                        </template>
+                      </template>
+
+                      <template #name="{ row }">
+                        <XAction
+                          data-action
+                          :to="{
+                            name: 'policy-summary-view',
+                            params: {
+                              mesh: row.mesh,
+                              policyPath: type.path,
+                              policy: row.id,
+                            },
+                            query: {
+                              page: route.params.page,
+                              size: route.params.size,
+                              s: route.params.s,
+                            },
+                          }"
+                        >
+                          {{ row.name }}
+                        </XAction>
+                      </template>
+                      <template #namespace="{ row: item }">
+                        {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
+                      </template>
+
+                      <template #targetRef="{ row: item }">
+                        <KumaTargetRef
+                          :target-ref="item.spec?.targetRef"
+                        />
+                      </template>
+
+                      <template #zone="{ row }">
+                        <template v-if="row.zone">
+                          <XAction
+                            :to="{
+                              name: 'zone-cp-detail-view',
+                              params: {
+                                zone: row.zone,
+                              },
+                            }"
+                          >
+                            {{ row.zone }}
+                          </XAction>
+                        </template>
+
+                        <template v-else>
+                          {{ t('common.detail.none') }}
+                        </template>
+                      </template>
+
+                      <template #actions="{ row: item }">
+                        <PolicyActionGroup
+                          :item="item"
+                          :type="type"
+                          @change="refresh"
+                        >
+                          <XAction
+                            :to="{
+                              name: 'policy-detail-view',
+                              params: {
+                                mesh: item.mesh,
+                                policyPath: type.path,
+                                policy: item.id,
+                              },
+                            }"
+                          >
+                            {{ t('common.collection.actions.view') }}
+                          </XAction>
+                        </PolicyActionGroup>
+                      </template>
+                    </AppCollection>
+                  </template>
+                </DataCollection>
+                <RouterView
+                  v-if="route.params.policy"
+                  v-slot="{ Component }"
+                >
+                  <XDrawer
+                    @close="route.replace({
+                      name: 'policy-list-view',
+                      params: {
+                        mesh: route.params.mesh,
+                        policyPath: route.params.policyPath,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="Component"
+                      v-if="typeof data !== 'undefined'"
+                      :items="data.items"
+                      :policy-type="type"
+                    />
+                  </XDrawer>
+                </RouterView>
+              </DataLoader>
+            </XLayout>
           </XCard>
         </AppView>
       </template>
@@ -292,20 +296,15 @@ header > h3 {
   margin-top: 0;
   float: left;
 }
-search form {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: var(--x-space-70);
-  margin-bottom: var(--x-space-70);
-}
 .app-collection:deep(:is(th, td):nth-child(1)) {
   padding-right: 0 !important;
   width: 16px !important;
 }
+search form {
+  display: flex;
+}
 .search-field {
   flex: 1;
+  width: 0;
 }
 </style>

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
@@ -50,7 +50,6 @@
                 @submit.prevent
               >
                 <XSearch
-                  class="search-field"
                   :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
                   :value="route.params.s"
                   @change="(s) => route.update({ s })"
@@ -206,8 +205,3 @@ const props = defineProps<{
   mesh: Mesh
 }>()
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
@@ -24,7 +24,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ s })"
@@ -168,8 +167,3 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -285,194 +285,196 @@
             <template #title>
               {{ t('services.detail.data_plane_proxies') }}
             </template>
-            <search>
-              <form
-                class="search-form"
-                @submit.prevent
-              >
-                <XSearch
-                  class="search-field"
-                  :keys="['name', 'tag', 'label']"
-                  :value="route.params.s"
-                  @change="(s) => route.update({ page: 1, s })"
-                />
-              </form>
-            </search>
-            <DataLoader
-              :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
-                mesh: route.params.mesh,
-                tags: JSON.stringify({
-                  ...props.data.spec.selector.dataplaneTags,
-                }),
-              }, {
-                page: route.params.page,
-                size: route.params.size,
-                search: `${route.params.s}${can('use zones') && props.data.zone.length > 0 ? ` zone:${props.data.zone}`: ''}`,
-              })"
-              variant="list"
-              v-slot="{ data: [dataplanes] }"
+            <XLayout
+              variant="y-stack"
             >
-              <DataCollection
-                type="data-planes"
-                :items="dataplanes.items"
-                :page="route.params.page"
-                :page-size="route.params.size"
-                :total="dataplanes.total"
-                @change="route.update"
-              >
-                <AppCollection
-                  class="data-plane-collection"
-                  data-testid="data-plane-collection"
-                  :headers="[
-                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                    { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
-                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="dataplanes.items"
-                  :is-selected-row="(row) => row.name === route.params.proxy"
-                  @resize="me.set"
+              <search>
+                <form
+                  @submit.prevent
                 >
-                  <template #name="{ row: item }">
-                    <XAction
-                      class="name-link"
-                      :to="{
-                        name: 'mesh-service-data-plane-summary-view',
+                  <XSearch
+                    :keys="['name', 'tag', 'label']"
+                    :value="route.params.s"
+                    @change="(s) => route.update({ page: 1, s })"
+                  />
+                </form>
+              </search>
+              <DataLoader
+                :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
+                  mesh: route.params.mesh,
+                  tags: JSON.stringify({
+                    ...props.data.spec.selector.dataplaneTags,
+                  }),
+                }, {
+                  page: route.params.page,
+                  size: route.params.size,
+                  search: `${route.params.s}${can('use zones') && props.data.zone.length > 0 ? ` zone:${props.data.zone}`: ''}`,
+                })"
+                variant="list"
+                v-slot="{ data: [dataplanes] }"
+              >
+                <DataCollection
+                  type="data-planes"
+                  :items="dataplanes.items"
+                  :page="route.params.page"
+                  :page-size="route.params.size"
+                  :total="dataplanes.total"
+                  @change="route.update"
+                >
+                  <AppCollection
+                    class="data-plane-collection"
+                    data-testid="data-plane-collection"
+                    :headers="[
+                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                      ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                      { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
+                      { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                      { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                    ]"
+                    :items="dataplanes.items"
+                    :is-selected-row="(row) => row.name === route.params.proxy"
+                    @resize="me.set"
+                  >
+                    <template #name="{ row: item }">
+                      <XAction
+                        class="name-link"
+                        :to="{
+                          name: 'mesh-service-data-plane-summary-view',
+                          params: {
+                            mesh: item.mesh,
+                            proxy: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                            s: route.params.s,
+                          },
+                        }"
+                        data-action
+                      >
+                        {{ item.name }}
+                      </XAction>
+                    </template>
+
+                    <template #namespace="{ row: item }">
+                      {{ item.namespace }}
+                    </template>
+
+                    <template #zone="{ row }">
+                      <XAction
+                        v-if="row.zone"
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: row.zone,
+                          },
+                        }"
+                      >
+                        {{ row.zone }}
+                      </XAction>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #certificate="{ row }">
+                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                      </template>
+
+                      <template v-else>
+                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                      </template>
+                    </template>
+
+                    <template #status="{ row }">
+                      <StatusBadge :status="row.status" />
+                    </template>
+
+                    <template #warnings="{ row: item }">
+                      <template
+                        v-for="warnings in [[
+                          {
+                            bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                            key: 'dp-cp-incompatible',
+                          },
+                          {
+                            bool: item.isCertExpiresSoon,
+                            key: 'certificate-expires-soon',
+                          },
+                          {
+                            bool: item.isCertExpired,
+                            key: 'certificate-expired',
+                          },
+                        ].filter(({ bool }) => bool)]"
+                        :key="typeof warnings"
+                      >
+                        <XIcon
+                          v-if="warnings.length > 0"
+                          name="warning"
+                          data-testid="warning"
+                        >
+                          <ul>
+                            <li
+                              v-for="{ key } in warnings"
+                              :key="key"
+                              :data-testid="`warning-${key}`"
+                            >
+                              {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                            </li>
+                          </ul>
+                        </XIcon>
+                        <template v-else>
+                          {{ t('common.collection.none') }}
+                        </template>
+                      </template>
+                    </template>
+
+                    <template #actions="{ row: item }">
+                      <XActionGroup>
+                        <XAction
+                          :to="{
+                            name: 'data-plane-detail-view',
+                            params: {
+                              proxy: item.id,
+                            },
+                          }"
+                        >
+                          {{ t('common.collection.actions.view') }}
+                        </XAction>
+                      </XActionGroup>
+                    </template>
+                  </AppCollection>
+                  <RouterView
+                    v-if="route.params.proxy"
+                    v-slot="child"
+                  >
+                    <XDrawer
+                      @close="route.replace({
+                        name: route.name,
                         params: {
-                          mesh: item.mesh,
-                          proxy: item.id,
+                          mesh: route.params.mesh,
                         },
                         query: {
                           page: route.params.page,
                           size: route.params.size,
                           s: route.params.s,
                         },
-                      }"
-                      data-action
+                      })"
                     >
-                      {{ item.name }}
-                    </XAction>
-                  </template>
-
-                  <template #namespace="{ row: item }">
-                    {{ item.namespace }}
-                  </template>
-
-                  <template #zone="{ row }">
-                    <XAction
-                      v-if="row.zone"
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: row.zone,
-                        },
-                      }"
-                    >
-                      {{ row.zone }}
-                    </XAction>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #certificate="{ row }">
-                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                    </template>
-
-                    <template v-else>
-                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                    </template>
-                  </template>
-
-                  <template #status="{ row }">
-                    <StatusBadge :status="row.status" />
-                  </template>
-
-                  <template #warnings="{ row: item }">
-                    <template
-                      v-for="warnings in [[
-                        {
-                          bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                          key: 'dp-cp-incompatible',
-                        },
-                        {
-                          bool: item.isCertExpiresSoon,
-                          key: 'certificate-expires-soon',
-                        },
-                        {
-                          bool: item.isCertExpired,
-                          key: 'certificate-expired',
-                        },
-                      ].filter(({ bool }) => bool)]"
-                      :key="typeof warnings"
-                    >
-                      <XIcon
-                        v-if="warnings.length > 0"
-                        name="warning"
-                        data-testid="warning"
-                      >
-                        <ul>
-                          <li
-                            v-for="{ key } in warnings"
-                            :key="key"
-                            :data-testid="`warning-${key}`"
-                          >
-                            {{ t(`data-planes.routes.items.warnings.${key}`) }}
-                          </li>
-                        </ul>
-                      </XIcon>
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            proxy: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-                <RouterView
-                  v-if="route.params.proxy"
-                  v-slot="child"
-                >
-                  <XDrawer
-                    @close="route.replace({
-                      name: route.name,
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    })"
-                  >
-                    <component
-                      :is="child.Component"
-                      v-if="typeof dataplanes !== 'undefined'"
-                      :items="dataplanes.items"
-                    />
-                  </XDrawer>
-                </RouterView>
-              </DataCollection>
-            </DataLoader>
+                      <component
+                        :is="child.Component"
+                        v-if="typeof dataplanes !== 'undefined'"
+                        :items="dataplanes.items"
+                      />
+                    </XDrawer>
+                  </RouterView>
+                </DataCollection>
+              </DataLoader>
+            </XLayout>
           </XCard>
         </div>
       </XLayout>
@@ -497,25 +499,6 @@ const props = defineProps<{
 <style lang="scss" scoped>
 .ip span {
   font-size: var(--x-font-size-30);
-}
-search {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: var(--x-space-70);
-  margin-bottom: var(--x-space-70);
-}
-
-.search-form {
-  display: flex;
-  flex-basis: 350px;
-  flex-grow: 1;
-}
-
-.search-field {
-  flex: 1;
 }
 
 .name-link {

--- a/packages/kuma-gui/src/app/services/views/MeshServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceListView.vue
@@ -24,7 +24,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ s })"
@@ -193,8 +192,3 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -77,194 +77,195 @@
         <template #title>
           <h3>{{ t('services.detail.data_plane_proxies') }}</h3>
         </template>
-
-        <search>
-          <form
-            class="search-form"
-            @submit.prevent
-          >
-            <XSearch
-              class="search-field"
-              :keys="['name', 'tag', ...(can('use zones') ? ['zone'] : []), 'namespace', 'label']"
-              :value="route.params.s"
-              @change="(s) => route.update({ page: 1, s })"
-            />
-          </form>
-        </search>
-        <DataLoader
-          :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
-            mesh: route.params.mesh,
-            service: route.params.service,
-          }, {
-            page: route.params.page,
-            size: route.params.size,
-            search: route.params.s,
-          })"
-          variant="list"
-          v-slot="{ data: [data] }"
+        <XLayout
+          variant="y-stack"
         >
-          <DataCollection
-            type="data-planes"
-            :items="data.items"
-            :page="route.params.page"
-            :page-size="route.params.size"
-            :total="data.total"
-            @change="route.update"
-          >
-            <AppCollection
-              class="data-plane-collection"
-              data-testid="data-plane-collection"
-              :headers="[
-                { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
-                { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :items="data.items"
-              :is-selected-row="(row) => row.name === route.params.proxy"
-              @resize="me.set"
+          <search>
+            <form
+              @submit.prevent
             >
-              <template #name="{ row: item }">
-                <XAction
-                  data-action
-                  class="name-link"
-                  :to="{
-                    name: 'service-data-plane-summary-view',
+              <XSearch
+                :keys="['name', 'tag', ...(can('use zones') ? ['zone'] : []), 'namespace', 'label']"
+                :value="route.params.s"
+                @change="(s) => route.update({ page: 1, s })"
+              />
+            </form>
+          </search>
+          <DataLoader
+            :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
+              mesh: route.params.mesh,
+              service: route.params.service,
+            }, {
+              page: route.params.page,
+              size: route.params.size,
+              search: route.params.s,
+            })"
+            variant="list"
+            v-slot="{ data: [data] }"
+          >
+            <DataCollection
+              type="data-planes"
+              :items="data.items"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data.total"
+              @change="route.update"
+            >
+              <AppCollection
+                class="data-plane-collection"
+                data-testid="data-plane-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.certificate'), label: 'Certificate info', key: 'certificate' },
+                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :items="data.items"
+                :is-selected-row="(row) => row.name === route.params.proxy"
+                @resize="me.set"
+              >
+                <template #name="{ row: item }">
+                  <XAction
+                    data-action
+                    class="name-link"
+                    :to="{
+                      name: 'service-data-plane-summary-view',
+                      params: {
+                        mesh: item.mesh,
+                        proxy: item.id,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    }"
+                  >
+                    {{ item.name }}
+                  </XAction>
+                </template>
+
+                <template #namespace="{ row: item }">
+                  {{ item.namespace }}
+                </template>
+
+                <template #zone="{ row }">
+                  <XAction
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </XAction>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #certificate="{ row }">
+                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                  </template>
+
+                  <template v-else>
+                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  </template>
+                </template>
+
+                <template #status="{ row }">
+                  <StatusBadge :status="row.status" />
+                </template>
+
+                <template #warnings="{ row: item }">
+                  <template
+                    v-for="warnings in [[
+                      {
+                        bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                        key: 'dp-cp-incompatible',
+                      },
+                      {
+                        bool: item.isCertExpiresSoon,
+                        key: 'certificate-expires-soon',
+                      },
+                      {
+                        bool: item.isCertExpired,
+                        key: 'certificate-expired',
+                      },
+                    ].filter(({ bool }) => bool)]"
+                    :key="typeof warnings"
+                  >
+                    <XIcon
+                      v-if="warnings.length > 0"
+                      name="warning"
+                      data-testid="warning"
+                    >
+                      <ul>
+                        <li
+                          v-for="{ key } in warnings"
+                          :key="key"
+                          :data-testid="`warning-${key}`"
+                        >
+                          {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                        </li>
+                      </ul>
+                    </XIcon>
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'data-plane-detail-view',
+                        params: {
+                          proxy: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+
+              <RouterView
+                v-slot="{ Component }"
+              >
+                <XDrawer
+                  v-if="route.child()"
+                  @close="route.replace({
+                    name: route.name,
                     params: {
-                      mesh: item.mesh,
-                      proxy: item.id,
+                      mesh: route.params.mesh,
                     },
                     query: {
                       page: route.params.page,
                       size: route.params.size,
                       s: route.params.s,
                     },
-                  }"
+                  })"
                 >
-                  {{ item.name }}
-                </XAction>
-              </template>
-
-              <template #namespace="{ row: item }">
-                {{ item.namespace }}
-              </template>
-
-              <template #zone="{ row }">
-                <XAction
-                  v-if="row.zone"
-                  :to="{
-                    name: 'zone-cp-detail-view',
-                    params: {
-                      zone: row.zone,
-                    },
-                  }"
-                >
-                  {{ row.zone }}
-                </XAction>
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #certificate="{ row }">
-                <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                  {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                </template>
-
-                <template v-else>
-                  {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                </template>
-              </template>
-
-              <template #status="{ row }">
-                <StatusBadge :status="row.status" />
-              </template>
-
-              <template #warnings="{ row: item }">
-                <template
-                  v-for="warnings in [[
-                    {
-                      bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                      key: 'dp-cp-incompatible',
-                    },
-                    {
-                      bool: item.isCertExpiresSoon,
-                      key: 'certificate-expires-soon',
-                    },
-                    {
-                      bool: item.isCertExpired,
-                      key: 'certificate-expired',
-                    },
-                  ].filter(({ bool }) => bool)]"
-                  :key="typeof warnings"
-                >
-                  <XIcon
-                    v-if="warnings.length > 0"
-                    name="warning"
-                    data-testid="warning"
-                  >
-                    <ul>
-                      <li
-                        v-for="{ key } in warnings"
-                        :key="key"
-                        :data-testid="`warning-${key}`"
-                      >
-                        {{ t(`data-planes.routes.items.warnings.${key}`) }}
-                      </li>
-                    </ul>
-                  </XIcon>
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'data-plane-detail-view',
-                      params: {
-                        proxy: item.id,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-
-            <RouterView
-              v-slot="{ Component }"
-            >
-              <XDrawer
-                v-if="route.child()"
-                @close="route.replace({
-                  name: route.name,
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                  query: {
-                    page: route.params.page,
-                    size: route.params.size,
-                    s: route.params.s,
-                  },
-                })"
-              >
-                <component
-                  :is="Component"
-                  v-if="typeof data !== 'undefined'"
-                  :items="data.items"
-                />
-              </XDrawer>
-            </RouterView>
-          </DataCollection>
-        </DataLoader>
+                  <component
+                    :is="Component"
+                    v-if="typeof data !== 'undefined'"
+                    :items="data.items"
+                  />
+                </XDrawer>
+              </RouterView>
+            </DataCollection>
+          </DataLoader>
+        </XLayout>
       </XCard>
     </AppView>
   </RouteView>
@@ -278,26 +279,6 @@ import { sources as dataplaneSources } from '@/app/data-planes/sources'
 </script>
 
 <style lang="scss" scoped>
-search {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: var(--x-space-70);
-  margin-bottom: var(--x-space-70);
-}
-
-.search-form {
-  display: flex;
-  flex-basis: 350px;
-  flex-grow: 1;
-}
-
-.search-field {
-  flex: 1;
-}
-
 .name-link {
   display: inline-block;
   width: 100%;

--- a/packages/kuma-gui/src/app/services/views/ServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListView.vue
@@ -22,7 +22,6 @@
           <search>
             <form @submit.prevent>
               <XSearch
-                class="search-field"
                 :keys="['name']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -160,8 +159,3 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
@@ -95,21 +95,19 @@
       </XAboutCard>
 
       <XCard>
+        <template #title>
+          <h2>
+            {{ t('workloads.routes.item.dataplaneProxies.title') }}
+          </h2>
+        </template>
         <XLayout
           variant="y-stack"
         >
-          <slot name="title">
-            <h2>
-              {{ t('workloads.routes.item.dataplaneProxies.title') }}
-            </h2>
-          </slot>
           <search>
             <form
-              class="search-form"
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', 'tag', 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -305,8 +303,3 @@ const props = defineProps<{
   data: WorkloadItem | Error | undefined
 }>()
 </script>
-<style scoped lang="scss">
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
@@ -36,11 +36,9 @@
           >
             <search>
               <form
-                class="search-form"
                 @submit.prevent
               >
                 <XSearch
-                  class="search-field"
                   :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
                   :value="route.params.s"
                   @change="(s) => route.update({ page: 1, s })"
@@ -167,8 +165,3 @@
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import { sources } from '@/app/workloads/sources'
 </script>
-<style scoped lang="scss">
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -40,7 +40,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', 'namespace', 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -169,8 +168,3 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -28,7 +28,6 @@
               @submit.prevent
             >
               <XSearch
-                class="search-field"
                 :keys="['name', 'namespace', 'label']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
@@ -169,8 +168,3 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 </script>
-<style lang="scss" scoped>
-.search-field {
-  width: 100%;
-}
-</style>

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -52,7 +52,6 @@
             <search>
               <form @submit.prevent>
                 <XSearch
-                  class="search-field"
                   :keys="['name']"
                   :value="route.params.s"
                   @change="(s) => route.update({ page: 1, s })"
@@ -292,8 +291,5 @@ const getEgresses = (data: {items: ZoneEgressOverview[]}) => {
   color: inherit;
   font-weight: var(--x-font-weight-semibold);
   text-decoration: none;
-}
-.search-field {
-  width: 100%;
 }
 </style>

--- a/packages/x/src/components/x-search/XSearch.vue
+++ b/packages/x/src/components/x-search/XSearch.vue
@@ -349,8 +349,8 @@ input {
 
 .dropdown {
   position: relative;
-  min-width: inherit;
-  width: 0;
+  width: 100%;
+  min-width: 0;
 }
 
 :deep(.popover) {


### PR DESCRIPTION
When introducing `XSearch` back in https://github.com/kumahq/kuma-gui/pull/3737 and the dropdown in https://github.com/kumahq/kuma-gui/pull/3748 there was a need to set the internal width of of the top most internal element to 0. This was due to two exceptional cases we have from a layout perspective:
1. dataplanes listing filters also include an inline select
2. policy listing is nested in a `separated` layout without a parent element giving a certain width that `width: 100%` can refer to

This caused that we had to add a `width: 100%` to all the other cases where `width: 100%` would just work. This PR now turns it around to leave and improve the CSS in the special cases.

---

While I went through the application I noticed that I could remove some more CSS that was not doing anything and most likely was left after some copy&paste and replaced it with `XLayout`.

---

Best to review without whitespaces.