### PR TITLE
chore(deps): remove actions/github-script dependency

### DIFF
--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -24,4 +24,4 @@ jobs:
           gh api repos/${{ vars.NOTIFY_REPO_OWNER }}/${{ vars.NOTIFY_REPO_NAME }}/dispatches \
             -X POST \
             -f event_type=${{ vars.NOTIFY_EVENT_TYPE }} \
-            -f client_payload[branch]=${{ github.ref_name }}
+            -f 'client_payload[branch]=${{ github.ref_name }}'

--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -18,16 +18,10 @@ jobs:
     name: Dispatch merged PR notification
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          github-token: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
-          script: |
-            const branch = process.env.GITHUB_REF_NAME;
-            return github.rest.repos.createDispatchEvent({
-              owner: '${{ vars.NOTIFY_REPO_OWNER }}',
-              repo: '${{ vars.NOTIFY_REPO_NAME }}',
-              event_type: '${{ vars.NOTIFY_EVENT_TYPE }}',
-              client_payload: {
-                branch
-              },
-            })
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ vars.NOTIFY_REPO_OWNER }}/${{ vars.NOTIFY_REPO_NAME }}/dispatches \
+            -X POST \
+            -f event_type=${{ vars.NOTIFY_EVENT_TYPE }} \
+            -f client_payload[branch]=${{ github.ref_name }}


### PR DESCRIPTION
I noticed in https://github.com/kumahq/kuma-gui/pull/4853 that we only have one single usage of `actions/github-script`.

I wondered if we could just use `curl` or `gh` instead (`gh` upgrades and security upgrades etc are managed by the OS)

I asked Claude and it gave me this, which seems fine to be (I also asked if it was "absolutely sure!" 😆 )

We won't know until we try and use it on master though. It it doesn't work we can revert.

If it does its one less dependency, one less renovate PR every so often.