### PR TITLE
refactor(mesh): make routes injectable

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/index.ts
+++ b/packages/kuma-gui/src/app/data-planes/index.ts
@@ -14,13 +14,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     // TODO: Uncomment once the legacy routes are removed
     // [token('data-planes.routes'), {
     //   service: () => {
+    //     const _routes = routes()
     //     return [
     //       (item: RouteRecordRaw) => {
     //         if (item.name === 'mesh-detail-tabs-view') {
-    //           item.children = (item.children ?? []).concat(routes().items())
+    //           item.children = (item.children ?? []).concat(_routes.items())
     //         }
     //         if(item.name === 'mesh') {
-    //           item.children = (item.children ?? []).concat(routes().item())
+    //           item.children = (item.children ?? []).concat(_routes.item())
     //         }
     //       },
     //     ]

--- a/packages/kuma-gui/src/app/data-planes/index.ts
+++ b/packages/kuma-gui/src/app/data-planes/index.ts
@@ -14,10 +14,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     // TODO: Uncomment once the legacy routes are removed
     // [token('data-planes.routes'), {
     //   service: () => {
-    //     return [routes()]
+    //     return [
+    //       (item: RouteRecordRaw) => {
+    //         if (item.name === 'mesh-detail-tabs-view') {
+    //           item.children = (item.children ?? []).concat(routes().items())
+    //         }
+    //         if(item.name === 'mesh') {
+    //           item.children = (item.children ?? []).concat(routes().item())
+    //         }
+    //       },
+    //     ]
     //   },
     //   labels: [
-    //     app.routes,
+    //     app.routeWalkers,
     //   ],
     // }],
     [token<DataplaneSources>('data-planes.sources'), {

--- a/packages/kuma-gui/src/app/gateways/index.ts
+++ b/packages/kuma-gui/src/app/gateways/index.ts
@@ -4,6 +4,7 @@ import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 export * from './routes'
 
 type Token = ReturnType<typeof token>
@@ -21,10 +22,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('gateway.routes'), {
       service: () => {
-        return [routes()]
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'mesh-detail-tabs-view') {
+              item.children = (item.children ?? []).concat(routes().items())
+            }
+            if(item.name === 'mesh') {
+              item.children = (item.children ?? []).concat(routes().item())
+            }
+          },
+        ]
       },
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('gateway.locales'), {

--- a/packages/kuma-gui/src/app/gateways/index.ts
+++ b/packages/kuma-gui/src/app/gateways/index.ts
@@ -22,13 +22,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('gateway.routes'), {
       service: () => {
+        const _routes = routes()
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {
-              item.children = (item.children ?? []).concat(routes().items())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
             if(item.name === 'mesh') {
-              item.children = (item.children ?? []).concat(routes().item())
+              item.children = (item.children ?? []).concat(_routes.item())
             }
           },
         ]

--- a/packages/kuma-gui/src/app/legacy-data-planes/index.ts
+++ b/packages/kuma-gui/src/app/legacy-data-planes/index.ts
@@ -11,13 +11,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('legacy.data-planes.routes'), {
       service: () => {
+        const _routes = routes()
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {
-              item.children = (item.children ?? []).concat(routes().items())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
             if(item.name === 'mesh') {
-              item.children = (item.children ?? []).concat(routes().item())
+              item.children = (item.children ?? []).concat(_routes.item())
             }
           },
         ]

--- a/packages/kuma-gui/src/app/legacy-data-planes/index.ts
+++ b/packages/kuma-gui/src/app/legacy-data-planes/index.ts
@@ -3,6 +3,7 @@ import { token } from '@kumahq/container'
 import { routes } from './routes'
 import { services as connections } from '@/app/connections'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -10,10 +11,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('legacy.data-planes.routes'), {
       service: () => {
-        return [routes()]
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'mesh-detail-tabs-view') {
+              item.children = (item.children ?? []).concat(routes().items())
+            }
+            if(item.name === 'mesh') {
+              item.children = (item.children ?? []).concat(routes().item())
+            }
+          },
+        ]
       },
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     ...connections(app),

--- a/packages/kuma-gui/src/app/legacy-data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/legacy-data-planes/routes.ts
@@ -1,5 +1,4 @@
 import { routes as connections, networking } from '@/app/connections/routes'
-import { routes as meshIdentity } from '@/app/mesh-identities/routes'
 import { routes as meshTrust } from '@/app/mesh-trusts/routes'
 import { routes as subscriptions } from '@/app/subscriptions/routes'
 import type { RouteRecordRaw } from 'vue-router'
@@ -88,7 +87,6 @@ export const legacyDataplaneRoutes = (): RouteRecordRaw[] => {
               name: 'data-plane-policy-config-summary-view',
               component: () => import('@/app/data-planes/views/DataplanePolicyConfigSummaryView.vue'),
             },
-            ...meshIdentity().summary('data-plane'),
             ...meshTrust().summary('data-plane'),
           ],
         },

--- a/packages/kuma-gui/src/app/legacy-data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/legacy-data-planes/routes.ts
@@ -1,4 +1,5 @@
 import { routes as connections, networking } from '@/app/connections/routes'
+import { routes as meshIdentity } from '@/app/mesh-identities/routes'
 import { routes as meshTrust } from '@/app/mesh-trusts/routes'
 import { routes as subscriptions } from '@/app/subscriptions/routes'
 import type { RouteRecordRaw } from 'vue-router'
@@ -87,6 +88,7 @@ export const legacyDataplaneRoutes = (): RouteRecordRaw[] => {
               name: 'data-plane-policy-config-summary-view',
               component: () => import('@/app/data-planes/views/DataplanePolicyConfigSummaryView.vue'),
             },
+            ...meshIdentity().summary('data-plane'),
             ...meshTrust().summary('data-plane'),
           ],
         },

--- a/packages/kuma-gui/src/app/meshes/index.ts
+++ b/packages/kuma-gui/src/app/meshes/index.ts
@@ -5,19 +5,7 @@ import MeshInsightsList from './components/MeshInsightsList.vue'
 import MeshStatus from './components/MeshStatus.vue'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
-import type { SplitRouteRecordRaw } from './routes'
 import { sources } from './sources'
-import { services as dataplanes } from '@/app/data-planes'
-import { services as externalServicesModule } from '@/app/external-services'
-import { services as gatewaysModule } from '@/app/gateways'
-import { services as legacyDataplanes } from '@/app/legacy-data-planes'
-import { services as meshIdentities } from '@/app/mesh-identities'
-import { services as meshTrusts } from '@/app/mesh-trusts'
-import { services as policies } from '@/app/policies'
-import { services as resources } from '@/app/resources'
-import { services as rules } from '@/app/rules'
-import { services as servicesModule } from '@/app/services'
-import { services as workloads } from '@/app/workloads'
 import type { ServiceDefinition } from '@kumahq/container'
 import type { RouteRecordRaw } from 'vue-router'
 
@@ -31,10 +19,6 @@ const $ = {
 }
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
-  const mesh = {
-    ...app,
-    routes: token<SplitRouteRecordRaw[]>('meshes.routes.children'),
-  }
   return [
     [$.MeshInsightsList, {
       service: () => {
@@ -57,18 +41,15 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
     }],
     [token('meshes.routes'), {
-      service: (r) => {
+      service: () => {
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'control-plane-root-view') {
-              item.children = (item.children ?? []).concat(routes(r[0], r[1], r[2], r[3], r[4], r[5]))
+              item.children = (item.children ?? []).concat(routes())
             }
           },
         ]
       },
-      arguments: [
-        mesh.routes,
-      ],
       labels: [
         app.routeWalkers,
       ],
@@ -79,17 +60,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.enUs,
       ],
     }],
-    ...servicesModule(mesh),
-    ...externalServicesModule(mesh),
-    ...gatewaysModule(mesh),
-    ...dataplanes(mesh),
-    ...legacyDataplanes(mesh),
-    ...policies(mesh),
-    ...rules(mesh),
-    ...workloads(mesh),
-    ...meshIdentities(mesh),
-    ...meshTrusts(mesh),
-    ...resources(mesh),
   ]
 }
 export const TOKENS = $

--- a/packages/kuma-gui/src/app/meshes/routes.ts
+++ b/packages/kuma-gui/src/app/meshes/routes.ts
@@ -7,14 +7,7 @@ export type SplitRouteRecordRaw = {
   item: () => RouteRecordRaw[]
 }
 
-export const routes = (
-  services: SplitRouteRecordRaw,
-  gateways: SplitRouteRecordRaw,
-  dataplanes: SplitRouteRecordRaw,
-  policies: SplitRouteRecordRaw,
-  workloads: SplitRouteRecordRaw,
-  resources: SplitRouteRecordRaw,
-): RouteRecordRaw[] => {
+export const routes = (): RouteRecordRaw[] => {
   return [
     {
       path: 'meshes',
@@ -47,20 +40,8 @@ export const routes = (
                     ...meshTrust().summary('mesh'),
                   ],
                 },
-                ...services.items(),
-                ...workloads.items(),
-                ...gateways.items(),
-                ...dataplanes.items(),
-                ...policies.items(),
-                ...resources.items(),
               ],
             },
-            ...services.item(),
-            ...gateways.item(),
-            ...dataplanes.item(),
-            ...policies.item(),
-            ...workloads.item(),
-            ...resources.item(),
           ],
         },
       ],

--- a/packages/kuma-gui/src/app/policies/index.ts
+++ b/packages/kuma-gui/src/app/policies/index.ts
@@ -28,13 +28,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('policies.routes'), {
       service: () => {
+        const _routes = routes()
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {
-              item.children = (item.children ?? []).concat(routes().items())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
             if(item.name === 'mesh') {
-              item.children = (item.children ?? []).concat(routes().item())
+              item.children = (item.children ?? []).concat(_routes.item())
             }
           },
         ]

--- a/packages/kuma-gui/src/app/policies/index.ts
+++ b/packages/kuma-gui/src/app/policies/index.ts
@@ -5,6 +5,7 @@ import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -27,10 +28,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('policies.routes'), {
       service: () => {
-        return [routes()]
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'mesh-detail-tabs-view') {
+              item.children = (item.children ?? []).concat(routes().items())
+            }
+            if(item.name === 'mesh') {
+              item.children = (item.children ?? []).concat(routes().item())
+            }
+          },
+        ]
       },
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('policies.locales'), {

--- a/packages/kuma-gui/src/app/resources/index.ts
+++ b/packages/kuma-gui/src/app/resources/index.ts
@@ -4,6 +4,7 @@ import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 type ResourcesSources = ReturnType<typeof sources>
@@ -21,10 +22,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('resources.routes'), {
       service: () => {
-        return [routes()]
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'mesh-detail-tabs-view') {
+              item.children = (item.children ?? []).concat(routes().items())
+            }
+            if(item.name === 'mesh') {
+              item.children = (item.children ?? []).concat(routes().item())
+            }
+          },
+        ]
       },
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('resources.locales'), {

--- a/packages/kuma-gui/src/app/resources/index.ts
+++ b/packages/kuma-gui/src/app/resources/index.ts
@@ -22,13 +22,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('resources.routes'), {
       service: () => {
+        const _routes = routes()
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {
-              item.children = (item.children ?? []).concat(routes().items())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
             if(item.name === 'mesh') {
-              item.children = (item.children ?? []).concat(routes().item())
+              item.children = (item.children ?? []).concat(_routes.item())
             }
           },
         ]

--- a/packages/kuma-gui/src/app/services/index.ts
+++ b/packages/kuma-gui/src/app/services/index.ts
@@ -23,13 +23,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('services.routes'), {
       service: (can: Can) => {
+        const _routes = routes(can)
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {
-              item.children = (item.children ?? []).concat(routes(can).items())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
             if(item.name === 'mesh') {
-              item.children = (item.children ?? []).concat(routes(can).item())
+              item.children = (item.children ?? []).concat(_routes.item())
             }
           },
         ]

--- a/packages/kuma-gui/src/app/services/index.ts
+++ b/packages/kuma-gui/src/app/services/index.ts
@@ -6,6 +6,7 @@ import { routes } from './routes'
 import { sources } from './sources'
 import type { Can } from '@/app/application'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -22,13 +23,22 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('services.routes'), {
       service: (can: Can) => {
-        return [routes(can)]
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'mesh-detail-tabs-view') {
+              item.children = (item.children ?? []).concat(routes(can).items())
+            }
+            if(item.name === 'mesh') {
+              item.children = (item.children ?? []).concat(routes(can).item())
+            }
+          },
+        ]
       },
       arguments: [
         app.can,
       ],
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('services.features'), {

--- a/packages/kuma-gui/src/app/workloads/index.ts
+++ b/packages/kuma-gui/src/app/workloads/index.ts
@@ -5,6 +5,7 @@ import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -12,10 +13,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('workloads.routes'), {
       service: () => {
-        return [routes()]
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'mesh-detail-tabs-view') {
+              item.children = (item.children ?? []).concat(routes().items())
+            }
+            if(item.name === 'mesh') {
+              item.children = (item.children ?? []).concat(routes().item())
+            }
+          },
+        ]
       },
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('workloads.sources'), {

--- a/packages/kuma-gui/src/app/workloads/index.ts
+++ b/packages/kuma-gui/src/app/workloads/index.ts
@@ -13,13 +13,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('workloads.routes'), {
       service: () => {
+        const _routes = routes()
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {
-              item.children = (item.children ?? []).concat(routes().items())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
             if(item.name === 'mesh') {
-              item.children = (item.children ?? []).concat(routes().item())
+              item.children = (item.children ?? []).concat(_routes.item())
             }
           },
         ]

--- a/packages/kuma-gui/src/main.ts
+++ b/packages/kuma-gui/src/main.ts
@@ -6,9 +6,20 @@ import { createApp } from 'vue'
 
 import { services as application, TOKENS as APPLICATION } from '@/app/application'
 import { services as configuration } from '@/app/configuration'
+import { services as dataplanes } from '@/app/data-planes'
+import { services as externalServices } from '@/app/external-services'
+import { services as gateways } from '@/app/gateways'
 import { TOKENS } from '@/app/kuma'
+import { services as legacyDataplanes } from '@/app/legacy-data-planes'
+import { services as meshIdentities } from '@/app/mesh-identities'
+import { services as meshTrusts } from '@/app/mesh-trusts'
+import { services as policies } from '@/app/policies'
+import { services as resources } from '@/app/resources'
+import { services as rules } from '@/app/rules'
 import { services as serviceMesh } from '@/app/service-mesh'
+import { services as services } from '@/app/services'
 import { services as vue, TOKENS as VUE } from '@/app/vue'
+import { services as workloads } from '@/app/workloads'
 
 async function mountVueApplication() {
   const $ = {
@@ -33,6 +44,17 @@ async function mountVueApplication() {
       ...$,
       routes: $.routesLabel,
     }),
+    services($),
+    externalServices($),
+    gateways($),
+    dataplanes($),
+    legacyDataplanes($),
+    workloads($),
+    policies($),
+    resources($),
+    rules($),
+    meshIdentities($),
+    meshTrusts($),
 
     // any DEV-time only service container configuration
     import.meta.env.MODE !== 'production'


### PR DESCRIPTION
See title

---

There are some more dependencies left-over in routes, such as `meshIdentity.summary` which I will address in follow-ups.