### PR TITLE
fix: fixes an issue with margins of the version header

### DIFF
--- a/packages/x/src/components/x-i18n/XI18n.vue
+++ b/packages/x/src/components/x-i18n/XI18n.vue
@@ -110,3 +110,14 @@ const safeT: TFunction = (
 }
 
 </script>
+<style lang="scss" scoped>
+/* default styles for markdown content */
+/* note whilst it doesn't seem necessary */
+/* the x-i189n scope is necessary here */
+/* to prevent "global" `p` styles from overwriting this */
+.x-i18n {
+  :deep(p + p) {
+    margin-block-start: var(--x-i18n-p-margin-block, 1em);
+  }
+}
+</style>

--- a/packages/x/src/components/x-i18n/XI18n.vue
+++ b/packages/x/src/components/x-i18n/XI18n.vue
@@ -113,11 +113,11 @@ const safeT: TFunction = (
 <style lang="scss" scoped>
 /* default styles for markdown content */
 /* note whilst it doesn't seem necessary */
-/* the x-i189n scope is necessary here */
+/* the x-i18n scope is necessary here */
 /* to prevent "global" `p` styles from overwriting this */
 .x-i18n {
   :deep(p + p) {
-    margin-block-start: var(--x-i18n-p-margin-block, 1em);
+    margin-block-start: 1em;
   }
 }
 </style>

--- a/packages/x/src/components/x-theme/XTheme.vue
+++ b/packages/x/src/components/x-theme/XTheme.vue
@@ -466,6 +466,11 @@ import '@kong-ui-public/app-layout/dist/style.css'
   a.k-button {
     text-decoration: none !important;
   }
+
+  /* styles for things that come from locales/i18n rendered from markdown */
+  .x-i18n p {
+    margin-bottom: var(--x-space-50);
+  }
 }
 </style>
 
@@ -542,19 +547,6 @@ import '@kong-ui-public/app-layout/dist/style.css'
   ul,
   ol {
     padding-left: var(--x-space-80);
-  }
-
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p,
-  ul,
-  ol {
-    &:not(:first-child) {
-      margin-top: var(--x-space-50);
-    }
   }
 
   p:empty {

--- a/packages/x/src/components/x-theme/XTheme.vue
+++ b/packages/x/src/components/x-theme/XTheme.vue
@@ -466,11 +466,6 @@ import '@kong-ui-public/app-layout/dist/style.css'
   a.k-button {
     text-decoration: none !important;
   }
-
-  /* styles for things that come from locales/i18n rendered from markdown */
-  .x-i18n p {
-    margin-bottom: var(--x-space-50);
-  }
 }
 </style>
 


### PR DESCRIPTION
Fixes an issue where this is too much top margin on our software version info:

## Before

<img width="1101" height="178" alt="Screenshot 2026-04-16 at 10 09 48" src="https://github.com/user-attachments/assets/09fc66e5-9e3e-4fdc-9c65-96a2c4e428d6" />

Note: I also removed a piece of global CSS that nobody quite knows why it was there in the first place (putting a margin top on lots of different HTML elements). Whilst the `p` selector here is what is causing the bug, I've removed the entire thing here and it looks to me like it doesn't effect anything.




