### PR TITLE
chore: move tertiary menus out of actions slot

### DIFF
--- a/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
@@ -11,7 +11,9 @@
       :title="t(`${route.child()?.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)"
     />
     <AppView>
-      <template #actions>
+      <XLayout
+        variant="action-group"
+      >
         <DataCollection
           :items="route.children"
           :empty="false"
@@ -38,7 +40,7 @@
             </XAction>
           </XActionGroup>
         </DataCollection>
-      </template>
+      </XLayout>
 
       <XI18n
         :path="`gateways.routes.items.navigation.${route.child()?.name}.description`"

--- a/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
@@ -7,7 +7,9 @@
     v-slot="{ route, t }"
   >
     <AppView>
-      <template #actions>
+      <XLayout
+        variant="action-group"
+      >
         <XActionGroup
           :expanded="true"
         >
@@ -32,7 +34,7 @@
             </XAction>
           </template>
         </XActionGroup>
-      </template>
+      </XLayout>
 
       <XI18n
         :path="`services.routes.items.navigation.${route.child()?.name}.description`"


### PR DESCRIPTION
Since now we have `XLayout variant="y-stack"` and `XLayout variant="action-group"` there is no reason to put these in the `AppView #actions` slot. They were only in actions originally for positioning purposes, and they are really "actions"