### PR TITLE
chore(dataplanes): implements kri 'protocol' links

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -238,21 +238,27 @@
                         <dt>{{ t('data-planes.routes.item.labels') }}</dt>
                         <dd>
                           <XLayout
+                            v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
+                            :key="typeof kumaRe"
                             variant="separated"
                             truncate
                           >
-                            <template
-                              v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                              :key="typeof kumaRe"
+                            <XAction
+                              v-for="[key, value] in labels"
+                              :key="key"
+                              :href="t(`common.kri.labelHrefs.${key.replaceAll('.', '~')}`, {
+                                mesh: props.data.mesh,
+                                zone: props.data.zone,
+                                namespace: props.data.namespace,
+                                name: value,
+                              }, { defaultMessage: '' })"
                             >
                               <XBadge
-                                v-for="[key, value] in labels"
-                                :key="key"
                                 :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
                               >
                                 {{ key }}:{{ value }}
                               </XBadge>
-                            </template>
+                            </XAction>
                           </XLayout>
                         </dd>
                       </div>

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -1,4 +1,13 @@
 common:
+  kri:
+    shortNames:
+      mesh: m
+      zone: z
+      workload: wl
+    labelHrefs:
+      kuma~io/mesh: kri://kri_m____{name}_
+      kuma~io/zone: kri://kri_z____{name}_
+      kuma~io/workload: kri://kri_wl_{mesh}_{zone}_{namespace}_{name}_
   i18n:
     ignore-error: ""
   product:

--- a/packages/kuma-gui/src/app/service-mesh/index.ts
+++ b/packages/kuma-gui/src/app/service-mesh/index.ts
@@ -3,6 +3,7 @@ import { token } from '@kumahq/container'
 import X from '@kumahq/x'
 import { useLink } from 'vue-router'
 
+import type { Can } from '@/app/application'
 import { services as controlPlanes } from '@/app/control-planes'
 import { services as hostnameGenerators } from '@/app/hostname-generators'
 import { Kri } from '@/app/kuma'
@@ -10,66 +11,41 @@ import { services as me } from '@/app/me'
 import { services as meshes } from '@/app/meshes'
 import { services as zones } from '@/app/zones'
 import type { ServiceDefinition, Token } from '@kumahq/container'
-import type { Router } from 'vue-router'
 
-const findAnchor = (target: HTMLElement) => {
-  // we look for anchors, or any other element that has [data-actionable]
-  const $el = target.tagName.toLowerCase() === 'a' ? target : target.closest('a,[data-actionable]')
-  if($el) {
-    switch(true) {
-      // if its a data-action element we "bubble down" to find a child [data-action]
-      case $el.hasAttribute('data-actionable'):
-        return $el.querySelector('[data-action]')
-      // otherwise we check for rel="x-internal"
-      // which allows us to use vue-router links in our i18n locales files via
-      // <a href="http-link" rel="x-internal" />
-      // and helps us support custom protocols
-      case ($el.getAttribute('rel') ?? '').includes('x-internal'):
-        return $el
-    }
-  }
-  // anything else we do nothing special
-  return null
-}
-const protocolHandler = (router: Router, doc = document) => {
-
-  const base = router.options.history.base
-
-  const listener = (e: Event) => {
-    // if its not a user generated event return
-    // if we ever need this listener to also fire on non-user generated events
-    // we'll have to refine findAnchor and remove this
-    if(!e.isTrusted) {
-      return
-    }
-    const $a = findAnchor(e.target as HTMLElement)
-    if($a) {
-      // anything with x-internal is something for whatever reason we can't/don't want to use RouterLink
-      if (($a.getAttribute('rel') ?? '').includes('x-internal')) {
-        const href = $a.getAttribute('href')
-        if(href) {
-          e.preventDefault()
-          e.stopPropagation()
-          router.push(href.startsWith(base) ? href.substring(base.length) : href)
-        }
-      // anything else
-      } else if('click' in $a && typeof $a.click === 'function') {
-        $a.click()
-      }
-    }
-  }
-  // install
-  doc.body.addEventListener('click', listener)
-
+const protocolHandler = (can: Can) => {
   return (href: string) => {
     const kriProto = 'kri://'
     switch (true) {
       case href.startsWith(kriProto): {
-        const { mesh, name, namespace, shortName } = Kri.fromString(href.substring(kriProto.length))
+        const { mesh, name, zone, namespace, shortName } = Kri.fromString(href.substring(kriProto.length))
         const id = `${name}${namespace !== '' ? `.${namespace}`: '' }`
 
         const to = (() => {
           switch (true) {
+            case shortName === 'm':
+              return {
+                name: 'mesh-detail-view',
+                params: {
+                  mesh: name,
+                },
+              }
+            case shortName === 'z':
+              if(can('use zones')) {
+                return {
+                  name: 'zone-cp-detail-view',
+                  params: {
+                    zone: name,
+                  },
+                }
+              }
+              break
+            case shortName === 'wl':
+              return {
+                name: 'workload-detail-view',
+                params: {
+                  wl: Kri.toString({ shortName, mesh, zone, namespace, name }),
+                },
+              }
             case shortName === 'msvc':
               return {
                 name: 'mesh-service-detail-view',
@@ -113,18 +89,18 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     ...me(app),
     [token('service-mesh.plugins'), {
-      service: (i18n, router) => {
+      service: (i18n, can) => {
         return [
           [Kongponents],
           [X, {
             i18n,
-            protocolHandler: protocolHandler(router),
+            protocolHandler: protocolHandler(can),
           }],
         ]
       },
       arguments: [
         app.i18n,
-        app.router,
+        app.can,
       ],
       labels: [
         app.plugins,

--- a/packages/x/src/components/x-action/XAction.vue
+++ b/packages/x/src/components/x-action/XAction.vue
@@ -176,15 +176,83 @@
     </template>
   </template>
 </template>
+<script lang="ts">
+// eslint-disable-next-line import/order
+import SharedPool from '../../utilities/SharedPool'
+// eslint-disable-next-line import/order
+import type { Router , RouteLocationNamedRaw } from 'vue-router'
+
+const findAnchor = (target: HTMLElement) => {
+  // we look for anchors, or any other element that has [data-actionable]
+  const $el = target.tagName.toLowerCase() === 'a' ? target : target.closest('a,[data-actionable]')
+  if($el) {
+    switch(true) {
+      // if its a data-action element we "bubble down" to find a child [data-action]
+      case $el.hasAttribute('data-actionable'):
+        return $el.querySelector('[data-action]')
+      // otherwise we check for rel="x-internal"
+      // which allows us to use vue-router links in our i18n locales files via
+      // <a href="http-link" rel="x-internal" />
+      // and helps us support custom protocols
+      case ($el.getAttribute('rel') ?? '').includes('x-internal'):
+        return $el
+    }
+  }
+  // anything else we do nothing special
+  return null
+}
+const createListener = (router: Router) => {
+  return (e: Event) => {
+    // if its not a user generated event return
+    // if we ever need this listener to also fire on non-user generated events
+    // we'll have to refine findAnchor and remove this
+    if(!e.isTrusted) {
+      return
+    }
+    const $a = findAnchor(e.target as HTMLElement)
+    if($a) {
+      // anything with x-internal is something for whatever reason we can't/don't want to use RouterLink
+      if (($a.getAttribute('rel') ?? '').includes('x-internal')) {
+        const href = $a.getAttribute('href')
+        if(href) {
+          e.preventDefault()
+          e.stopPropagation()
+          const base = router.options.history.base
+          router.push(href.startsWith(base) ? href.substring(base.length) : href)
+        }
+      // anything else
+      } else if('click' in $a && typeof $a.click === 'function') {
+        $a.click()
+      }
+    }
+
+  }
+}
+const pool = new SharedPool<Router, (e: Event) => void>((state, router, item) => {
+  switch (state) {
+    case 'creating': {
+      const listener = createListener(router)
+      document.body.addEventListener('click', listener)
+      return listener
+    }
+    case 'acquiring':
+      return item
+    case 'releasing':
+      return item
+    case 'destroying':
+      document.body.removeEventListener('click', item)
+      return item
+  }
+})
+</script>
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import { KDropdownItem, KButton } from '@kong/kongponents'
-import { computed, watch, inject, provide, useAttrs } from 'vue'
+import { computed, watch, inject, provide, useAttrs, onMounted, onBeforeUnmount } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 
 import { useProtocolHandler } from '../../'
 import type { ButtonAppearance } from '@kong/kongponents'
-import type { RouteLocationNamedRaw } from 'vue-router'
 
 type BooleanLocationQueryValue = string | number | undefined | boolean
 type BooleanLocationQueryRaw = Record<string | number, BooleanLocationQueryValue | BooleanLocationQueryValue[]>
@@ -221,12 +289,16 @@ const group = inject<{
 
 const router = useRouter()
 
+const sym = Symbol('protocolHandler')
+onMounted(() => pool.acquire(router, sym))
+onBeforeUnmount(() => pool.release(router, sym))
+
 const protocolHandler = useProtocolHandler()
 const href = computed(() => props.href.includes('://') ? protocolHandler(props.href) : props.href)
 const target = computed(() => props.href.length > 0 && props.href === href.value ? '_blank' : undefined)
 const rel = computed(() => target.value === '_blank' ? 'noopener noreferrer' : href.value.length > 0 && props.href === href.value ? undefined : 'x-internal')
 
-if(href.value.length > 0 || typeof attrs.onClick === 'function' || props.for || props.to) {
+if(href.value.length > 0 || typeof attrs.onClick === 'function' || props.for || Object.keys(props.to).length) {
   provide('x-action', {})
 }
 

--- a/packages/x/src/utilities/SharedPool.ts
+++ b/packages/x/src/utilities/SharedPool.ts
@@ -1,0 +1,55 @@
+type Transition<K, T> = (state: 'creating' | 'acquiring' | 'releasing' | 'destroying', key: K, item: T) => T
+type Entry<T> = {
+  value: T
+  references: Set<symbol>
+}
+export default class SharedPool<K, T> {
+  constructor(
+    protected transition: Transition<K, T>,
+    protected pool: Map<K, Entry<T>> = new Map(),
+  ) {}
+
+  // getter, not init
+  acquire(key: K, ref: symbol): T {
+    const create = !this.pool.has(key)
+    if (create) {
+      const references = {
+        value: this.transition('creating', key, {} as T),
+        references: new Set<symbol>(),
+      }
+      this.pool.set(key, references)
+    }
+    // there is no way pool/usage.get(item) can be undefined due to using has
+    // above hence we use ! to avoid typescript
+    const item = this.pool.get(key)!
+    if (!create) {
+      this.transition('acquiring', key, item.value)
+    }
+    item.references.add(ref)
+    return item.value
+  }
+
+  // deleter
+  release(key: K, ref: symbol) {
+    if (this.pool.has(key)) {
+      // there is no way pool/usage.get(item) can be undefined due to using has
+      // above hence we use ! to avoid typescript
+      const item = this.pool.get(key)!
+      item.references.delete(ref)
+      if (item.references.size === 0) {
+        this.pool.delete(key)
+        this.transition('destroying', key, item.value)
+      } else {
+        this.transition('releasing', key, item.value)
+      }
+    }
+  }
+
+  destroy() {
+    Array.from(this.pool.entries()).forEach(([key, item]) => {
+      Array.from(item.references).forEach((ref) => {
+        this.release(key, ref)
+      })
+    })
+  }
+}


### PR DESCRIPTION
Allows us to link by full ~or partial~ KRIs i.e. `href="kri://kri_m_____default_"` etc.

<img width="1315" height="450" alt="Screenshot 2026-05-15 at 18 50 22" src="https://github.com/user-attachments/assets/d90c8ce1-aeb6-49c8-a7fe-d260aa349952" />



I've only implemented this in the non-legacy DataplaneDetailView labels for now, with an eye to using it everywhere else we use labels (or tags) following merge of this. Currently supported labels are `kuma.io/mesh`, `kuma.io/zone` and `kuma.io/workload`.

~Still a bit TBD, and there is still a little work to come on this PR but I'll add some inlines now to help review.~ I think I've finished on this now, so this is definitely good for a review now. I'd also like to use it to apply to labels on other PRs I've been using (those PRs aren't merged yet)

I thought it was useful to include the link to the original PR for protocol handlers https://github.com/kumahq/kuma-gui/pull/4256