### PR TITLE
refactor(zones,mesh-external-service): remove zone proxy related info and warnings

### DIFF
--- a/packages/kuma-gui/src/app/services/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/services/locales/en-us/index.yaml
@@ -90,6 +90,4 @@ services:
     notifications:
       mtls-warning: !!text/markdown |
         mTLS is not enabled on this mesh. <a href="{KUMA_DOCS_URL}/policies/mutual-tls/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Enable mTLS for MeshExternalService to work</a>
-      no-zone-egress: !!text/markdown |
-        There is no connected ZoneEgress in this mesh. <a href="{KUMA_DOCS_URL}/production/cp-deployment/zoneegress?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Add a ZoneEgress for MeshExternalService to work</a>
 

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
@@ -14,185 +14,166 @@
       :render="false"
       :title="t(`services.routes.mesh-external-service-list-view.title`)"
     />
-    <DataSource
-      :src="uri(egressSources, `/zone-cps/:name/egresses`, {
-        name: '*',
-      }, {
-        page: 1,
-        size: 100,
-      })"
-      v-slot="{ data: sourceEgresses }"
+    <AppView
+      :docs="t('services.mesh-external-service.href.docs')"
+      :notifications="true"
     >
-      <AppView
-        :docs="t('services.mesh-external-service.href.docs')"
-        :notifications="true"
-      >
-        <XCard>
-          <XLayout variant="y-stack">
-            <search>
-              <form
-                @submit.prevent
-              >
-                <XSearch
-                  :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
-                  :value="route.params.s"
-                  @change="(s) => route.update({ s })"
-                />
-              </form>
-            </search>
-            <DataLoader
-              :src="uri(sources, '/meshes/:mesh/mesh-external-services', {
-                mesh: route.params.mesh,
-              },{
-                page: route.params.page,
-                size: route.params.size,
-                search: route.params.s,
-              })"
-              :data="[sourceEgresses]"
-              variant="list"
-              v-slot="{ data: [data, egresses] }"
+      <XCard>
+        <XLayout variant="y-stack">
+          <search>
+            <form
+              @submit.prevent
             >
-              <XNotification
-                :notify="!props.mesh.mtlsBackend"
-                :uri="`mes-mtls-warning.${props.mesh.id}`"
-              >
-                <XI18n
-                  path="services.mesh-external-service.notifications.mtls-warning"
-                />
-              </XNotification>
-              <XNotification
-                :notify="!egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')"
-                :uri="`mes-no-zone-ingress.${props.mesh.id}`"
-              >
-                <XI18n
-                  path="services.mesh-external-service.notifications.no-zone-egress"
-                />
-              </XNotification>
-              <DataCollection
-                type="services"
+              <XSearch
+                :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : []), 'label']"
+                :value="route.params.s"
+                @change="(s) => route.update({ s })"
+              />
+            </form>
+          </search>
+          <DataLoader
+            :src="uri(sources, '/meshes/:mesh/mesh-external-services', {
+              mesh: route.params.mesh,
+            },{
+              page: route.params.page,
+              size: route.params.size,
+              search: route.params.s,
+            })"
+            variant="list"
+            v-slot="{ data: [data] }"
+          >
+            <XNotification
+              :notify="!props.mesh.mtlsBackend"
+              :uri="`mes-mtls-warning.${props.mesh.id}`"
+            >
+              <XI18n
+                path="services.mesh-external-service.notifications.mtls-warning"
+              />
+            </XNotification>
+            <DataCollection
+              type="services"
+              :items="data.items"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data.total"
+              @change="route.update"
+            >
+              <AppCollection
+                data-testid="service-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.port'), label: 'Port', key: 'port' },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
                 :items="data.items"
-                :page="route.params.page"
-                :page-size="route.params.size"
-                :total="data.total"
-                @change="route.update"
+                :is-selected-row="(item) => item.name === route.params.service"
+                @resize="me.set"
               >
-                <AppCollection
-                  data-testid="service-collection"
-                  :headers="[
-                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                    { ...me.get('headers.port'), label: 'Port', key: 'port' },
-                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="data.items"
-                  :is-selected-row="(item) => item.name === route.params.service"
-                  @resize="me.set"
+                <template #name="{ row: item }">
+                  <XCopyButton
+                    :text="item.name"
+                  >
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'mesh-external-service-summary-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                          s: route.params.s,
+                        },
+                      }"
+                    >
+                      {{ item.name }}
+                    </XAction>
+                  </XCopyButton>
+                </template>
+                <template
+                  #namespace="{ row: item }"
                 >
-                  <template #name="{ row: item }">
-                    <XCopyButton
-                      :text="item.name"
+                  {{ item.namespace }}
+                </template>
+                <template #zone="{ row: item }">
+                  <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                    <XAction
+                      v-if="item.labels['kuma.io/zone']"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: item.labels['kuma.io/zone'],
+                        },
+                      }"
                     >
-                      <XAction
-                        data-action
-                        :to="{
-                          name: 'mesh-external-service-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                            s: route.params.s,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </XCopyButton>
-                  </template>
-                  <template
-                    #namespace="{ row: item }"
-                  >
-                    {{ item.namespace }}
-                  </template>
-                  <template #zone="{ row: item }">
-                    <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
-                      <XAction
-                        v-if="item.labels['kuma.io/zone']"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: item.labels['kuma.io/zone'],
-                          },
-                        }"
-                      >
-                        {{ item.labels['kuma.io/zone'] }}
-                      </XAction>
-                    </template>
-
-                    <template v-else>
-                      {{ t('common.detail.none') }}
-                    </template>
-                  </template>
-                  <template
-                    #port="{ row: item }"
-                  >
-                    <template
-                      v-if="item.spec.match"
-                    >
-                      <KumaPort
-                        :port="item.spec.match"
-                      />
-                    </template>
+                      {{ item.labels['kuma.io/zone'] }}
+                    </XAction>
                   </template>
 
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'mesh-external-service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
+                  <template v-else>
+                    {{ t('common.detail.none') }}
                   </template>
-                </AppCollection>
-                <RouterView
-                  v-if="data.items && route.params.service"
-                  v-slot="child"
+                </template>
+                <template
+                  #port="{ row: item }"
                 >
-                  <XDrawer
-                    @close="route.replace({
-                      name: 'mesh-external-service-list-view',
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    })"
+                  <template
+                    v-if="item.spec.match"
                   >
-                    <component
-                      :is="child.Component"
-                      :items="data.items"
+                    <KumaPort
+                      :port="item.spec.match"
                     />
-                  </XDrawer>
-                </RouterView>
-              </DataCollection>
-            </DataLoader>
-          </XLayout>
-        </XCard>
-      </AppView>
-    </DataSource>
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'mesh-external-service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="data.items && route.params.service"
+                v-slot="child"
+              >
+                <XDrawer
+                  @close="route.replace({
+                    name: 'mesh-external-service-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                      s: route.params.s,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    :items="data.items"
+                  />
+                </XDrawer>
+              </RouterView>
+            </DataCollection>
+          </DataLoader>
+        </XLayout>
+      </XCard>
+    </AppView>
   </RouteView>
 </template>
 
@@ -200,7 +181,6 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import type { Mesh } from '@/app/meshes/data'
-import { sources as egressSources } from '@/app/zone-egresses/sources'
 
 const props = defineProps<{
   mesh: Mesh

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -27,15 +27,7 @@
             />
           </h1>
         </template>
-
-        <DataSource
-          :src="`/zone-ingress-overviews?page=1&size=100`"
-          @change="getIngresses"
-        />
-        <DataSource
-          :src="`/zone-egress-overviews?page=1&size=100`"
-          @change="getEgresses"
-        />
+        
         <XI18n
           path="zone-cps.routes.items.intro"
           default-path="common.i18n.ignore-error"
@@ -78,8 +70,6 @@
                     { ...me.get('headers.type'), label: '&nbsp;', key: 'type' },
                     { ...me.get('headers.name'), label: 'Name', key: 'name' },
                     { ...me.get('headers.zoneCpVersion'), label: 'Zone leader CP version', key: 'zoneCpVersion' },
-                    { ...me.get('headers.ingress'), label: 'Ingresses (online / total)', key: 'ingress' },
-                    { ...me.get('headers.egress'), label: 'Egresses (online / total)', key: 'egress' },
                     { ...me.get('headers.state'), label: 'Status', key: 'state' },
                     { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
                     { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
@@ -118,22 +108,6 @@
 
                   <template #zoneCpVersion="{ row: item }">
                     {{ get(item.zoneInsight, 'version.kumaCp.version', t('common.collection.none')) }}
-                  </template>
-
-                  <template #ingress="{ row: item }">
-                    <template
-                      v-for="proxies in [ingresses[item.name] || {online: [], offline: []}]"
-                    >
-                      {{ proxies.online.length }} / {{ proxies.online.length + proxies.offline.length }}
-                    </template>
-                  </template>
-
-                  <template #egress="{ row: item }">
-                    <template
-                      v-for="proxies in [egresses[item.name] || {online: [], offline: []}]"
-                    >
-                      {{ proxies.online.length }} / {{ proxies.online.length + proxies.offline.length }}
-                    </template>
                   </template>
 
                   <template #state="{ row: item }">
@@ -230,55 +204,12 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
-
 import { useZoneActionGroup } from '../'
 import { sources as zoneSources } from '../sources'
 import { get } from '@/app/application'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
-
-type ZoneProxies<T> = Record<string, {online: T[], offline: T[]}>
-const ingresses = ref<ZoneProxies<ZoneIngressOverview>>({})
-const egresses = ref<ZoneProxies<ZoneEgressOverview>>({})
 const ZoneActionGroup = useZoneActionGroup()
-
-const getIngresses = (data: {items: ZoneIngressOverview[]}) => {
-  const prop = 'zoneIngress'
-  ingresses.value = data.items.reduce((prev, item) => {
-    const name = item[prop]?.zone
-    if (typeof name !== 'undefined') {
-      if (typeof prev[name] === 'undefined') {
-        prev[name] = {
-          online: [],
-          offline: [],
-        }
-      }
-      const state = typeof item[`${prop}Insight`].connectedSubscription !== 'undefined' ? 'online' : 'offline'
-      prev[name][state].push(item)
-    }
-    return prev
-  }, {} as ZoneProxies<ZoneIngressOverview>)
-}
-const getEgresses = (data: {items: ZoneEgressOverview[]}) => {
-  const prop = 'zoneEgress'
-  egresses.value = data.items.reduce((prev, item) => {
-    const name = item[prop]?.zone
-    if (typeof name !== 'undefined') {
-      if (typeof prev[name] === 'undefined') {
-        prev[name] = {
-          online: [],
-          offline: [],
-        }
-      }
-      const state = typeof item[`${prop}Insight`].connectedSubscription !== 'undefined' ? 'online' : 'offline'
-      prev[name][state].push(item)
-    }
-    return prev
-  }, {} as ZoneProxies<ZoneEgressOverview>)
-}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
With the new mesh-scoped zone-proxies we can't easily and reliably tell if there are any zone-ingresses and zone-egresses. Therefore we've decided to remove the columns from the zones listing and the warning from the `MeshExternalService` listing.

Closes https://github.com/kumahq/kuma-gui/issues/4881