### PR TITLE
chore(dataplanes): remove tags usage for service and protocol

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
@@ -4,6 +4,8 @@ Feature: mesh / dataplanes / overview / summary / Inbound
     Given the CSS selectors
       | Alias                  | Selector                                        |
       | summary                | [data-testid='slideout-container']              |
+      | title                  | $summary [data-testid='slideout-title']         |
+      | protocol               | $summary [data-testid='protocol']               |
       | inbound-policies-rules | $summary [data-testid='inbound-policies-rules'] |
       | inbound-policies-rule  | $inbound-policies-rules li:first-of-type        |
     And the environment
@@ -51,9 +53,8 @@ Feature: mesh / dataplanes / overview / summary / Inbound
                   kuma.io/protocol: http
       """
     When I visit the "/meshes/default/data-planes/service-less/overview/inbound/self_inbound_http/overview" URL
-    And the "$summary" element exists
-    And the "$summary" element contains "Inbound :12345"
-    And the "$summary" element contains "HTTP"
+    And the "$title" element contains "Inbound :12345"
+    And the "$protocol" element contains "HTTP"
     And the "$inbound-policies-rule" element contains "MeshFaultInjection"
     And the "$inbound-policies-rule" element contains "kri_mfi_default_pigsty_jury_innovation_appliance"
     And the "$inbound-policies-rule [data-testid='k-code-block']" element exists

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
@@ -49,8 +49,10 @@ Feature: mesh / dataplanes / overview / summary / Inbound
             inbound:
               - name: http
                 port: 12345
+                protocol: http
+      # prove that we use protocol over the tag
                 tags:
-                  kuma.io/protocol: http
+                  kuma.io/protocol: tcp
       """
     When I visit the "/meshes/default/data-planes/service-less/overview/inbound/self_inbound_http/overview" URL
     And the "$title" element contains "Inbound :12345"

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -134,7 +134,7 @@ export const DataplaneNetworking = {
             clusterName: item.servicePort && item.servicePort !== item.port ? `localhost_${item.servicePort}` : name,
             // If a health property is unset the inbound is considered healthy
             state: (typeof item.state !== 'undefined' ? String(item.state) : 'Ready'),
-            protocol: item.protocol ?? '',
+            protocol: item.protocol ?? tags['kuma.io/protocol'] ?? 'tcp',
             address,
             addressPort: `${address}:${item.port}`,
             // inbound serviceAddress, inbound address, networkingAddress because the internal services accessible address

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -44,8 +44,8 @@ const DataplaneOutbound = {
     return {
       ...item,
       tags,
-      name: tags['kuma.io/service'],
-      service: tags['kuma.io/service'],
+      // @TODO how do we get the name of the outbound?
+      name: tags['kuma.io/service'] ?? '',
       protocol: tags['kuma.io/protocol'] ?? 'tcp',
       address,
       addressPort: `${address}${typeof item.port === 'number' ? `:${item.port}` : ''}`,
@@ -99,9 +99,8 @@ export const DataplaneNetworking = {
         ? ((tags = {}) => [{
           address: networking.address ?? '',
           tags,
-          name: tags['kuma.io/service'] ?? '',
-          service: tags['kuma.io/service'] ?? '',
-          protocol: tags['kuma.io/protocol'] ?? 'tcp',
+          name: '',
+          protocol: '',
           state: 'Ready',
           // these could be filled out during 'cloning'
           // i.e. these are like template variables to be filled out
@@ -135,8 +134,7 @@ export const DataplaneNetworking = {
             clusterName: item.servicePort && item.servicePort !== item.port ? `localhost_${item.servicePort}` : name,
             // If a health property is unset the inbound is considered healthy
             state: (typeof item.state !== 'undefined' ? String(item.state) : 'Ready'),
-            service: tags['kuma.io/service'] ?? '',
-            protocol: tags['kuma.io/protocol'] ?? 'tcp',
+            protocol: '',
             address,
             addressPort: `${address}:${item.port}`,
             // inbound serviceAddress, inbound address, networkingAddress because the internal services accessible address

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -134,7 +134,7 @@ export const DataplaneNetworking = {
             clusterName: item.servicePort && item.servicePort !== item.port ? `localhost_${item.servicePort}` : name,
             // If a health property is unset the inbound is considered healthy
             state: (typeof item.state !== 'undefined' ? String(item.state) : 'Ready'),
-            protocol: '',
+            protocol: item.protocol ?? '',
             address,
             addressPort: `${address}:${item.port}`,
             // inbound serviceAddress, inbound address, networkingAddress because the internal services accessible address

--- a/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
@@ -42,19 +42,6 @@ describe('Dataplane', () => {
         expect(actual.networking.inbounds).toBeDefined()
       },
     )
-    test(
-      'dataplane.networking.inbound.service is set',
-      async ({ fixture }) => {
-        const actual = await fixture.setup((item) => {
-          return item
-        }, {
-          env: {
-            KUMA_DATAPLANEINBOUND_COUNT: '1',
-          },
-        })
-        expect(actual.networking.inbounds[0].service).toStrictEqual(actual.networking.inbounds[0].tags['kuma.io/service'])
-      },
-    )
   })
   describe('dataplane.networking.outbounds', () => {
     test(

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -129,7 +129,7 @@
                               <ul>
                                 <li
                                   v-for="inbound in unhealthyInbounds"
-                                  :key="`${inbound.service}:${inbound.port}`"
+                                  :key="`${inbound.name}:${inbound.port}`"
                                 >
                                   {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound.port }) }}
                                 </li>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -37,7 +37,7 @@
                 <XBadge
                   appearance="info"
                 >
-                  {{ t(`http.api.value.${inbound.protocol}`) }}
+                  {{ t(`http.api.value.${props.data.protocol}`) }}
                 </XBadge>
               </td>
             </tr>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -38,7 +38,7 @@
                   data-testid="protocol"
                   appearance="info"
                 >
-                  {{ t(`http.api.value.${props.data.protocol}`) }}
+                  {{ t(`http.api.value.${inbound.protocol}`) }}
                 </XBadge>
               </td>
             </tr>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -35,6 +35,7 @@
               </th>
               <td>
                 <XBadge
+                  data-testid="protocol"
                   appearance="info"
                 >
                   {{ t(`http.api.value.${props.data.protocol}`) }}

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -137,7 +137,7 @@
                             <ul>
                               <li
                                 v-for="inbound in unhealthyInbounds"
-                                :key="`${inbound.service}:${inbound.port}`"
+                                :key="`${inbound.name}:${inbound.port}`"
                               >
                                 {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound.port }) }}
                               </li>
@@ -512,17 +512,26 @@
                       if (port === String(props.data.dataplane.networking.admin?.port ?? 9901)) {
                         return prev
                       }
+                      const keys = Object.keys(value ?? {})
                       return prev.concat([
                         {
                           ...props.data.dataplane.networking.inbounds[0],
                           name: key,
                           clusterName: key,
                           port: Number(port),
-                          protocol: ['http', 'tcp'].find(item => typeof value[item] !== 'undefined') ?? 'tcp',
+                          protocol: keys.includes('grpc') ? 'grpc' : keys.includes('http') ? 'http' : 'tcp',
                           addressPort: `${props.data.dataplane.networking.inbounds[0].address}:${port}`,
                         },
                       ])
-                    }, []) : props.data.dataplane.networking.inbounds]"
+                    }, []) : props.data.dataplane.networking.inbounds.map(item => {
+                      // if http stats exist then its a http inbound
+                      // otherwise assume tcp
+                      const keys = Object.keys(traffic?.inbounds[item.name] ?? {})
+                      return {
+                        ...item,
+                        protocol: keys.includes('grpc') ? 'grpc' : keys.includes('http') ? 'http' : 'tcp',
+                      }
+                    })]"
                     :key="typeof inbounds"
                   >
                     <ConnectionGroup

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -523,15 +523,7 @@
                           addressPort: `${props.data.dataplane.networking.inbounds[0].address}:${port}`,
                         },
                       ])
-                    }, []) : props.data.dataplane.networking.inbounds.map(item => {
-                      // if http stats exist then its a http inbound
-                      // otherwise assume tcp
-                      const keys = Object.keys(traffic?.inbounds[item.name] ?? {})
-                      return {
-                        ...item,
-                        protocol: keys.includes('grpc') ? 'grpc' : keys.includes('http') ? 'http' : 'tcp',
-                      }
-                    })]"
+                    }, []) : props.data.dataplane.networking.inbounds]"
                     :key="typeof inbounds"
                   >
                     <ConnectionGroup

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_.ts
@@ -77,14 +77,16 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
                 const hasServiceAddress = fake.datatype.boolean({ probability: 0.25 })
                 const serviceAddress = hasServiceAddress ? fake.internet.ipv4() : undefined
                 const servicePort = hasServiceAddress ? fake.internet.port() : undefined
+                const protocol = fake.kuma.protocol()
                 const tags = fake.kuma.tags({
-                  protocol: fake.kuma.protocol(),
+                  protocol,
                   service: fake.kuma.serviceName(),
                   zone: multizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
                 })
 
                 return {
                   port,
+                  protocol,
                   tags,
                   ...(fake.datatype.boolean()
                     ? {

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -117,6 +117,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
               return {
                 address,
                 port: ports[i].port,
+                protocol: ports[i].protocol,
                 // these aren't synced, if they need seed syncing please move
                 // above with address
                 ...(fake.datatype.boolean() ? {

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_overview.ts
@@ -78,6 +78,7 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
         const address = fake.internet.ip()
         const zone = tags['kuma.io/zone'] ?? zoneQuery ?? fake.word.noun()
 
+
         return {
           type: 'DataplaneOverview',
           mesh,
@@ -124,8 +125,11 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
               ...(type === 'STANDARD' ? {
                 // normal proxies have inbound and outbound
                 inbound: Array.from({ length: inboundCount }).map((_) => {
+                  const protocol = fake.kuma.protocol()
+
                   return {
                     address,
+                    protocol,
                     port: fake.number.int({ min: 1, max: 65535 }),
                     ...(fake.datatype.boolean() ? {
                       serviceAddress: fake.internet.ip(),
@@ -134,7 +138,7 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
                       servicePort: fake.number.int({ min: 1, max: 65535 }),
                     } : {}),
                     tags: fake.kuma.tags({
-                      protocol: fake.kuma.protocol(),
+                      protocol,
                       service,
                       zone: multizone && fake.datatype.boolean() ? zone : undefined,
                     }),


### PR DESCRIPTION
Removes `.service` property entirely, we barely used it (only for a `:key`) and I've replaced it here with the `.name` which is equally as unique.

I also removed `.protocol` which previously was an alias to the `tags['kuma.io/protocol']` tag.

Instead of using the tag we now just look to see if there are stats for `http`, if there are then the protocol is `http`, otherwise its `tcp`. This is the exact same method we use for figuring out protocol for gateways - now we just do the same for "inbounds".

Continuation of https://github.com/kumahq/kuma-gui/issues/4570