### PR TITLE
chore(mesh-identity): data cleanup for MeshIdentity and MeshTrust

### DIFF
--- a/packages/kuma-gui/features/mesh/MeshIdentity.feature
+++ b/packages/kuma-gui/features/mesh/MeshIdentity.feature
@@ -5,6 +5,7 @@ Feature: mesh / mesh-identity
       | Alias     | Selector                           |
       | mesh-mtls | [data-testid="mesh-mtls"]          |
       | summary   | [data-testid="slideout-container"] |
+      | summary-title      | $summary [data-testid='slideout-title']  |
     And the environment
       """
       KUMA_MTLS_ENABLED: false
@@ -17,6 +18,10 @@ Feature: mesh / mesh-identity
       body:
         items:
           - name: identity-1
+            mesh: default
+            kri: kri_mid_default___identity-1_
+            labels:
+              kuma.io/display-name: identity-1
       """
     When I visit the "/meshes/default" URL
     Then the "$mesh-mtls" element exists
@@ -30,6 +35,8 @@ Feature: mesh / mesh-identity
           - name: identity-1
             mesh: default
             kri: kri_mid_default___identity-1_
+            labels:
+              kuma.io/display-name: identity-1
       """
     And the URL "/mesh-insight/default" responds with
       """
@@ -44,7 +51,7 @@ Feature: mesh / mesh-identity
     Then I click the "$mesh-mtls a:first-child" element
     Then the URL contains "/meshes/default/overview/meshidentity/kri_mid_default___identity-1_"
     And the "$summary" element exists
-    And the "$summary" element contains "identity-1"
+    And the "$summary-title" element contains "identity-1"
     And the "$summary [data-testid='k-code-block']" element exists
     And the "$summary [data-testid='k-code-block']" element contains "type: MeshIdentity"
     And the "$summary [data-testid='k-code-block']" element contains "mesh: default"

--- a/packages/kuma-gui/features/mesh/MeshTrust.feature
+++ b/packages/kuma-gui/features/mesh/MeshTrust.feature
@@ -1,4 +1,4 @@
-Feature: mesh / mesh-identity
+Feature: mesh / mesh-trust
 
   Background:
     Given the CSS selectors
@@ -6,6 +6,7 @@ Feature: mesh / mesh-identity
       | meshtrusts-listing | [data-testid="mesh-trusts-listing"] |
       | item               | $meshtrusts-listing tbody tr        |
       | summary            | [data-testid="slideout-container"]  |
+      | summary-title      | $summary [data-testid='slideout-title']  |
 
   Scenario: MeshTrusts are listed in mesh overview
     Given the URL "/meshes/default/meshtrusts" responds with
@@ -13,6 +14,10 @@ Feature: mesh / mesh-identity
       body:
         items:
           - name: trust-1
+            mesh: default
+            kri: kri_mtrust_default___trust-1_
+            labels:
+              kuma.io/display-name: trust-1
             status:
               origin:
                 kri: kri_mid_default_default_foo_bar_baz
@@ -29,6 +34,9 @@ Feature: mesh / mesh-identity
         items:
           - name: trust-1
             mesh: default
+            kri: kri_mtrust_default___trust-1_
+            labels:
+              kuma.io/display-name: trust-1
             status:
               origin:
                 kri: kri_mid_default_default_foo_bar_baz
@@ -37,7 +45,7 @@ Feature: mesh / mesh-identity
     Then I click the "$item:nth-child(1) td:first-child a" element
     Then the URL contains "/meshes/default/overview/meshtrust/kri_mtrust_default___trust-1_"
     And the "$summary" element exists
-    And the "$summary" element contains "trust-1"
+    And the "$summary-title" element contains "trust-1"
     And the "$summary [data-testid='k-code-block']" element exists
     And the "$summary [data-testid='k-code-block']" element contains "type: MeshTrust"
     And the "$summary [data-testid='k-code-block']" element contains "mesh: default"
@@ -63,8 +71,9 @@ Feature: mesh / mesh-identity
     Then I click the "$item:nth-child(1) td:nth-child(3) a" element
     Then the URL contains "/meshes/default/overview/meshidentity/kri_mid_default_default_foo_bar_baz"
     And the "$summary" element exists
-    And the "$summary" element contains "bar"
+    And the "$summary-title" element contains "bar"
     And the "$summary [data-testid='k-code-block']" element exists
     And the "$summary [data-testid='k-code-block']" element contains "type: MeshIdentity"
     And the "$summary [data-testid='k-code-block']" element contains "mesh: default"
     And the "$summary [data-testid='k-code-block']" element contains "name: bar"
+    Then pause

--- a/packages/kuma-gui/src/app/mesh-identities/data/MeshIdentity.ts
+++ b/packages/kuma-gui/src/app/mesh-identities/data/MeshIdentity.ts
@@ -14,15 +14,13 @@ export const MeshIdentity = {
     const name = labels['kuma.io/display-name'] ?? item.name
 
     return {
-      // defaults
-      kri: Kri.toString({ shortName: 'mid', mesh, zone, namespace, name }),
-      creationTime: '',
-      modificationTime: '',
-      labels,
-      // overwrite
       ...item,
+      kri: item.kri ?? Kri.toString({ shortName: 'mid', mesh, zone, namespace, name }),
       name,
       mesh,
+      labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
       // aliases
       id,
       namespace,

--- a/packages/kuma-gui/src/app/mesh-identities/data/MeshIdentity.ts
+++ b/packages/kuma-gui/src/app/mesh-identities/data/MeshIdentity.ts
@@ -6,17 +6,38 @@ export type KumaMeshIdentity = components['schemas']['MeshIdentityItem']
 
 export const MeshIdentity = {
   fromObject: (item: KumaMeshIdentity) => {
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
     return {
-      kri: Kri.toString({ shortName: 'mid', mesh: item.mesh, name: item.name}),
+      // defaults
+      kri: Kri.toString({ shortName: 'mid', mesh, zone, namespace, name }),
+      creationTime: '',
+      modificationTime: '',
+      labels,
+      // overwrite
       ...item,
+      name,
+      mesh,
+      // aliases
+      id,
+      namespace,
+      zone,
       raw: item,
+      //
     }
   },
 
   fromCollection: (collection: KumaMeshIdentityList) => {
+    const items = Array.isArray(collection.items) ? collection.items.map(MeshIdentity.fromObject) : []
     return {
       ...collection,
-      items: collection.items?.map((item) => MeshIdentity.fromObject(item)) ?? [],
+      items,
+      total: collection.total ?? items.length,
     }
   },
 }

--- a/packages/kuma-gui/src/app/mesh-identities/index.ts
+++ b/packages/kuma-gui/src/app/mesh-identities/index.ts
@@ -4,11 +4,11 @@ import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
 
 type Token = ReturnType<typeof token>
-type ResourcesSources = ReturnType<typeof sources>
+type Sources = ReturnType<typeof sources>
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
-    [token<ResourcesSources>('mesh-identities.sources'), {
+    [token<Sources>('mesh-identities.sources'), {
       service: sources,
       arguments: [
         app.api,

--- a/packages/kuma-gui/src/app/mesh-trusts/data/MeshTrust.ts
+++ b/packages/kuma-gui/src/app/mesh-trusts/data/MeshTrust.ts
@@ -6,9 +6,29 @@ export type KumaMeshTrust = components['schemas']['MeshTrustItem']
 
 export const MeshTrust = {
   fromObject: (item: KumaMeshTrust) => {
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
     return {
-      kri: Kri.toString({ shortName: 'mtrust', mesh: item.mesh, name: item.name }),
+      // defaults
+      kri: Kri.toString({ shortName: 'mtrust', mesh, zone, namespace, name }),
+      creationTime: '',
+      modificationTime: '',
+      labels,
+      // overwrite
       ...item,
+      name,
+      mesh,
+      // aliases
+      id,
+      namespace,
+      zone,
+      raw: item,
+      //
       status: {
         ...item.status,
         origin: {
@@ -16,14 +36,15 @@ export const MeshTrust = {
           kri: item.status?.origin?.kri ?? '',
         },
       },
-      raw: item,
     }
   },
 
   fromCollection: (collection: KumaMeshTrustList) => {
+    const items = Array.isArray(collection.items) ? collection.items.map(MeshTrust.fromObject) : []
     return {
       ...collection,
-      items: collection.items?.map((item) => MeshTrust.fromObject(item)) ?? [],
+      items,
+      total: collection.total ?? items.length,
     }
   },
 }

--- a/packages/kuma-gui/src/app/mesh-trusts/data/MeshTrust.ts
+++ b/packages/kuma-gui/src/app/mesh-trusts/data/MeshTrust.ts
@@ -14,15 +14,13 @@ export const MeshTrust = {
     const name = labels['kuma.io/display-name'] ?? item.name
 
     return {
-      // defaults
-      kri: Kri.toString({ shortName: 'mtrust', mesh, zone, namespace, name }),
-      creationTime: '',
-      modificationTime: '',
-      labels,
-      // overwrite
       ...item,
+      kri: item.kri ?? Kri.toString({ shortName: 'mtrust', mesh, zone, namespace, name }),
       name,
       mesh,
+      labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
       // aliases
       id,
       namespace,

--- a/packages/kuma-gui/src/app/mesh-trusts/index.ts
+++ b/packages/kuma-gui/src/app/mesh-trusts/index.ts
@@ -4,11 +4,11 @@ import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
 
 type Token = ReturnType<typeof token>
-type ResourcesSources = ReturnType<typeof sources>
+type Sources = ReturnType<typeof sources>
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
-    [token<ResourcesSources>('mesh-trusts.sources'), {
+    [token<Sources>('mesh-trusts.sources'), {
       service: sources,
       arguments: [
         app.api,

--- a/packages/kuma-http-api/mocks/FakeKuma.ts
+++ b/packages/kuma-http-api/mocks/FakeKuma.ts
@@ -178,6 +178,13 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
     return `${d.toISOString().slice(0, -5)}Z`
   }
 
+  timespan() {
+    return ((modificationTime) => ({
+      creationTime: this.date({ refDate: modificationTime }),
+      modificationTime,
+    }))(this.date())
+  }
+
   connection<T>(_: T, i: number, arr: T[]) {
     const connected = this.faker.date.past()
     const times: {
@@ -291,7 +298,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       ...additionalTags,
     }
   }
-  labels({ name, zone, namespace }: { name?: string, zone?: string, namespace?: string }): Record<string, string> {
+  labels({ name, mesh, zone, namespace, env }: { name?: string, mesh?: string, zone?: string, namespace?: string, env?: string }): Record<string, string> {
     const additional = Object.fromEntries(
       this.faker.helpers.multiple(
         () => [
@@ -331,8 +338,14 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       ...(name ? {
         'kuma.io/display-name': name,
       } : {}),
+      ...(mesh ? {
+        'kuma.io/mesh': mesh,
+      } : {}),
       ...(namespace ? {
         'k8s.kuma.io/namespace': namespace,
+      } : {}),
+      ...(env ? {
+        'kuma.io/env': env,
       } : {}),
       ...additional,
     }
@@ -546,8 +559,8 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
     return resourceNames.get(resourceName ?? this.faker.helpers.arrayElement([...resourceNames.keys()])) ?? ''
   }
 
-  kri({ resourceName, shortName, mesh, zone, namespace, name, sectionName }: Partial<{ resourceName: string, shortName: string, mesh: string, zone: string, namespace: string, name: string, sectionName: string }> = {}) {
-    return `kri_${shortName ?? this.shortName(resourceName)}_${mesh ?? this.faker.word.noun()}_${zone ?? this.faker.word.noun()}_${namespace ?? this.k8s.namespace()}_${name ?? this.faker.word.noun()}_${sectionName ?? this.faker.word.noun()}`
+  kri({ resourceName, shortName, mesh, zone, namespace, name, displayName, sectionName }: Partial<{ resourceName: string, shortName: string, mesh: string, zone: string, namespace: string, name: string, displayName: string, sectionName: string }> = {}) {
+    return `kri_${shortName ?? this.shortName(resourceName)}_${mesh ?? this.faker.word.noun()}_${zone ?? this.faker.word.noun()}_${namespace ?? this.k8s.namespace()}_${displayName ?? name ?? this.faker.word.noun()}_${sectionName ?? ''}`
   }
 
   contextualKri({ context, name }: { context: string, name: string }) {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshidentities.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshidentities.ts
@@ -1,94 +1,132 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-import type { components } from '@kumahq/kuma-http-api'
+import type { paths } from '@kumahq/kuma-http-api'
 
 
-export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
-  const params = req.params
-  const mesh = params.mesh as string
-  const itemsCount = parseInt(env('KUMA_MESHIDENTITY_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
+type MeshIdentitiesResponse = paths['/meshes/{mesh}/meshidentities']['get']['responses']['200']['content']['application/json']
+
+export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) => {
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+
+  const { offset, total, next, pageTotal } = pager(
+    env('KUMA_MESHIDENTITY_COUNT', `${fake.number.int({ min: 1, max: 3 })}`),
+    req,
+    `/meshes/${req.params.mesh}/meshidens`,
+  )
+
   return {
     headers: {},
     body: {
-      items: Array.from({ length: itemsCount }, () => ({
-        type: 'MeshIdentity',
-        mesh,
-        name: fake.word.noun(),
-        labels: {
-          'kuma.io/mesh': mesh,
-          'kuma.io/zone': fake.word.noun(),
-          'kuma.io/origin': 'zone',
-          'kuma.io/namespace': fake.word.noun(),
-        },
-        creationTime: fake.date.past().toISOString(),
-        modificationTime: fake.date.recent().toISOString(),
-        kri: fake.kuma.kri({ resourceName: 'MeshIdentity', mesh }),
-        spec: {
-          provider: {
-            bundled: {
-              autogenerate: {
-                enabled: fake.datatype.boolean(),
-              },
-              ca: {
-                certificate: {
-                  envVar: {
-                    name: fake.word.noun() + '-cert',
-                  },
-                  file: {
-                    path: `${fake.system.directoryPath()}/${fake.system.commonFileName('crt')}`,
-                  },
-                  insecureInline: {
-                    value: fake.word.noun(),
-                  },
-                  secretRef: {
-                    kind: 'Secret',
-                    name: fake.word.noun(),
-                  },
-                  type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
+      total,
+      next,
+      items: Array.from({ length: pageTotal }, (_, i) => {
+        const id = offset + i
+        const [
+          _prefix,
+          shortName,
+          mesh,
+          zone,
+          nspace,
+          displayName,
+        ] = [
+          'kri', // prefix
+          'mtrust', // shortName
+          String(req.params.mesh), // mesh
+          fake.helpers.arrayElement(['', fake.word.noun()]), // zone
+          ...([k8s ? fake.word.noun() : '', `${fake.word.noun()}-${id}`]), // nspace, displayName
+        ]
+        const name = `${displayName}${nspace ? `.${nspace}` : ''}`
+
+        return {
+          ...fake.kuma.timespan(),
+          type: 'MeshIdentity',
+          mesh,
+          name,
+          kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, displayName }),
+          labels: fake.kuma.labels({
+            name: displayName,
+            mesh,
+            env: k8s ? 'kubernetes' : 'universal',
+            ...(zone ? { zone } : {}),
+            ...(k8s ? { namespace: nspace } : {}),
+          }),
+          spec: {
+            provider: {
+              bundled: {
+                autogenerate: {
+                  enabled: fake.datatype.boolean(),
                 },
-                privateKey: {
-                  envVar: {
-                    name: fake.word.noun(),
+                ca: {
+                  certificate: {
+                    envVar: {
+                      name: fake.word.noun() + '-cert',
+                    },
+                    file: {
+                      path: `${fake.system.directoryPath()}/${fake.system.commonFileName('crt')}`,
+                    },
+                    insecureInline: {
+                      value: fake.word.noun(),
+                    },
+                    secretRef: {
+                      kind: 'Secret',
+                      name: fake.word.noun(),
+                    },
+                    type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
                   },
-                  file: {
-                    path: `${fake.system.directoryPath()}/${fake.system.commonFileName('key')}`,
+                  privateKey: {
+                    envVar: {
+                      name: fake.word.noun(),
+                    },
+                    file: {
+                      path: `${fake.system.directoryPath()}/${fake.system.commonFileName('key')}`,
+                    },
+                    insecureInline: {
+                      value: fake.word.noun(),
+                    },
+                    secretRef: {
+                      kind: 'Secret',
+                      name: fake.word.noun(),
+                    },
+                    type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
                   },
-                  insecureInline: {
-                    value: fake.word.noun(),
-                  },
-                  secretRef: {
-                    kind: 'Secret',
-                    name: fake.word.noun(),
-                  },
-                  type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
+                },
+                certificateParameters: {
+                  expiry: fake.date.soon().toISOString(),
+                },
+                insecureAllowSelfSigned: fake.datatype.boolean(),
+                meshTrustCreation: fake.helpers.arrayElement(['Enabled', 'Disabled']),
+              },
+              spire: {
+                agent: {
+                  timeout: '1s',
                 },
               },
-              certificateParameters: {
-                expiry: fake.date.soon().toISOString(),
-              },
-              insecureAllowSelfSigned: fake.datatype.boolean(),
-              meshTrustCreation: fake.helpers.arrayElement(['Enabled', 'Disabled']),
+              type: fake.helpers.arrayElement(['Bundled', 'Spire']),
             },
-            spire: {
-              agent: {
-                timeout: '1s',
-              },
-            },
-            type: fake.helpers.arrayElement(['Bundled', 'Spire']),
-          },
-          selector: {
-            dataplane: {
-              matchLabels: {
-                'kuma.io/mesh': mesh,
-                'kuma.io/zone': fake.word.noun(),
+            selector: {
+              dataplane: {
+                matchLabels: fake.kuma.labels({
+                  mesh,
+                  ...(zone ? { zone } : {}),
+                }),
               },
             },
+            spiffeID: {
+              path: '/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}',
+              trustDomain: '{{ .Mesh }}.{{ .Zone }}.mesh.local',
+            },
           },
-          spiffeID: {
-            path: fake.kuma.spiffeId({ mesh }),
-            trustDomain: fake.word.noun(),
+          status: {
+            conditions: [
+              {
+                type: 'Ready',
+                message: 'Successfully initialized',
+                reason: 'Ready',
+                status: 'True',
+              },
+            ],
           },
-        },
-      }) satisfies components['schemas']['MeshIdentityItem']),
-    },
+        }
+      }),
+    } satisfies MeshIdentitiesResponse,
   }
 }

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshidentities/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshidentities/_.ts
@@ -1,6 +1,7 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
-import type { components } from '@kumahq/kuma-http-api'
+import type { paths } from '@kumahq/kuma-http-api'
 
+type MeshIdentityResponse = paths['/meshes/{mesh}/meshidentities/{name}']['get']['responses']['200']['content']['application/json']
 
 export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
@@ -10,7 +11,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const kri = req.params.kri ? `kri_mid_${req.params.kri}` : undefined
   const [
     _prefix,
-    _shortName,
+    shortName,
     mesh,
     zone,
     nspace,
@@ -30,24 +31,25 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
     headers: {},
     body: {
       ...(k8sFormat && { apiVersion: 'kuma.io/v1alpha1' }),
-      ...(k8sFormat ? { kind: 'MeshIdentity' } : { type: 'MeshIdentity' }),
+      ...fake.kuma.timespan(),
+      type: 'MeshIdentity',
+      mesh,
+      name,
+      kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, displayName }),
       ...((() => {
         const metadata = {
           name,
           labels: {
             ...fake.kuma.labels({
               name: displayName,
+              mesh,
+              env: k8s ? 'kubernetes' : 'universal',
               ...(zone ? { zone } : {}),
               ...(k8s ? { namespace: nspace } : {}),
             }),
           }}
         return k8sFormat ? { metadata } : metadata
       })()),
-      ...(!k8sFormat && {
-        creationTime: fake.date.past().toISOString(),
-        modificationTime: fake.date.recent().toISOString(),
-      }),
-      kri: fake.kuma.kri({ resourceName: 'MeshIdentity', mesh, name }),
       spec: {
         provider: {
           bundled: {
@@ -103,17 +105,27 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
         },
         selector: {
           dataplane: {
-            matchLabels: {
-              'kuma.io/mesh': mesh,
-              'kuma.io/zone': fake.word.noun(),
-            },
+            matchLabels: fake.kuma.labels({
+              mesh,
+              ...(zone ? { zone } : {}),
+            }),
           },
         },
         spiffeID: {
-          path: fake.kuma.spiffeId({ mesh }),
-          trustDomain: fake.word.noun(),
+          path: '/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}',
+          trustDomain: '{{ .Mesh }}.{{ .Zone }}.mesh.local',
         },
-      } satisfies components['schemas']['MeshIdentityItem']['spec'],
-    },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            message: 'Successfully initialized',
+            reason: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    } satisfies MeshIdentityResponse,
   }
 }

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts.ts
@@ -3,46 +3,67 @@ import type { paths } from '@kumahq/kuma-http-api'
 
 type MeshTrustsResponse = paths['/meshes/{mesh}/meshtrusts']['get']['responses']['200']['content']['application/json']
 
-export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
-  const params = req.params
-  const mesh = params.mesh as string
+export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) => {
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
-  const itemsCount = parseInt(env('KUMA_MESHTRUST_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
-  const namespace = fake.word.noun()
-  const zone = fake.word.noun()
-  const origin = fake.kuma.origin()
+
+  const { offset, total, next, pageTotal } = pager(
+    env('KUMA_MESHTRUST_COUNT', `${fake.number.int({ min: 1, max: 3 })}`),
+    req,
+    `/meshes/${req.params.mesh}/meshtrusts`,
+  )
+
   return {
-    headers: {
-    },
+    headers: {},
     body: {
-      items: Array.from({ length: itemsCount }, () => ({
-        type: 'MeshTrust',
-        mesh,
-        name: fake.word.noun(),
-        labels: {
-          'k8s.kuma.io/namespace': namespace,
-          'kuma.io/env': k8s ? 'kubernetes' : 'universal',
-          'kuma.io/mesh': mesh,
-          'kuma.io/origin': origin,
-          ...(origin === 'zone' ? { 'kuma.io/zone': zone } : {}),
-        },
-        creationTime: fake.date.past().toISOString(),
-        modificationTime: fake.date.recent().toISOString(),
-        spec: {
-          caBundles: [{
-            pem: {
-              value: fake.kuma.certificate(false),
-            },
-            type: 'Pem',
-          }],
-          trustDomain: `${mesh}.${fake.word.noun()}.mesh.local`,
-        },
-        status: {
-          origin: {
-            kri: fake.kuma.kri({ resourceName: 'MeshIdentity', mesh, namespace, zone }),
+      total,
+      next,
+      items: Array.from({ length: pageTotal }, (_, i) => {
+        const id = offset + i
+        const [
+          _prefix,
+          shortName,
+          mesh,
+          zone,
+          nspace,
+          displayName,
+        ] = [
+          'kri', // prefix
+          'mtrust', // shortName
+          String(req.params.mesh), // mesh
+          fake.helpers.arrayElement(['', fake.word.noun()]), // zone
+          ...([k8s ? fake.word.noun() : '', `${fake.word.noun()}-${id}`]), // nspace, displayName
+        ]
+        const name = `${displayName}${nspace ? `.${nspace}` : ''}`
+
+        return {
+          ...fake.kuma.timespan(),
+          type: 'MeshTrust',
+          mesh,
+          name,
+          kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, displayName }),
+          labels: fake.kuma.labels({
+            name: displayName,
+            mesh,
+            env: k8s ? 'kubernetes' : 'universal',
+            ...(zone ? { zone } : {}),
+            ...(k8s ? { namespace: nspace } : {}),
+          }),
+          spec: {
+            caBundles: [{
+              pem: {
+                value: fake.kuma.certificate(false),
+              },
+              type: 'Pem',
+            }],
+            trustDomain: `${mesh}.${fake.word.noun()}.mesh.local`,
           },
-        },
-      })),
+          status: {
+            origin: {
+              kri: fake.kuma.kri({ resourceName: 'MeshIdentity', mesh, zone, namespace: fake.word.noun() }),
+            },
+          },
+        }
+      }),
     } satisfies MeshTrustsResponse,
   }
 }

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshtrusts/_.ts
@@ -11,7 +11,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const kri = req.params.kri ? `kri_mtrust_${req.params.kri}` : undefined
   const [
     _prefix,
-    _shortName,
+    shortName,
     mesh,
     zone,
     nspace,
@@ -25,20 +25,17 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
     ...(k8s ? String(req.params.name).split('.').toReversed() : ['', String(req.params.name)]), // nspace, displayName
   ]
   const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
-  const namespace = fake.word.noun()
 
   const k8sFormat = req.url.searchParams.get('format') === 'kubernetes'
   return {
     headers: {},
     body: {
-      ...(k8sFormat ? {
-        apiVersion: 'kuma.io/v1alpha1',
-      } : {}),
+      ...(k8sFormat ? { apiVersion: 'kuma.io/v1alpha1' } : {}),
+      ...fake.kuma.timespan(),
       type: 'MeshTrust',
       mesh,
       name,
-      creationTime: fake.date.past().toISOString(),
-      modificationTime: fake.date.recent().toISOString(),
+      kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, displayName }),
       ...((() => {
         const metadata = {
           mesh,
@@ -46,6 +43,8 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
           labels: {
             ...fake.kuma.labels({
               name: displayName,
+              mesh,
+              env: k8s ? 'kubernetes' : 'universal',
               ...(zone ? { zone } : {}),
               ...(k8s ? { namespace: nspace } : {}),
             }),
@@ -64,7 +63,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
       },
       status: {
         origin: {
-          kri: fake.kuma.kri({ resourceName: 'MeshIdentity', mesh, namespace, zone }),
+          kri: fake.kuma.kri({ resourceName: 'MeshIdentity', mesh, zone, namespace: fake.word.noun() }),
         },
       },
     } satisfies MeshTrustResponse,


### PR DESCRIPTION
Whilst looking at/investigating https://github.com/kumahq/kuma-gui/pull/4957 I noticed there were a few things I could/should amend in the MeshTrust/MeshIdentity data layer.

- Use display-name for the name
- Add an `id` (we don't need it for these resources because these use kri's but added for consistency)
- include mesh, zone, namespace and use the display-name for the default KRI (again highly unlikely this is ever used)
- default `total` in the collection
- add a bunch of "aliases" that we use for other resources

The only user facing amend here is that we no longer show `name.namespace` in the GUI for titles (and badges), instead we just show `name` (minus the `.namespace`)

---

I also then noticed that the mocks where missing quite a lot of information such as:

- KRIs
- paging (plus totals etc)
- status
- displayName labels

So I fixed that up also and updated the necessary tests.

