### PR TITLE
fix(meshes): use undefined over `[]` for breadcrumbs

### DIFF
--- a/packages/kuma-gui/src/app/meshes/views/MeshRootView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshRootView.vue
@@ -4,7 +4,7 @@
     v-slot="{ t }"
   >
     <AppView
-      :breadcrumbs="['mesh-list-view'].includes(String(router.currentRoute.value.name ?? '')) ? [] : [
+      :breadcrumbs="['mesh-list-view'].includes(String(router.currentRoute.value.name ?? '')) ? undefined : [
         {
           to: {
             name: 'mesh-list-view',


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/4859.

I used `[]` for the "empty" conditional. Which actually means "don't show any breadcrumbs at all, not even any above this"

Both `[]` and `undefined` have the same behaviour in Kuma, but if you embed kuma elsewhere then using `[]` means any higher breadcrumbs no longer show.
