### PR TITLE
fix: undo KSlideout z-index-ing

### DIFF
--- a/packages/x/src/components/x-drawer/XDrawer.vue
+++ b/packages/x/src/components/x-drawer/XDrawer.vue
@@ -8,6 +8,7 @@
     :max-width="props.width"
     offset-top="var(--x-drawer-offset-top, 0)"
     data-testid="summary"
+    :z-index="zIndex"
     @close="emit('close')"
   >
     <template #title>
@@ -20,6 +21,9 @@
 <script lang="ts" setup>
 import { onClickOutside, useThrottleFn } from '@vueuse/core'
 import { ref, provide, useId } from 'vue'
+
+// @ts-ignore pretend this is a number so we can pass it to KSlideout
+const zIndex: number = 'auto'
 
 const id = useId()
 provide('app-summary-view', id)

--- a/packages/x/src/components/x-drawer/XDrawer.vue
+++ b/packages/x/src/components/x-drawer/XDrawer.vue
@@ -8,7 +8,6 @@
     :max-width="props.width"
     offset-top="var(--x-drawer-offset-top, 0)"
     data-testid="summary"
-    :z-index="zIndex"
     @close="emit('close')"
   >
     <template #title>
@@ -21,9 +20,6 @@
 <script lang="ts" setup>
 import { onClickOutside, useThrottleFn } from '@vueuse/core'
 import { ref, provide, useId } from 'vue'
-
-// @ts-ignore pretend this is a number so we can pass it to KSlideout
-const zIndex: number = 'auto'
 
 const id = useId()
 provide('app-summary-view', id)
@@ -69,5 +65,8 @@ const emit = defineEmits<{
   button.slideout-close-icon {
     height: fit-content;
   }
+}
+:deep(.slideout-container) {
+  z-index: auto !important;
 }
 </style>


### PR DESCRIPTION
Undoes the z-indexing of KSlideout

Unfortunately KSlideout doesn't support specifying a z-index as `auto`, so we work around that with a bit of strange piece of TS, open to other suggestions to do the same.