### PR TITLE
chore(deps): adds a renovate group for vue and @vue/shared

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -102,6 +102,16 @@
         "engines"
       ],
       "rangeStrategy": "bump"
+    },
+    {
+      "description": [
+        " Group vue and @vue/shared"
+      ],
+      "groupName": "vue",
+      "matchPackageNames": [
+        "vue",
+        "@vue/shared"
+      ]
     }
   ]
 }


### PR DESCRIPTION
I'm currently looking into why https://github.com/kumahq/kuma-gui/pull/4938 is failing and I noticed that https://github.com/kumahq/kuma-gui/pull/4937 was also upgrading vue/shared. Whilst I don't think it will fix the issue I have wiht the Vue upgrade, it may help if they are both upgraded at the same time, and judging by the current versions numbers being the same they should probably be upgraded at the same time anyway.

This PR adds a renovate group to group them (I asked the LLM to do it), we won't know if this works until merge.