### PR TITLE
fix(ci): fix duplicate YAML key in e2e tests

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Tls.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Tls.feature
@@ -13,7 +13,6 @@ Feature: mesh / dataplanes / overview / TLS
       KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
       KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY: true
-      KUMA_MESHSERVICE_MODE: Exclusive
       """
     And the URL "/meshes/default/dataplanes/backend/_overview" responds with
       """


### PR DESCRIPTION
Fixes up a duplicate YAML key in our tests. Assuming this got in here via either a rebase or kriss-krossing of PRs.

(see https://github.com/kumahq/kuma-gui/actions/runs/23240555624/job/67560959685?pr=4720)