### PR TITLE
fix(workloads): don't render a zone link if zones aren't enabled

### DIFF
--- a/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
@@ -10,7 +10,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t, uri, can }"
   >
     <DataSource
       :src="uri(sources, '/resource/:kri', { kri: route.params.kri })"
@@ -75,7 +75,7 @@
               :end="data.modificationTime"
             />
             <XDl>
-              <div v-if="data.zone.length">
+              <div v-if="can('use zones') && data.zone.length">
                 <dt>{{ t('http.api.property.zone') }}</dt>
                 <dd>
                   <XAction

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
@@ -42,7 +42,7 @@
                 </dd>
               </div>
 
-              <div v-if="props.data.zone.length">
+              <div v-if="can('use zones') && props.data.zone.length">
                 <dt>{{ t('http.api.property.zone') }}</dt>
                 <dd>
                   <XAction


### PR DESCRIPTION
## Before

<img width="2211" height="1163" alt="Screenshot 2026-05-28 at 15 07 13" src="https://github.com/user-attachments/assets/cb6e970b-e420-4620-9bb3-defaaa70458f" />

## After

<img width="2224" height="1029" alt="Screenshot 2026-05-28 at 15 08 07" src="https://github.com/user-attachments/assets/56294723-3af8-4e8b-ba24-cf88fc6c696b" />


We noticed this is also not working properly in the new resources area so we just added a commit on the end of here to fix that also.
