### PR TITLE
chore(renovate): remove duplicate presets

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommits",
     "Kong/public-shared-renovate//base/github-actions",
     "Kong/public-shared-renovate//base/javascript"
   ],


### PR DESCRIPTION
The following presets are duplicate:

- We inherit [`config:best-practices`](https://github.com/Kong/public-shared-renovate/blob/1065b26c7b9aa611cb8b2cbc28db5a9bbe613407/base/javascript.json#L10) which [includes `config:recommended`](https://docs.renovatebot.com/presets-config/#configbest-practices) already
- We inherit [`:semanticCommits`](https://github.com/Kong/public-shared-renovate/blob/1065b26c7b9aa611cb8b2cbc28db5a9bbe613407/base/javascript.json#L25) already