### PR TITLE
fix(x): fixes XSelect reactivity

### DIFF
--- a/packages/x/src/components/x-select/XSelect.vue
+++ b/packages/x/src/components/x-select/XSelect.vue
@@ -1,9 +1,9 @@
 <template>
   <KSelect
-    v-model="selected"
+    :model-value="props.selected"
     :label="props.label"
     :items="items"
-    @selected="emit('change', String($event.value))"
+    @selected="(value) => emit('change', value.value)"
   >
     <template
       #selected-item-template="{ item }: any"
@@ -26,7 +26,7 @@
 </template>
 <script lang="ts" setup>
 import { KSelect } from '@kong/kongponents'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 const emit = defineEmits<{
   (event: 'change', value: string): void
@@ -41,7 +41,6 @@ const props = withDefaults(defineProps<{
 
 const slots = defineSlots()
 
-const selected = ref(props.selected)
 
 const items = computed(() => {
   const items = Object.keys(slots).reduce<


### PR DESCRIPTION
I found that setting `XSelect:selected` after mounting did not have the desired effect, and saw that the reactively was "unlinked" in the below PR.

This PR uses a slightly different approach and seems to me like the duplicate calls mentioned in the below PR still do not happen.

The PR pretty much just puts things back but changes to use `model-value` (1 way) to avoid lint issues with potentially mutating `v-model` (2 way). Generally, where possible, we like to avoid 2 way bindings anyway.

FYI: I wasn't totally sure where I was seeing this duplicate call that resulted in the below PR but I tested it in places in places where I could remember that we use XSelect.

- https://github.com/kumahq/kuma-gui/pull/3491