### PR TITLE
chore(deps): adds additional npm flags to `make install`

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -13,6 +13,8 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 	@cd $(NPM_WORKSPACE_ROOT) \
 		&& npm $(if $(CI),clean-install,install) \
 					--ignore-scripts \
+					--allow-git none \
+					--min-release-age 12 \
 		&& touch $(NPM_WORKSPACE_ROOT)/node_modules
 #
 .PHONY: .sync
@@ -21,7 +23,9 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 		&& npm install \
 					--package-lock-only \
 					--prefer-dedupe \
-					--ignore-scripts
+					--ignore-scripts \
+					--allow-git none \
+					--min-release-age 12
 
 .PHONY: .clean
 .clean:


### PR DESCRIPTION
Adds two new flags to all `npm install` invocations via `make install`

- `--allow-git none` prevents dependencies from using git references
- `--min-release-age` bring this in line with our renovate config, but also effects transitives.

Note: we continue to use `--ignore-scripts` everywhere to prevent any automatic-like script execution.