### PR TITLE
feat(dataplanes): update threshold for cert expires soon warning

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
@@ -18,7 +18,7 @@ Feature: mesh / dataplanes / warnings
       KUMA_MESHSERVICE_MODE: Exclusive
       """
 
-  Scenario: With a certificate expires soon (at least 1 week before) a cert warning is shown
+  Scenario: With a certificate expires soon (at least 6 hours before) a cert warning is shown
     Given the URL "/meshes/default/dataplanes/dpp-1/_overview" responds with
       """
       body:
@@ -27,7 +27,7 @@ Feature: mesh / dataplanes / warnings
             certificateExpirationTime: 2022-10-03T12:40:13Z
             lastCertificateRegeneration: 2021-10-03T12:40:13Z
       """
-    When the date is "2022-10-02T12:40:13Z"
+    When the date is "2022-10-03T06:45:13Z"
     And I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expires-soon-cert-warning" element exists
 

--- a/packages/kuma-gui/features/mesh/legacy-dataplanes/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/legacy-dataplanes/Warnings.feature
@@ -15,7 +15,7 @@ Feature: mesh / dataplanes / warnings
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: false
       """
 
-  Scenario: With a certificate expires soon (at least 1 week before) a cert warning is shown
+  Scenario: With a certificate expires soon (at least 6 hours before) a cert warning is shown
     Given the URL "/meshes/default/dataplanes/dpp-1/_overview" responds with
       """
       body:
@@ -24,7 +24,7 @@ Feature: mesh / dataplanes / warnings
             certificateExpirationTime: 2022-10-03T12:40:13Z
             lastCertificateRegeneration: 2021-10-03T12:40:13Z
       """
-    When the date is "2022-10-02T12:40:13Z"
+    When the date is "2022-10-03T06:45:13Z"
     And I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expires-soon-cert-warning" element exists
 

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
@@ -147,8 +147,8 @@ function getIsCertExpired({ mTLS }: DataplaneInsight): boolean {
 function getIsCertExpiresSoon({ mTLS }: DataplaneInsight): boolean {
   if (!mTLS?.certificateExpirationTime) return false
   const expiryTime = new Date(mTLS.certificateExpirationTime).getTime()
-  const weekBefore = expiryTime - 3_600_000 * 24 * 7
-  return Date.now() > weekBefore && Date.now() < expiryTime
+  const expiresSoonThreshold = 1_000 * 60 * 60 * 6 // 6 hours
+  return Date.now() > expiryTime - expiresSoonThreshold && Date.now() < expiryTime
 }
 
 export type DataplaneOverview = ReturnType<typeof DataplaneOverview.fromObject>


### PR DESCRIPTION
As the default certificate expiry is currently set to 1 day, the GUI would always show a warning that the certificate expires soon when not increasing the expiration time manually. For now we've decided to change the threshold to show the warning from 1 week to 6 hours. After the backend has changed the default expiration time, the GUI may change aswell again.

Potentially it would be good to change the threshold to a relative number, like a percentage of the difference between `mTLS.certificateExpirationTime` and `mTLS.lastCertificateRegeneration` and max 7 days before 🤔 

Closes https://github.com/kumahq/kuma-gui/issues/4962