### PR TITLE
refactor(workloads/routes): embed summary

### DIFF
--- a/packages/kuma-gui/src/app/workloads/routes.ts
+++ b/packages/kuma-gui/src/app/workloads/routes.ts
@@ -25,16 +25,6 @@ export const routes = () => {
     ]
   }
 
-  const summary = (): RouteRecordRaw[] => {
-    return [
-      {
-        path: ':wl',
-        name: 'workload-summary-view',
-        component: () => import('@/app/workloads/views/WorkloadSummaryView.vue'),
-      },
-    ]
-  }
-
   return {
     items: (): RouteRecordRaw[] => {
       return [
@@ -42,11 +32,16 @@ export const routes = () => {
           path: 'workloads',
           name: 'workload-list-view',
           component: () => import('@/app/workloads/views/WorkloadListView.vue'),
-          children: [...summary()],
+          children: [
+            {
+              path: ':wl',
+              name: 'workload-summary-view',
+              component: () => import('@/app/workloads/views/WorkloadSummaryView.vue'),
+            },
+          ],
         },
       ]
     },
     item,
-    summary,
   }
 }


### PR DESCRIPTION
Having the workloads `summary` route definition not embedded directly to `items` is not following the pattern we have in most cases. We only need to have `summary` separated if we need to embed the route separately from the `items` in other routes. For now this should only be the case for data planes and gateways and will be the case for mesh-identites and mesh-trusts.