### PR TITLE
chore(ci): fixup vite/connect based mocking

### DIFF
--- a/packages/config/src/vite/plugins/server.ts
+++ b/packages/config/src/vite/plugins/server.ts
@@ -29,19 +29,6 @@ const read = async (path: string) => {
   }
   return (await readFile(`${cwd}/${path}`)).toString()
 }
-const version = JSON.parse((await read('./package.json'))).version
-
-export const defaultKumaHtmlVars = {
-  baseGuiPath: '/gui',
-  apiUrl: 'http://localhost:5681',
-  version,
-  product: 'Kuma', // we no longer use this, it can be removed in the backend
-  mode: 'global',
-  environment: 'universal',
-  storeType: 'postgres',
-  apiReadOnly: false,
-}
-
 const exists = async (path: string) => {
   try {
     return (await stat(path)).isFile()
@@ -49,6 +36,30 @@ const exists = async (path: string) => {
     return false
   }
 }
+const Cookie = {
+  parse: (str: string, { prefix = '' } = { prefix: '' }) => {
+    return Object.fromEntries(str.split(';')
+      .map((item) => item.trim())
+      .filter((item) => item !== '')
+      .map((item) => {
+        const [key, ...value] = item.split('=')
+        return [key, value.join('=')] as [string, string]
+      })
+      .filter(([key, value]) => key.startsWith(prefix)))
+  },
+}
+
+export const defaultKumaHtmlVars = {
+  baseGuiPath: '/gui',
+  apiUrl: 'http://localhost:5681',
+  version: JSON.parse((await read('./package.json'))).version,
+  product: 'Kuma', // we no longer use this, it can be removed in the backend
+  mode: 'global',
+  environment: 'universal',
+  storeType: 'postgres',
+  apiReadOnly: false,
+}
+
 const interpolate = (template: string, vars: KumaHtmlVars) => {
   return template
     .replace('{{.BaseGuiPath}}', '/gui')
@@ -63,6 +74,7 @@ export const kumaIndexHtmlVars = (htmlVars: Partial<KumaHtmlVars> = {}): Plugin 
   }
 }
 
+
 const server = ({
   template = './index.html',
   vars = {},
@@ -70,19 +82,22 @@ const server = ({
 }: Partial<ServerOptions> = {}) => async (server: PreviewServer | ViteDevServer) => {
   const { enabled: isCspEnabled = true } = csp
   server.middlewares.use('/', async (req, res, next) => {
-    const url = req.originalUrl || ''
-    const baseGuiPath = vars.baseGuiPath || '/gui'
-    const path = `${dirname(template).replace(baseGuiPath, '')}${url}`
-    if ((url === '/' || url.startsWith(`${baseGuiPath}/`)) && !await exists(path)) {
+    const add = server.httpServer?.address() ?? ''
+    const address = {
+      address: 'localhost',
+      port: typeof add === 'string' ? server.config.server.port : add.port,
+    }
 
-      const cookies = (req.headers?.cookie ?? '').split(';')
-        .map((item) => item.trim())
-        .filter((item) => item !== '')
-        .reduce((prev, item) => {
-          const [key, value] = item.split('=')
-          prev[key] = value
-          return prev
-        }, {} as Record<string, string>)
+    const htmlVars = {
+      ...defaultKumaHtmlVars,
+      apiUrl: `http://${address.address}:${address.port}`,
+      ...vars,
+    }
+
+    const url = req.originalUrl || ''
+    const path = `${dirname(template).replace(htmlVars.baseGuiPath, '')}${url}`
+    if (!await exists(path) && (url === '/' || url.startsWith(`${htmlVars.baseGuiPath}/`))) {
+      const cookies = Cookie.parse(req.headers?.cookie ?? '', { prefix: 'KUMA_' })
 
       // we create a totally new index.html from our template here
       // so anything added by Vite that is not in our index.html template
@@ -91,14 +106,15 @@ const server = ({
       let body = interpolate(
         await read(template),
         {
-          ...defaultKumaHtmlVars,
-          ...vars,
+          ...htmlVars,
+          // only overwrite with a cookie if the cookie is defined
           ...Object.fromEntries(Object.entries({
             version: cookies.KUMA_VERSION,
             mode: cookies.KUMA_MODE,
             environment: cookies.KUMA_ENVIRONMENT,
             storeType: cookies.KUMA_STORE_TYPE,
           }).filter(([_, value]) => typeof value !== 'undefined')),
+          //
         } satisfies KumaHtmlVars,
       )
 

--- a/packages/fake-api/src/index.ts
+++ b/packages/fake-api/src/index.ts
@@ -30,6 +30,12 @@ export function escapeRoute(route: string): string {
   return route.replaceAll('+', '\\+')
 }
 
+export const addOrigin = <T>(fs: Record<string, T>, origin: string) => {
+  return Object.fromEntries(Object.entries(fs).map(([route, response]) => {
+    return [route.includes('://') ? route : `${origin}${route}`, response]
+  }))
+}
+
 
 export class Router<T> {
   routes: Map<URLPattern, T> = new Map()

--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -1,6 +1,6 @@
 import { createFetch } from './index'
 import type { Dependencies, FS } from './index'
-import type { Plugin } from 'vite'
+import type { Plugin, PreviewServer, ViteDevServer } from 'vite'
 
 type PluginOptions<TDependencies extends object = {}> = {
   fs: FS<TDependencies>
@@ -9,58 +9,59 @@ type PluginOptions<TDependencies extends object = {}> = {
 
 export default <TDependencies extends object = {}>(opts: PluginOptions<TDependencies>): Plugin => {
 
+  const server = async (server: PreviewServer | ViteDevServer) => {
+    const { fs, dependencies } = opts
+
+    const add = server.httpServer?.address() ?? ''
+    const address = {
+      address: 'localhost',
+      port: typeof add === 'string' ? server.config.server.port : add.port,
+    }
+
+    const baseUrl = `http://${address.address}:${address.port}`
+    const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
+      return [route.includes('://') ? route : `${baseUrl}${route}`, response]
+    }))
+    const fetch = createFetch({
+      dependencies,
+      fs: _fs,
+    })
+    server.middlewares.use(async (req, res, next) => {
+      try {
+        // headers can be string | string[] | undefined, not string
+        const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
+          if(typeof item !== 'undefined') {
+            prev[key] = Array.isArray(item) ? item[0] : item
+          }
+          return prev
+        }, {} as Record<string, string>)
+        const response = await fetch(`${baseUrl}${req.url ?? ''}`, {
+          method: req.method,
+          headers,
+        })
+        const type = response.headers.get('Content-Type') ?? 'application/json'
+        res.setHeader('Content-Type', type)
+        res.setHeader('Status-Code', response.headers.get('Status-Code') ?? '200')
+        const resp = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
+        if(response.headers.get('Transfer-Encoding') === 'chunked') {
+          res.write(resp)
+          res.end()
+        } else {
+          // res.removeHeader('Content-Length')
+          res.end(resp)
+        }
+      } catch (e) {
+        if (e instanceof Error && e.message.endsWith('not found')) {
+          next()
+        } else {
+          throw e
+        }
+      }
+    })
+  }
   return {
     name: 'fake-api',
-    configureServer: async (server) => {
-      const { fs, dependencies } = opts
-
-      const add = server.httpServer?.address() ?? ''
-      const address = {
-        address: 'localhost',
-        port: typeof add === 'string' ? server.config.server.port : add.port,
-      }
-
-      const baseUrl = `http://${address.address}:${address.port}`
-      const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
-        return [route.includes('://') ? route : `${baseUrl}${route}`, response]
-      }))
-      const fetch = createFetch({
-        dependencies,
-        fs: _fs,
-      })
-      server.middlewares.use(async (req, res, next) => {
-        try {
-          // headers can be string | string[] | undefined, not string
-          const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
-            if(typeof item !== 'undefined') {
-              prev[key] = Array.isArray(item) ? item[0] : item
-            }
-            return prev
-          }, {} as Record<string, string>)
-
-          const response = await fetch(`${baseUrl}${req.url ?? ''}`, {
-            method: req.method,
-            headers,
-          })
-          const type = response.headers.get('Content-Type') ?? 'application/json'
-          res.setHeader('Content-Type', type)
-          res.setHeader('Status-Code', response.headers.get('Status-Code') ?? '200')
-          const resp = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
-          if(response.headers.get('Transfer-Encoding') === 'chunked') {
-            res.write(resp)
-            res.end()
-          } else {
-            // res.removeHeader('Content-Length')
-            res.end(resp)
-          }
-        } catch (e) {
-          if (e instanceof Error && e.message.endsWith('not found')) {
-            next()
-          } else {
-            throw e
-          }
-        }
-      })
-    },
+    configureServer: server,
+    configurePreviewServer: server,
   }
 }

--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -47,7 +47,6 @@ export default <TDependencies extends object = {}>(opts: PluginOptions<TDependen
           res.write(resp)
           res.end()
         } else {
-          // res.removeHeader('Content-Length')
           res.end(resp)
         }
       } catch (e) {

--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -13,7 +13,14 @@ export default <TDependencies extends object = {}>(opts: PluginOptions<TDependen
     name: 'fake-api',
     configureServer: async (server) => {
       const { fs, dependencies } = opts
-      const baseUrl = `http://${server.config.server.host}:${server.config.server.port}`
+
+      const add = server.httpServer?.address() ?? ''
+      const address = {
+        address: 'localhost',
+        port: typeof add === 'string' ? server.config.server.port : add.port,
+      }
+
+      const baseUrl = `http://${address.address}:${address.port}`
       const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
         return [route.includes('://') ? route : `${baseUrl}${route}`, response]
       }))
@@ -31,14 +38,21 @@ export default <TDependencies extends object = {}>(opts: PluginOptions<TDependen
             return prev
           }, {} as Record<string, string>)
 
-          const response = await fetch(`http://${server.config.server.host}:${server.config.server.port}${req.url ?? ''}`, {
+          const response = await fetch(`${baseUrl}${req.url ?? ''}`, {
             method: req.method,
             headers,
           })
           const type = response.headers.get('Content-Type') ?? 'application/json'
           res.setHeader('Content-Type', type)
           res.setHeader('Status-Code', response.headers.get('Status-Code') ?? '200')
-          res.end(type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text()))
+          const resp = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
+          if(response.headers.get('Transfer-Encoding') === 'chunked') {
+            res.write(resp)
+            res.end()
+          } else {
+            // res.removeHeader('Content-Length')
+            res.end(resp)
+          }
         } catch (e) {
           if (e instanceof Error && e.message.endsWith('not found')) {
             next()

--- a/packages/gherkin-web/src/playwright/steps/index.ts
+++ b/packages/gherkin-web/src/playwright/steps/index.ts
@@ -2,13 +2,14 @@ import { createFetch } from '@kumahq/fake-api'
 import { expect } from '@playwright/test'
 import { createBdd, test as base } from 'playwright-bdd'
 
-import { getClient, YAML, merge, Cookie, routeToRegexp } from '../..'
+import { getClient, YAML, merge, routeToRegexp } from '../..'
 import type { DataTable } from '@cucumber/cucumber'
 
 type Options = {
-  negativeTimeout?: number
   dependencies: any
   fs: any
+  negativeTimeout?: number
+  passthrough?: boolean
   client?: ReturnType<typeof getClient>
 }
 
@@ -20,29 +21,23 @@ export const test = base.extend<{
   },
 })
 
-export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, client = getClient() }: Options) {
-  const _fetch = createFetch({
+export async function setupSteps({
+  dependencies,
+  fs,
+  negativeTimeout = 4000,
+  passthrough = true,
+  client = getClient(),
+}: Options) {
+  const fetch = createFetch({
     dependencies,
     fs,
   })
   const config = {
     negativeTimeout,
-    fetch: async (...rest: Parameters<typeof _fetch>) => {
-      const options = rest[1] ?? {}
-      const cookie = options?.headers?.cookie ?? ''
-      const cookies = Cookie.parse(Array.isArray(cookie) ? cookie.join('') : cookie)
-
-      const res = _fetch(...rest)
-
-      if (cookies.KUMA_LATENCY) {
-        await new Promise((resolve) => setTimeout(resolve, parseInt(cookies.KUMA_LATENCY)))
-      }
-      return res
-    },
+    fetch,
+    passthrough,
   }
   const { Given, When, Then, Before, After } = createBdd(test)
-
-  const fetch = config.fetch
 
   const timeout = (negative: boolean) => negative ? { timeout: config.negativeTimeout } : {}
 
@@ -78,6 +73,13 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
         value: 'false',
         url: `${baseURL}`,
       },
+      ...(config.passthrough ? [
+        {
+          name: 'KUMA_API_URL',
+          value: 'http://localhost:5681',
+          url: `${baseURL}`,
+        },
+      ] : []),
     ])
     const p = Object.keys(fs).map(route => {
       return context.route(
@@ -87,13 +89,11 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
             const url = request.url()
             const cookies = await context.cookies()
             const envs = Object.entries(env).map(([name, value]) => ( {name, value} ))
-            const response = await fetch(url, {
-              method: request.method(),
-              headers: {
-                cookie: [...cookies, ...envs].map((c) => `${c.name}=${c.value}`).join('; '),
-                ...request.headers(),
-              },
-            })
+            const headers = {
+              cookie: [...cookies, ...envs].map((c) => `${c.name}=${c.value}`).join('; '),
+              ...request.headers(),
+            }
+
             client.request({
               url: new URL(url),
               request: {
@@ -101,13 +101,26 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
                 body: request.postDataJSON() ?? {},
               },
             })
-            const type = response.headers.get('Content-Type') ?? 'application/json'
-            const body = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
-            await route.fulfill({
-              status: parseInt(response.headers.get('Status-Code') ?? '200'),
-              contentType: type,
-              body,
-            })
+
+            if (env.KUMA_LATENCY) {
+              await new Promise((resolve) => setTimeout(resolve, parseInt(env.KUMA_LATENCY)))
+            }
+            if(config.passthrough) {
+              await route.fallback({ headers })
+            } else {
+              const response = await fetch(url, {
+                method: request.method(),
+                headers,
+              })
+              const type = response.headers.get('Content-Type') ?? 'application/json'
+              const body = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
+              await route.fulfill({
+                status: parseInt(response.headers.get('Status-Code') ?? '200'),
+                contentType: type,
+                body,
+              })
+
+            }
           } catch (e) {
             console.error(e)
             await route.continue()
@@ -176,6 +189,9 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
               body: request.postDataJSON() ?? {},
             },
           })
+          if (env.KUMA_LATENCY) {
+            await new Promise((resolve) => setTimeout(resolve, parseInt(env.KUMA_LATENCY)))
+          }
           const type = response.headers.get('Content-Type') ?? 'application/json'
 
           const _yaml = (YAML.parse(yaml) ?? {}) as {
@@ -227,6 +243,9 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
   // TODO(jc): we can probably combine these 2 steps
   When(/^I click the "(.*)" element(?: and select "(.*)")?$/, async ({ page }, selector: string, _value?: string) => {
     const $elem = page.locator($(selector))
+    await $elem.waitFor({
+      state: 'attached',
+    })
     switch ('click') {
       case 'click':
         await $elem.dispatchEvent('click')
@@ -236,6 +255,9 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
 
   When(/^I (.*) on the "(.*)" element$/, async ({ page }, event: string, selector: string) => {
     const $elem = page.locator($(selector))
+    await $elem.waitFor({
+      state: 'attached',
+    })
     switch (event) {
       case 'hover':
         await $elem.hover({ force: true })
@@ -249,6 +271,9 @@ export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, cli
 
   When('I {string} {string} into the {string} element', async ({ page }, event: string, text: string, selector: string) => {
     const $elem = page.locator($(selector))
+    await $elem.waitFor({
+      state: 'attached',
+    })
     switch (event) {
       case 'input':
       case 'type':

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
@@ -59,7 +59,7 @@ Feature: mesh / dataplanes / overview / summary / Inbound
     And the "$protocol" element contains "HTTP"
     And the "$inbound-policies-rule" element contains "MeshFaultInjection"
     And the "$inbound-policies-rule" element contains "kri_mfi_default_pigsty_jury_innovation_appliance"
-    And the "$inbound-policies-rule [data-testid='k-code-block']" element exists
+    And the "$inbound-policies-rule table:first-of-type [data-testid='k-code-block']" element exists
 
   Scenario: Clicking on origin leads to policy detail view
     And the URL "/meshes/default/dataplanes/service-less/_layout" responds with

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/Navigation.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/Navigation.feature
@@ -3,7 +3,7 @@ Feature: zones / ingresses / navigation
   Background:
     Given the CSS selectors
       | Alias         | Selector                                                                    |
-      | row           | [data-testid$='-collection'] tr:first-child                                 |
+      | row           | [data-testid$='-collection'] tbody tr:first-child                                 |
       | action-group  | $row [data-testid='x-action-group-control']                                 |
       | view          | $row [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
       | action        | $row [data-action]                                                          |

--- a/packages/kuma-gui/src/app/kuma/debug.ts
+++ b/packages/kuma-gui/src/app/kuma/debug.ts
@@ -1,11 +1,13 @@
 import { token } from '@kumahq/container'
-import { fs } from '@kumahq/kuma-http-api/mocks'
+import { addOrigin } from '@kumahq/fake-api'
+import { fs, remote } from '@kumahq/kuma-http-api/mocks'
 
 import type { Env } from '@/app/application'
 import type { ServiceDefinition, Token } from '@kumahq/container'
 
 
 const $ = {
+  remoteFS: token<typeof remote>('fake.fs.remote'),
   kumaFS: token<typeof fs>('fake.fs.kuma'),
 }
 
@@ -28,7 +30,6 @@ export const locales = (app: Record<string, Token>): ServiceDefinition[] => [
     ],
   }],
 ]
-
 export const services = (app: Record<string, Token>): ServiceDefinition[] => [
   [token('kuma.env.vars'), {
     service: () => {
@@ -40,14 +41,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => [
       app.vars,
     ],
   }],
+  [$.remoteFS, {
+    service: () => addOrigin(remote, 'https://kuma.io'),
+    labels: [
+      app.fakeFS,
+    ],
+  }],
   [$.kumaFS, {
-    service: (env: Env) => {
-      // return fs
-      const baseURL = env('KUMA_API_URL')
-      return Object.fromEntries(Object.entries(fs).map(([route, response]) => {
-        return [route.includes('://') ? route : `${baseURL}${route}`, response]
-      }))
-    },
+    service: (env: Env) => addOrigin(fs, env('KUMA_API_URL')),
     arguments: [
       app.env,
     ],

--- a/packages/kuma-gui/vite.config.preview.ts
+++ b/packages/kuma-gui/vite.config.preview.ts
@@ -1,4 +1,6 @@
 import { replicateKumaServer } from '@kumahq/config/vite'
+import fakeApi from '@kumahq/fake-api/vite'
+import { fs, dependencies } from '@kumahq/kuma-http-api/mocks'
 import { defineConfig } from 'vite'
 
 import type { UserConfigFn } from 'vite'
@@ -12,6 +14,7 @@ export const config: UserConfigFn = () => {
       replicateKumaServer({
         template: './dist/gui/index.html',
       }),
+      fakeApi({ dependencies, fs }),
     ],
   }
 }

--- a/packages/kuma-http-api/mocks/fs.ts
+++ b/packages/kuma-http-api/mocks/fs.ts
@@ -123,6 +123,10 @@ import _50 from './src/zones/_'
 import _12 from './src/zones/_/_overview'
 import _11 from './src/zones/_overview'
 
+export const remote = {
+  // stats
+  '/latest_version': _124,
+}
 export const fs = {
   // static/testing
   '/meshes/:mesh/meshgateways/test-meshgateway': _134,
@@ -144,8 +148,6 @@ export const fs = {
   '/meshes/:mesh/dataplanes/grpc-service-75b4ccdfd5-z2jmp.kuma-demo/_rules': _630,
   '/meshes/:mesh/dataplanes/test-dataplane/_rules': _129,
   ///
-  // stats
-  'https://kuma.io/latest_version': _124,
   '/config': _1,
   '/policies': _2,
   '/global-insight': _5,

--- a/packages/kuma-http-api/mocks/index.ts
+++ b/packages/kuma-http-api/mocks/index.ts
@@ -3,7 +3,7 @@ import { base, en } from '@faker-js/faker'
 import type { Env as Keys } from './Env'
 import FakeKuma from './FakeKuma'
 export { default as FakeKuma } from './FakeKuma'
-export { fs } from './fs'
+export * from './fs'
 
 export interface RestRequest {
   method: string

--- a/packages/kuma-http-api/mocks/src/_resources.ts
+++ b/packages/kuma-http-api/mocks/src/_resources.ts
@@ -8,7 +8,9 @@ export default ({ env }: Dependencies): ResponseHandler => (_req) => {
   const resourceCount = parseInt(env('KUMA_RESOURCE_COUNT', `${resources.length}`))
 
   return {
-    headers: {},
+    headers: {
+      'Transfer-Encoding': 'chunked',
+    },
     body: {
       resources: resources.slice(0, resourceCount),
     } satisfies Resources,

--- a/packages/kuma-http-api/mocks/src/config.ts
+++ b/packages/kuma-http-api/mocks/src/config.ts
@@ -5,7 +5,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (_req) => {
   const zoneName = mode === 'zone' ? fake.word.noun() : undefined
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       access: {
         static: {

--- a/packages/kuma-http-api/mocks/src/dataplanes/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/dataplanes/_overview.ts
@@ -41,7 +41,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   }
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/global-insight.ts
+++ b/packages/kuma-http-api/mocks/src/global-insight.ts
@@ -23,6 +23,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (_req) => {
 
   return {
     headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
     },
     body: {
       createdAt: fake.kuma.nanodate(),

--- a/packages/kuma-http-api/mocks/src/hostnamegenerators.ts
+++ b/packages/kuma-http-api/mocks/src/hostnamegenerators.ts
@@ -17,7 +17,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const zoneQuery = query.get('filter[labels.kuma.io/zone]')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/hostnamegenerators/_.ts
+++ b/packages/kuma-http-api/mocks/src/hostnamegenerators/_.ts
@@ -11,44 +11,44 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const creationTime = fake.date.past()
 
-  const body = {
-    ...(req.url.searchParams.get('format') === 'kubernetes' && {
-      apiVersion: 'kuma.io/v1alpha1',
-    }),
-    type: 'HostnameGenerator',
-    name,
-    labels: k8s
-      ? {
-        'kuma.io/display-name': displayName,
-        'k8s.kuma.io/namespace': namespace,
-        'kuma.io/env': fake.kuma.env(),
-        'kuma.io/mesh': 'default',
-        'kuma.io/origin': fake.kuma.origin(),
-        'kuma.io/zone': fake.word.noun(),
-      }
-      : {},
-    spec: {
-      selector: {
-        [meshServiceTypeSelector]: {
-          matchLabels: {
-            'kuma.io/origin': fake.kuma.origin(),
-            'kuma.io/env': fake.kuma.env(),
+  return {
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
+    body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
+      type: 'HostnameGenerator',
+      name,
+      labels: k8s
+        ? {
+          'kuma.io/display-name': displayName,
+          'k8s.kuma.io/namespace': namespace,
+          'kuma.io/env': fake.kuma.env(),
+          'kuma.io/mesh': 'default',
+          'kuma.io/origin': fake.kuma.origin(),
+          'kuma.io/zone': fake.word.noun(),
+        }
+        : {},
+      spec: {
+        selector: {
+          [meshServiceTypeSelector]: {
+            matchLabels: {
+              'kuma.io/origin': fake.kuma.origin(),
+              'kuma.io/env': fake.kuma.env(),
+            },
           },
         },
+        template: fake.kuma.hostnameTemplate({
+          external: meshServiceTypeSelector === 'meshExternalService',
+          multizone: meshServiceTypeSelector === 'meshMultiZoneService',
+          withNamespace: fake.datatype.boolean(),
+          withZone: fake.datatype.boolean(),
+        }),
       },
-      template: fake.kuma.hostnameTemplate({
-        external: meshServiceTypeSelector === 'meshExternalService',
-        multizone: meshServiceTypeSelector === 'meshMultiZoneService',
-        withNamespace: fake.datatype.boolean(),
-        withZone: fake.datatype.boolean(),
-      }),
-    },
-    creationTime: creationTime.toISOString(),
-    modificationTime: fake.date.between({ from: creationTime, to: Date.now() }).toISOString(),
-  } satisfies HostnameGenerator
-
-  return {
-    headers: {},
-    body,
+      creationTime: creationTime.toISOString(),
+      modificationTime: fake.date.between({ from: creationTime, to: Date.now() }).toISOString(),
+    } satisfies HostnameGenerator,
   }
 }

--- a/packages/kuma-http-api/mocks/src/mesh-insights.ts
+++ b/packages/kuma-http-api/mocks/src/mesh-insights.ts
@@ -10,7 +10,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const nameQuery = query.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/mesh-insights/_.ts
+++ b/packages/kuma-http-api/mocks/src/mesh-insights/_.ts
@@ -58,7 +58,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const totalVersions = fake.kuma.partition(1, dpTotal, 5, dpTotal)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'MeshInsight',
       name: String(params.mesh),

--- a/packages/kuma-http-api/mocks/src/meshes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes.ts
@@ -7,7 +7,6 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
   )
   return {
     headers: {
-      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
     },
     body: {
       total,

--- a/packages/kuma-http-api/mocks/src/meshes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes.ts
@@ -6,7 +6,9 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
     '/meshes',
   )
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_.ts
@@ -24,7 +24,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const isMtlsEnabled = isMtlsEnabledOverride !== '' ? isMtlsEnabledOverride === 'true' : fake.datatype.boolean()
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/circuit-breakers.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/circuit-breakers.ts
@@ -7,11 +7,13 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
     req,
     `/meshes/${params.mesh}/circuit-breakers`,
   )
-  
+
   const queryName = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/circuit-breakers/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/circuit-breakers/_.ts
@@ -1,8 +1,10 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/circuit-breakers/_/_resources/dataplanes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/circuit-breakers/_/_resources/dataplanes.ts
@@ -9,7 +9,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
     `/meshes/${mesh}/circuit-breakers/${name}/_resources/dataplanes`,
   )
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_.ts
@@ -33,7 +33,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
 
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(k8sFormat ? {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_inbounds/_/_policies.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_inbounds/_/_policies.ts
@@ -8,7 +8,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const mesh = req.params.mesh as string
   const ruleCount = parseInt(env('KUMA_DATAPLANE_RULE_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       policies: Array.from({ length: fake.number.int({ min: 1, max: 10 })}).map(() => {
         const kind = fake.kuma.policyName()

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
@@ -44,7 +44,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const zone = fake.word.noun()
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       kri: fake.kuma.kri({
         resourceName: 'Dataplane',

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_outbounds/_/_policies.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_outbounds/_/_policies.ts
@@ -7,7 +7,9 @@ type OutboundPolicyConf = components['schemas']['PolicyConf']
 export default ({ env: _env, fake }: Dependencies): ResponseHandler => (req) => {
   const mesh = req.params.mesh as string
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       policies: Array.from({ length: fake.number.int({ min: 1, max: 10 })}).map((_, i) => {
         const kind = fake.kuma.policyName()

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -74,7 +74,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const service = fake.word.noun()
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'DataplaneOverview',
       mesh,

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_policies.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_policies.ts
@@ -7,7 +7,9 @@ type PolicyConf = components['schemas']['PolicyConf']
 export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const mesh = req.params.mesh as string
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       policies: Array.from({ length: fake.number.int({ min: 1, max: 3 })}).map((_, i) => {
         const kind = fake.kuma.policyName()

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_rules.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_rules.ts
@@ -32,7 +32,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const nspace = parts.at(-1) ?? ''
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       httpMatches: [],
       resource: {

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/clusters.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/clusters.ts
@@ -15,7 +15,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
 
   if (type === 'gateway_builtin') {
     return {
-      headers: {},
+      headers: {
+        ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+      },
       body: `meshtrace:opentelemetry::observability_name::meshtrace_opentelemetry
 meshtrace:opentelemetry::default_priority::max_connections::1024
 meshtrace:opentelemetry::default_priority::max_pending_requests::1024
@@ -310,7 +312,9 @@ ${service}::10.244.0.2:8080::success_rate::-1
 ${service}::10.244.0.2:8080::local_origin_success_rate::-1`
   }).join('\n')
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: `${inbounds}
 ${outbounds}
 access_log_sink::observability_name::access_log_sink

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/policies.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/policies.ts
@@ -5,7 +5,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
 
   if (req.params.name.includes('-builtin')) {
     return {
-      headers: {},
+      headers: {
+        ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+      },
       body: {
         kind: 'MeshGatewayDataplane',
         gateway: {
@@ -185,7 +187,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
     }
   }
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       kind: 'SidecarDataplane',
       total: 7,

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -680,6 +680,7 @@ tcp.${service}.${direction}_cx_rx_bytes_total: ${fake.number.int(minMax)}`
 
   return {
     headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
       // 'Status-Code': '500',
       'Content-Type': 'text/plain',
     },

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_overview.ts
@@ -60,7 +60,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   })()
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/external-services.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/external-services.ts
@@ -9,7 +9,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/external-services/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/external-services/_.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const name = req.params.name as string
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/fault-injections.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/fault-injections.ts
@@ -10,7 +10,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const queryName = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/fault-injections/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/fault-injections/_.ts
@@ -2,7 +2,9 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/health-checks.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/health-checks.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const queryName = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/health-checks/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/health-checks/_.ts
@@ -2,7 +2,9 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshaccesslogs.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshaccesslogs.ts
@@ -16,7 +16,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const queryNamespace = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
@@ -70,7 +72,7 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
                         path: fake.helpers.arrayElement([fake.system.directoryPath(), `${fake.system.directoryPath()}/${fake.system.fileName()}.log`]),
                       },
                     },
-                    { 
+                    {
                       type: 'OpenTelemetry' as const,
                       openTelemetry: {
                         endpoint: `otel-collector:${fake.internet.port()}`,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshaccesslogs/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshaccesslogs/_.ts
@@ -24,7 +24,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'MeshAccessLog',
       mesh,
@@ -59,7 +61,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
                     path: fake.helpers.arrayElement([fake.system.directoryPath(), `${fake.system.directoryPath()}/${fake.system.fileName()}.log`]),
                   },
                 },
-                { 
+                {
                   type: 'OpenTelemetry' as const,
                   openTelemetry: {
                     endpoint: `otel-collector:${fake.internet.port()}`,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices.ts
@@ -18,7 +18,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices/_.ts
@@ -28,7 +28,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(query.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices/_/_hostnames.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices/_/_hostnames.ts
@@ -7,23 +7,23 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const total = fake.number.int({ min: 1, max: 5 })
   const [displayName] = (req.params.serviceName as string).split('.')
 
-  const body = {
-    total,
-    items: Array.from({ length: total }).map(() => {
-      const namespace = fake.k8s.namespace()
-      const hostnameTemplate = fake.kuma.hostnameTemplate({ withNamespace: fake.datatype.boolean(), external: true })
-
-      return {
-        hostname: hostnameTemplate.replace('{{ .DisplayName }}', displayName).replace('{{ .Namespace }}', namespace),
-        zones: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(() => ({
-          name: fake.word.noun(),
-        })),
-      }
-    }),
-  } satisfies HostnamesResponse
-
   return {
-    headers: {},
-    body,
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
+    body: {
+      total,
+      items: Array.from({ length: total }).map(() => {
+        const namespace = fake.k8s.namespace()
+        const hostnameTemplate = fake.kuma.hostnameTemplate({ withNamespace: fake.datatype.boolean(), external: true })
+
+        return {
+          hostname: hostnameTemplate.replace('{{ .DisplayName }}', displayName).replace('{{ .Namespace }}', namespace),
+          zones: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(() => ({
+            name: fake.word.noun(),
+          })),
+        }
+      }),
+    } satisfies HostnamesResponse,
   }
 }

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections.ts
@@ -13,7 +13,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const queryNamespace = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections/_.ts
@@ -23,7 +23,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'MeshFaultInjection',
       mesh,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections/_/_resources/dataplanes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections/_/_resources/dataplanes.ts
@@ -1,8 +1,10 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
 
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total: 3,
       items: [

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgatewayroutes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgatewayroutes.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const queryName = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgatewayroutes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgatewayroutes/_.ts
@@ -2,7 +2,9 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways.ts
@@ -17,7 +17,9 @@ export default ({ env, fake, pager }: Dependencies): ResponseHandler => (req) =>
   const queryZone = req.url.searchParams.get('filter[labels.kuma.io/zone]')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_.ts
@@ -27,7 +27,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const listenerCount = parseInt(env('KUMA_LISTENER_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       // Just a quick, obvious way to verify the “Copy as Kubernetes” copy button functionality.
       ...(req.url.searchParams.get('format') === 'kubernetes' && {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_/_resources/dataplanes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_/_resources/dataplanes.ts
@@ -1,8 +1,10 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
 
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total: 3,
       items: [

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_/_rules.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_/_rules.ts
@@ -14,7 +14,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const ruleMatchCount = parseInt(env('KUMA_RULE_MATCH_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       resource: {
         type: 'MeshGateway',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/test-meshgateway/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/test-meshgateway/_.ts
@@ -1,12 +1,14 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
 import type { MeshGateway } from '@/types/index.d'
 
-export default (_deps: Dependencies): ResponseHandler => (req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const mesh = req.params.mesh as string
   const name = req.params.name as string
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'MeshGateway',
       mesh,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/test-meshgateway/_rules.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/test-meshgateway/_rules.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const name = req.params.name as string
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       resource: {
         mesh,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes.ts
@@ -16,7 +16,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const zoneQuery = req.url.searchParams.get('filter[labels.kuma.io/zone]')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes/_.ts
@@ -28,7 +28,9 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
 
   const ruleMatchCount = parseInt(env('KUMA_RULE_MATCH_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(k8sFormat ? {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshidentities.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshidentities.ts
@@ -14,7 +14,9 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshidentities/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshidentities/_.ts
@@ -28,7 +28,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
 
   const k8sFormat = req.url.searchParams.get('format') === 'kubernetes'
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(k8sFormat && { apiVersion: 'kuma.io/v1alpha1' }),
       ...fake.kuma.timespan(),

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshmultizoneservices.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshmultizoneservices.ts
@@ -17,7 +17,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 120 })}`))
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshmultizoneservices/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshmultizoneservices/_.ts
@@ -29,7 +29,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
 
   const k8sFormat = req.url.searchParams.get('format') === 'kubernetes'
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(k8sFormat ? {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshmultizoneservices/_/_hostnames.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshmultizoneservices/_/_hostnames.ts
@@ -7,23 +7,23 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const total = fake.number.int({ min: 1, max: 5 })
   const [displayName] = (req.params.serviceName as string).split('.')
 
-  const body = {
-    total,
-    items: Array.from({ length: total }).map(() => {
-      const namespace = fake.k8s.namespace()
-      const hostnameTemplate = fake.kuma.hostnameTemplate({ withNamespace: fake.datatype.boolean(), multizone: true })
-
-      return {
-        hostname: hostnameTemplate.replace('{{ .DisplayName }}', displayName).replace('{{ .Namespace }}', namespace),
-        zones: Array.from({ length: fake.number.int({ min: 1, max: 5 })}).map(() => ({
-          name: fake.word.noun(),
-        })),
-      }
-    }),
-  } satisfies HostnamesResponse
-
   return {
-    headers: {},
-    body,
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
+    body: {
+      total,
+      items: Array.from({ length: total }).map(() => {
+        const namespace = fake.k8s.namespace()
+        const hostnameTemplate = fake.kuma.hostnameTemplate({ withNamespace: fake.datatype.boolean(), multizone: true })
+
+        return {
+          hostname: hostnameTemplate.replace('{{ .DisplayName }}', displayName).replace('{{ .Namespace }}', namespace),
+          zones: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(() => ({
+            name: fake.word.noun(),
+          })),
+        }
+      }),
+    } satisfies HostnamesResponse,
   }
 }

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshservices.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshservices.ts
@@ -18,7 +18,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshservices/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshservices/_.ts
@@ -29,7 +29,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const proxies = fake.number.int({ min: 1, max: 120 })
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(query.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshservices/_/_hostnames.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshservices/_/_hostnames.ts
@@ -7,23 +7,23 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const total = fake.number.int({ min: 1, max: 5 })
   const [displayName] = (req.params.serviceName as string).split('.')
 
-  const body = {
-    total,
-    items: Array.from({ length: total }).map(() => {
-      const namespace = fake.k8s.namespace()
-      const hostnameTemplate = fake.kuma.hostnameTemplate({ withNamespace: fake.datatype.boolean() })
-
-      return {
-        hostname: hostnameTemplate.replace('{{ .DisplayName }}', displayName).replace('{{ .Namespace }}', namespace),
-        zones: Array.from({ length: fake.number.int({ min: 1, max: 5 })}).map(() => ({
-          name: fake.word.noun(),
-        })),
-      }
-    }),
-  } satisfies HostnamesResponse
-
   return {
-    headers: {},
-    body,
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
+    body: {
+      total,
+      items: Array.from({ length: total }).map(() => {
+        const namespace = fake.k8s.namespace()
+        const hostnameTemplate = fake.kuma.hostnameTemplate({ withNamespace: fake.datatype.boolean() })
+
+        return {
+          hostname: hostnameTemplate.replace('{{ .DisplayName }}', displayName).replace('{{ .Namespace }}', namespace),
+          zones: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(() => ({
+            name: fake.word.noun(),
+          })),
+        }
+      }),
+    } satisfies HostnamesResponse,
   }
 }

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts.ts
@@ -13,7 +13,9 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts/_.ts
@@ -28,7 +28,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
 
   const k8sFormat = req.url.searchParams.get('format') === 'kubernetes'
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(k8sFormat ? { apiVersion: 'kuma.io/v1alpha1' } : {}),
       ...fake.kuma.timespan(),

--- a/packages/kuma-http-api/mocks/src/meshes/_/proxytemplates.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/proxytemplates.ts
@@ -4,7 +4,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const total = fake.number.int(200)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/proxytemplates/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/proxytemplates/_.ts
@@ -2,7 +2,9 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/rate-limits.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/rate-limits.ts
@@ -1,7 +1,9 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total: 0,
       items: [],

--- a/packages/kuma-http-api/mocks/src/meshes/_/retries.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/retries.ts
@@ -4,7 +4,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const total = fake.number.int(200)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/service-insights.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/service-insights.ts
@@ -13,7 +13,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const serviceTypes = serviceType ? serviceType.split(',') as Array<'internal' | 'external' | 'gateway_delegated' | 'gateway_builtin'> : undefined
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/service-insights/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/service-insights/_.ts
@@ -11,7 +11,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const status = serviceType !== 'external' ? fake.kuma.serviceStatusKeyword() : undefined
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'ServiceInsight',
       mesh,

--- a/packages/kuma-http-api/mocks/src/meshes/_/timeouts.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/timeouts.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const nameQuery = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-logs.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-logs.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const nameQuery = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-logs/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-logs/_.ts
@@ -2,7 +2,9 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-permissions.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-permissions.ts
@@ -9,7 +9,9 @@ export default ({ fake, pager }: Dependencies): ResponseHandler => (req) => {
   const nameQuery = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-permissions/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-permissions/_.ts
@@ -2,7 +2,9 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-routes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-routes.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const nameQuery = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-traces.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-traces.ts
@@ -6,7 +6,9 @@ export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const nameQuery = req.url.searchParams.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/meshes/_/traffic-traces/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/traffic-traces/_.ts
@@ -1,8 +1,10 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   const params = req.params
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/meshes/_/virtual-outbounds.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/virtual-outbounds.ts
@@ -1,9 +1,11 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   const total = 0
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: total }),

--- a/packages/kuma-http-api/mocks/src/meshes/_/workloads.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/workloads.ts
@@ -11,7 +11,9 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       next,

--- a/packages/kuma-http-api/mocks/src/meshes/_/workloads/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/workloads/_.ts
@@ -28,7 +28,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const creationTime = fake.date.past()
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(k8sFormat && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/policies.ts
+++ b/packages/kuma-http-api/mocks/src/policies.ts
@@ -1,7 +1,9 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       policies: [
         {

--- a/packages/kuma-http-api/mocks/src/zone-ingresses/_.ts
+++ b/packages/kuma-http-api/mocks/src/zone-ingresses/_.ts
@@ -25,7 +25,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/zone-ingresses/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zone-ingresses/_/_overview.ts
@@ -12,7 +12,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'ZoneIngressOverview',
       name,

--- a/packages/kuma-http-api/mocks/src/zone-ingresses/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zone-ingresses/_overview.ts
@@ -12,7 +12,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
 
   const zoneName = env('KUMA_ZONE_NAME', req.url.searchParams.get('filter[labels.kuma.io/zone]') ?? 'zone-0')
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_.ts
@@ -25,7 +25,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       ...(req.url.searchParams.get('format') === 'kubernetes' && {
         apiVersion: 'kuma.io/v1alpha1',

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_/_overview.ts
@@ -12,7 +12,9 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       type: 'ZoneEgressOverview',
       name,

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_/clusters.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_/clusters.ts
@@ -70,7 +70,9 @@ ${service}::10.244.0.2:8080::success_rate::-1
 ${service}::10.244.0.2:8080::local_origin_success_rate::-1`
   }).join('\n')
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: `${inbounds}
 ${outbounds}
 access_log_sink::observability_name::access_log_sink

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_/stats.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_/stats.ts
@@ -1,7 +1,8 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
     headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
     },
     body: `${stats()}`,
   }

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_/xds.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_/xds.ts
@@ -1,7 +1,9 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       version_info: '0',
       resources: [

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_overview.ts
@@ -12,7 +12,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const nameQuery = query.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/zoneingresses/_/clusters.ts
+++ b/packages/kuma-http-api/mocks/src/zoneingresses/_/clusters.ts
@@ -70,7 +70,9 @@ ${service}::10.244.0.2:8080::success_rate::-1
 ${service}::10.244.0.2:8080::local_origin_success_rate::-1`
   }).join('\n')
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: `${inbounds}
 ${outbounds}
 access_log_sink::observability_name::access_log_sink

--- a/packages/kuma-http-api/mocks/src/zoneingresses/_/stats.ts
+++ b/packages/kuma-http-api/mocks/src/zoneingresses/_/stats.ts
@@ -1,7 +1,8 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
     headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
     },
     body: `${stats()}`,
   }

--- a/packages/kuma-http-api/mocks/src/zoneingresses/_/xds.ts
+++ b/packages/kuma-http-api/mocks/src/zoneingresses/_/xds.ts
@@ -1,7 +1,9 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-export default (_deps: Dependencies): ResponseHandler => (_req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (_req) => {
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       version_info: '0',
       resources: [

--- a/packages/kuma-http-api/mocks/src/zones.ts
+++ b/packages/kuma-http-api/mocks/src/zones.ts
@@ -8,7 +8,9 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
   )
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {

--- a/packages/kuma-http-api/mocks/src/zones/_.ts
+++ b/packages/kuma-http-api/mocks/src/zones/_.ts
@@ -1,15 +1,19 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
 
-export default (_deps: Dependencies): ResponseHandler => (req) => {
+export default ({ fake }: Dependencies): ResponseHandler => (req) => {
   switch (req.method.toUpperCase()) {
     case 'DELETE':
       return {
-        headers: {},
+        headers: {
+          ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+        },
         body: {},
       }
     default:
       return {
-        headers: {},
+        headers: {
+          ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+        },
         body: {
           type: 'Zone',
           name: req.params.name,

--- a/packages/kuma-http-api/mocks/src/zones/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zones/_/_overview.ts
@@ -9,6 +9,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
 
   return {
     headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
       'Status-Code': env('KUMA_STATUS_CODE', '200'),
     },
     body: {

--- a/packages/kuma-http-api/mocks/src/zones/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zones/_overview.ts
@@ -9,7 +9,9 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
   const nameQuery = query.get('name')
 
   return {
-    headers: {},
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {


### PR DESCRIPTION
Tweaks our vite based mock runner so we can use vite (which uses node connect http server) to serve our mocks.

Please use the below cookie config for the moment (my vite server is currently running on `:8081`)

<img width="351" height="80" alt="Screenshot 2026-05-05 at 16 49 10" src="https://github.com/user-attachments/assets/c424b1f7-bccf-42ab-9e98-d160ce07af14" />

Running our mocks in vite instead of MSW will soon become the default. MSW will only be used for our preview sites.

I probably will have a little more to write here

---

Wanted to quote this issue from a while back here:

> Whilst it doesn't have to be done here, if you have this running we may aswell not use MSW during local development work and only use it for the PR previews.

https://github.com/kumahq/kuma-gui/issues/2001
