### PR TITLE
fix(policies): fixes an issue with redirecting the first policy list

### DIFF
--- a/packages/kuma-gui/features/mesh/policies/Index.feature
+++ b/packages/kuma-gui/features/mesh/policies/Index.feature
@@ -5,6 +5,8 @@ Feature: mesh / policies / index
       | Alias            | Selector                                                                                 |
       | policy-type-list | [data-testid='policy-type-list']                                                         |
       | items            | [data-testid='app-collection']                                                           |
+      | dataplanes-tab   | [data-testid='data-plane-list-view-tab'] a                                               |
+      | policies-tab     | [data-testid='policy-list-index-view-tab'] a                                             |
       | detail-view      | [data-testid='policy-detail-tabs-view']                                                  |
       | items-header     | $items th                                                                                |
       | item             | $items tbody tr                                                                          |
@@ -14,6 +16,7 @@ Feature: mesh / policies / index
       | button-docs      | [data-testid='policy-documentation-link']                                                |
       | breadcrumbs      | .k-breadcrumbs                                                                           |
       | input-search     | [data-testid='filter-bar-filter-input']                                                  |
+
     And the environment
       """
       KUMA_MODE: global
@@ -44,6 +47,62 @@ Feature: mesh / policies / index
       | Value     |
       | fake-cb-1 |
     Then the URL contains "/meshes/default/policies/circuit-breakers"
+
+  Scenario: Navigating from `/dataplanes` to `/policies` redirects
+    Given the environment
+      """
+      KUMA_RESOURCE_COUNT: 2
+      """
+    Given the URL "/_resources" responds with
+      """
+      body:
+        resources:
+          - includeInFederation: true
+            name: MeshFaultInjection
+            path: meshfaultinjections
+            pluralDisplayName: Mesh Fault Injections
+            policy:
+              hasFromTargetRef: true
+              hasRulesTargetRef: true
+              hasToTargetRef: true
+              isFromAsRules: false
+              isTargetRef: true
+            readOnly: false
+            scope: Mesh
+            shortName: mfi
+            singularDisplayName: Mesh Fault Injection
+          - includeInFederation: true
+            name: MeshCircuitBreaker
+            path: meshcircuitbreakers
+            pluralDisplayName: Mesh Circuit Breakers
+            policy:
+              hasFromTargetRef: true
+              hasRulesTargetRef: true
+              hasToTargetRef: true
+              isFromAsRules: true
+              isTargetRef: true
+            readOnly: false
+            scope: Mesh
+            shortName: mcb
+            singularDisplayName: Mesh Circuit Breaker
+      """
+    And the URL "/mesh-insights/default" responds with
+      """
+      body:
+        policies:
+          MeshFaultInjection:
+            total: 0
+          MeshCircuitBreaker:
+            total: 100
+      """
+    When I visit the "/meshes/default/data-planes" URL
+    And I wait for 100 ms
+    And I click the "$policies-tab" element
+    And I wait for 100 ms
+    And I click the "$dataplanes-tab" element
+    And I wait for 100 ms
+    And I click the "$policies-tab" element
+    Then the URL contains "/meshes/default/policies/meshfaultinjections"
 
   Scenario: Listing has expected content
     When I visit the "/meshes/default/policies/circuit-breakers" URL

--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -71,7 +71,6 @@
                             :data-testid="`policy-type-link-${policyType.name}`"
                             @vue:mounted="async (vNode) => {
                               if(route.params.policyPath.length === 0 && i === 0 && vNode.props?.to) {
-                                await nextTick()
                                 route.replace(vNode.props.to)
                               }
                             }"
@@ -110,7 +109,6 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
-import { nextTick } from 'vue'
 
 import { sources as meshSources } from '@/app/meshes/sources'
 import { sources } from '@/app/policies/sources'

--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -71,6 +71,7 @@
                             :data-testid="`policy-type-link-${policyType.name}`"
                             @vue:mounted="async (vNode) => {
                               if(route.params.policyPath.length === 0 && i === 0 && vNode.props?.to) {
+                                await nextTick()
                                 route.replace(vNode.props.to)
                               }
                             }"
@@ -109,6 +110,7 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import { nextTick } from 'vue'
 
 import { sources as meshSources } from '@/app/meshes/sources'
 import { sources } from '@/app/policies/sources'

--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -69,8 +69,9 @@
                               },
                             }"
                             :data-testid="`policy-type-link-${policyType.name}`"
-                            @vue:mounted="(vNode) => {
+                            @vue:mounted="async (vNode) => {
                               if(route.params.policyPath.length === 0 && i === 0 && vNode.props?.to) {
+                                await nextTick()
                                 route.replace(vNode.props.to)
                               }
                             }"
@@ -109,6 +110,8 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import { nextTick } from 'vue'
+
 import { sources as meshSources } from '@/app/meshes/sources'
 import { sources } from '@/app/policies/sources'
 </script>


### PR DESCRIPTION
Quite a while ago we started noticing that a "policy page redirect" we have in place would no perform the intended refresh.

I'm assuming that at some point a Vue upgrade has slightly changed the behaviour here, because things had used this approach for a very long time before we started noticing the issue.

Note: we did have a test in place for this, but the test was on "initial visit", not navigating from a different page. I also found it quite difficult to reliably replicate, and the chances of replicating seemed different depending on the version of browser you are using (not totally sure on this it might have just been a feeling). I added a test that I eventually managed to get to reproduce the issue reliably. You can see in the commits that I added (and then reverted) a temporary commit to make sure that CI failed without the fix.

The fix itself is the same one we added when the new resources area (which uses the same approach) wasn't immediately working. I've used the exact same straight-forwards fix here to hopefully resolve the issue.

Closes https://github.com/kumahq/kuma-gui/issues/4775