### PR TITLE
fix(hostname-generators): amend breadcrumbs

### DIFF
--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -21,7 +21,17 @@
       })"
       v-slot="{ data: sourceData, error }"
     >
-      <AppView :docs="t('hostname-generators.href.docs')">
+      <AppView
+        :docs="t('hostname-generators.href.docs')"
+        :breadcrumbs="[
+          {
+            to: {
+              name: 'hostname-generator-list-view',
+            },
+            text: t('hostname-generators.routes.item.breadcrumbs'),
+          },
+        ]"
+      >
         <template #title>
           <DataLoader
             :data="[sourceData]"

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorRootView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorRootView.vue
@@ -1,18 +1,8 @@
 <template>
   <RouteView
     name="hostname-generator-root-view"
-    v-slot="{ t }"
   >
-    <AppView
-      :breadcrumbs="[
-        {
-          to: {
-            name: 'hostname-generator-list-view',
-          },
-          text: t('hostname-generators.routes.item.breadcrumbs'),
-        },
-      ]"
-    >
+    <AppView>
       <RouterView />
     </AppView>
   </RouteView>


### PR DESCRIPTION
Moves the HostnameGenerators into the detail route so we only get breadcrumbs on the detail page (the title acts as the "where you are" thing on the listing page.