### PR TITLE
chore(meshes): remove breadcrumb from mesh list

### DIFF
--- a/packages/kuma-gui/src/app/meshes/views/MeshRootView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshRootView.vue
@@ -4,7 +4,7 @@
     v-slot="{ t }"
   >
     <AppView
-      :breadcrumbs="[
+      :breadcrumbs="['mesh-list-view'].includes(String(router.currentRoute.value.name ?? '')) ? [] : [
         {
           to: {
             name: 'mesh-list-view',
@@ -17,3 +17,7 @@
     </AppView>
   </RouteView>
 </template>
+<script lang="ts" setup>
+import { useRouter } from 'vue-router'
+const router = useRouter()
+</script>


### PR DESCRIPTION
Currently we have a `Meshes` breadcrumb _and_ `Meshes` title on the mesh listing page.

If its in the title we don't need the breadcrumb.

---

Note: This isn't ideally how I'd like to do it, but taking a quick look at zones (where the breadcrumbs are correct), this should be possible by reconfiguring all the routing config. Unfortunately I don't want that much chrurn right now in order to fix this, so I've used a different approach which is perfectly fine from a functional perspective, but don't use the same approach as zones _yet_.