### PR TITLE
fix(x-theme): button resets

### DIFF
--- a/packages/x/src/components/x-theme/XTheme.vue
+++ b/packages/x/src/components/x-theme/XTheme.vue
@@ -573,6 +573,18 @@ import '@kong-ui-public/app-layout/dist/style.css'
   textarea {
     resize: vertical;
   }
+  button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin: 0;
+    padding: 0;
+    font-size: 100%;
+    line-height: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    color: inherit;
+  }
 
   img,
   svg {


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/4725 we moved our "base"/"reset" CSS into XTheme to only apply to things inside of an XTheme (instead of globally). Whilst doing that I cleaned up a couple of things that seemed "obviously" no longer needed.

I'd assumed that we only ever use KButtons for buttons and therefore removed a button reset, but turns out we do use buttons for things that look like links but have `@click` on them. Pretty sure we only have these in one place (which isn't shipped yet) because we hit another issue a while back with these buttons and we concluded that we do this only in one place.

This PR re-adds the button reset back so the buttons keep their link-like styling not a native button styling.