### PR TITLE
fix(ci): don't use github.workflow on a called workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ run-name: |
 # Already running workflows will be cancelled.
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ inputs.branch || github.ref_name }}
+  group: release-${{ inputs.branch || github.ref_name }}
 
 on:
 


### PR DESCRIPTION
`github.workflow` used in a workflow that is called using `workflow_call` takes the name of the calling workflow.

This means when the workflow runs normally this value is `release` whereas when using `workflow_call` is `main` (in our case)

This PR just hardcodes the value to the name of the workflow: `release`

Followup of https://github.com/kumahq/kuma-gui/pull/4765

