### PR TITLE
refactor(dataplanes): reword and highlight warning about reachable backends/services

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -1,11 +1,11 @@
 data-planes:
   notifications:
     recommend-reachable: !!text/markdown |
-      We've identified outbound services that would benefit from using { mode, select,
+      To ensure optimal performance and resource usage, this data plane proxy should be configured with { mode, select,
         Exclusive { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
         ReachableBackends { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
         other { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a> }
-      } to dramatically improve performance.
+      } for its outbound services.
     dp-cp-incompatible: !!text/markdown |
       Unsupported version of Kuma DP (**{ kumaDp }**)
     envoy-dp-incompatible: !!text/markdown |

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -723,6 +723,21 @@
                             Non mesh traffic
                           </ConnectionCard>
                         </ConnectionGroup>
+                        <template
+                          v-for="direction in ['upstream'] as const"
+                          :key="direction"
+                        >
+                          <XNotification
+                            :notify="!!Object.values(traffic?.outbounds ?? {}).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
+                            variant="warning"
+                            :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
+                          >
+                            <XI18n
+                              path="data-planes.notifications.recommend-reachable"
+                              :params="{ mode: props.mesh.meshServices.mode }"
+                            />
+                          </XNotification>
+                        </template>
                         <DataCollection
                           type="outbounds"
                           :items="dataplaneLayout.outbounds"

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -710,7 +710,7 @@
                       >
                         <XNotification
                           :notify="!!Object.values(traffic.outbounds).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
-                          variant="info"
+                          variant="warning"
                           :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
                         >
                           <XI18n


### PR DESCRIPTION
This PR

- changes the depiction of the `recommend-reachable` notification from info to warning
- changes the wording to make this more a requirement than an info
- adds the warning also to the new dataplane detail view, it was currently only shown in legacy

Closes https://github.com/kumahq/kuma-gui/issues/4904