### PR TITLE
fix(resources/resource-type-list-view): width on small viewports

### DIFF
--- a/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
@@ -29,7 +29,7 @@
               variant="x-stack"
               size="large"
             >
-              <XCard class="resource-types-collection">
+              <XCard class="resource-type-collection">
                 <template #actions>
                   <XLayout
                     variant="separated"
@@ -167,11 +167,9 @@ import { sources as meshesSources } from '@/app/meshes/sources'
 import { sources } from '@/app/resources/sources'
 </script>
 <style lang="scss" scoped>
-.resource-types-collection {
-  flex-grow: 1;
-  overflow-y: auto;
-  min-height: 0;
+.resource-type-collection {
   max-width: 500px;
+  align-self: flex-start;
 }
 
 ul {


### PR DESCRIPTION
I've aligned it with the `policy-type-list`. The `overflow-y` had no effect and caused that the width of the listing could shrink below the content width.

**Before**

<img width="682" height="1273" alt="image" src="https://github.com/user-attachments/assets/ce11d3dc-07e4-4453-854e-61229aa27903" />


**After**

<img width="681" height="1258" alt="image" src="https://github.com/user-attachments/assets/55096ca5-24d6-499b-93a7-959b5d16662c" />
