### PR TITLE
chore(kri): finishing touches to KRI label links and rollout to details

### DIFF
--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -84,6 +84,7 @@ const $ = {
   errorHandler: token<(e: Error) => void>('application.error.handler'),
 
   i18n: token<{t: ReturnType<typeof I18n>['t']}>('i18n'),
+  regexp: token<{r: (str: string) => RegExp}>('i18n'),
   enUs: token('i18n.locale.enUs'),
 
   storage: token<ReturnType<typeof storage>>('application.storage'),
@@ -131,10 +132,10 @@ const addRouteName = (item: RouteRecordRaw) => {
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('application.plugins'), {
-      service: (dataSourcePool, can, env, i18n) => {
+      service: (dataSourcePool, can, env, i18n, regexp) => {
         return [
           [Data, { dataSourcePool }],
-          [Routing, { can, env, i18n }],
+          [Routing, { can, env, i18n, regexp}],
         ]
       },
       arguments: [
@@ -142,6 +143,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         $.can,
         $.env,
         $.i18n,
+        $.regexp,
       ],
       labels: [
         app.plugins,
@@ -203,6 +205,16 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         $.enUs,
         app.env,
       ],
+    }],
+    [$.regexp, {
+      service: () => {
+        // @TODO regexps will move to locales/yaml
+        const re = new Map<string, RegExp>([
+          ['kuma.label', /^(.+\.)?kuma\.io\//],
+        ])
+        //
+        return { r: (str: string) => re.has(str) ? re.get(str) : new RegExp('') }
+      },
     }],
 
     [$.fetch, {
@@ -275,11 +287,13 @@ export const [
   useEnv,
   useCan,
   useI18n,
+  useRegExp,
   useDataEmptyState,
 ] = createInjections(
   $.env,
   $.can,
   $.i18n,
+  $.regexp,
   $.DataEmptyState,
 )
 export { YAML, get } from './utilities'

--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -210,6 +210,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: () => {
         // @TODO regexps will move to locales/yaml
         const re = new Map<string, RegExp>([
+          // NOTE: regexp for kuma labels only
+          // we don't use this for matching URLs
+          // only to color labels grey or blue (currently)
           ['kuma.label', /^(.+\.)?kuma\.io\//],
         ])
         //

--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
@@ -7,10 +7,21 @@
         class="aside"
       >
         <slot name="aside">
-          <TagList
+          <XAction
             v-if="props.service.length > 0"
-            :tags="[{label: 'kuma.io/service', value: props.service}]"
-          />
+            :href="t(`common.label.href.${`kuma.io/service`.replaceAll('.', '~')}`, {
+              mesh: '',
+              zone: '',
+              namespace: '',
+              name: props.service.replaceAll('_', '~'),
+            }, { defaultMessage: '' })"
+          >
+            <XBadge
+              variant="kuma-label"
+            >
+              kuma.io/service:<strong>{{ props.service }}</strong>
+            </XBadge>
+          </XAction>
         </slot>
       </div>
       <div class="title">
@@ -176,7 +187,6 @@ import formatBytes from 'pretty-bytes'
 
 import { useI18n } from '@/app/application'
 import DataCard from '@/app/common/data-card/DataCard.vue'
-import TagList from '@/app/common/TagList.vue'
 const { t } = useI18n()
 const props = withDefaults(defineProps<{
   protocol: string

--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
@@ -17,7 +17,7 @@
             }, { defaultMessage: '' })"
           >
             <XBadge
-              variant="kuma-label"
+              variant="reserved-kv"
             >
               kuma.io/service:<strong>{{ props.service }}</strong>
             </XBadge>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -7,7 +7,7 @@
       proxyType: '',
     }"
     name="data-plane-detail-view"
-    v-slot="{ route, t, can, uri }"
+    v-slot="{ route, t, can, uri, r }"
   >
     <DataSource
       :src="uri(connectionSources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
@@ -217,6 +217,32 @@
                         />
                       </dd>
                     </div>
+                    <div v-if="Object.keys(props.data.labels).length > 0">
+                      <dt>{{ t('data-planes.routes.item.labels') }}</dt>
+                      <dd>
+                        <XLayout
+                          variant="separated"
+                        >
+                          <XAction
+                            v-for="(value, key) in props.data.labels"
+                            :key="key"
+                            :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                              mesh: props.data.mesh,
+                              zone: props.data.zone,
+                              namespace: props.data.namespace,
+                              name: value,
+                            }, { defaultMessage: '' })"
+                          >
+                            <XBadge
+                              :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            >
+                              {{ key }}:<strong>{{ value }}</strong>
+                            </XBadge>
+                          </XAction>
+                        </XLayout>
+                      </dd>
+                    </div>
+                    <!-- @TODO gateways don't use this view at the moment, but we want move away from the legacy view -->
                     <div
                       v-if="props.data.dataplane.networking.gateway"
                     >
@@ -224,45 +250,29 @@
                         {{ t('http.api.property.tags') }}
                       </dt>
                       <dd>
-                        <TagList
-                          :tags="props.data.dataplane.networking.gateway.tags"
-                        />
+                        <XLayout
+                          variant="separated"
+                        >
+                          <XAction
+                            v-for="(value, key) in props.data.dataplane.networking.gateway.tags"
+                            :key="key"
+                            :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                              mesh: props.data.mesh,
+                              zone: props.data.zone,
+                              namespace: props.data.namespace,
+                              name: value.replaceAll('_', '~'),
+                            }, { defaultMessage: '' })"
+                          >
+                            <XBadge
+                              :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            >
+                              {{ key }}:<strong>{{ value }}</strong>
+                            </XBadge>
+                          </XAction>
+                        </XLayout>
                       </dd>
                     </div>
-
-                    <template
-                      v-for="labels in [Object.entries(props.data.labels)]"
-                      :key="typeof labels"
-                    >
-                      <div v-if="labels.length > 0">
-                        <dt>{{ t('data-planes.routes.item.labels') }}</dt>
-                        <dd>
-                          <XLayout
-                            v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                            :key="typeof kumaRe"
-                            variant="separated"
-                            truncate
-                          >
-                            <XAction
-                              v-for="[key, value] in labels"
-                              :key="key"
-                              :href="t(`common.kri.labelHrefs.${key.replaceAll('.', '~')}`, {
-                                mesh: props.data.mesh,
-                                zone: props.data.zone,
-                                namespace: props.data.namespace,
-                                name: value,
-                              }, { defaultMessage: '' })"
-                            >
-                              <XBadge
-                                :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                              >
-                                {{ key }}:{{ value }}
-                              </XBadge>
-                            </XAction>
-                          </XLayout>
-                        </dd>
-                      </div>
-                    </template>
+                    <!-- -->
                   </XDl>
 
                   <XLayout
@@ -994,7 +1004,6 @@ import { ref } from 'vue'
 
 import { sources } from '../sources'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import TagList from '@/app/common/TagList.vue'
 import ConnectionCard from '@/app/connections/components/connection-traffic/ConnectionCard.vue'
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -234,7 +234,7 @@
                             }, { defaultMessage: '' })"
                           >
                             <XBadge
-                              :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                              :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                             >
                               {{ key }}:<strong>{{ value }}</strong>
                             </XBadge>
@@ -264,7 +264,7 @@
                             }, { defaultMessage: '' })"
                           >
                             <XBadge
-                              :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                              :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                             >
                               {{ key }}:<strong>{{ value }}</strong>
                             </XBadge>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -743,7 +743,7 @@
                                       </template>
 
                                       <template #body>
-                                        <XBadge variant="decorative">
+                                        <XBadge appearance="decorative">
                                           {{ item.type }}
                                         </XBadge>
                                       </template>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -49,7 +49,7 @@
                     }, { defaultMessage: '' })"
                   >
                     <XBadge
-                      :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                      :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                     >
                       {{ key }}:<strong>{{ value }}</strong>
                     </XBadge>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -6,7 +6,7 @@
       connection: '',
     }"
     :name="props.routeName"
-    v-slot="{ t, route, uri }"
+    v-slot="{ t, route, uri, r }"
   >
     <AppView>
       <XLayout variant="y-stack">
@@ -35,10 +35,26 @@
                 Tags
               </th>
               <td>
-                <TagList
-                  :tags="inbound.tags"
-                  alignment="right"
-                />
+                <XLayout
+                  variant="separated"
+                >
+                  <XAction
+                    v-for="(value, key) in inbound.tags"
+                    :key="key"
+                    :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                      mesh: '',
+                      zone: '',
+                      namespace: '',
+                      name: value.replaceAll('_', '~'),
+                    }, { defaultMessage: '' })"
+                  >
+                    <XBadge
+                      :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                    >
+                      {{ key }}:<strong>{{ value }}</strong>
+                    </XBadge>
+                  </XAction>
+                </XLayout>
               </td>
             </tr>
             <tr v-if="inbound.protocol.length > 0">
@@ -215,7 +231,6 @@ import { DataplaneNetworkingLayout, DataplaneOverview } from '../data'
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import TagList from '@/app/common/TagList.vue'
 import { Kri } from '@/app/kuma'
 import { sources as policySources } from '@/app/policies/sources'
 

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, uri, can }"
+    v-slot="{ route, t, uri, can, r }"
   >
     <DataCollection
       :items="props.items"
@@ -183,18 +183,22 @@
                       <XLayout
                         variant="separated"
                       >
-                        <template
-                          v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                          :key="typeof kumaRe"
+                        <XAction
+                          v-for="(value, key) in item.labels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: item.mesh,
+                            zone: item.zone,
+                            namespace: item.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
                         >
                           <XBadge
-                            v-for="(value, key) in item.labels"
-                            :key="key"
-                            :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
+                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                           >
-                            {{ key }}:{{ value }}
+                            {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>
-                        </template>
+                        </XAction>
                       </XLayout>
                     </td>
                   </tr>
@@ -216,10 +220,26 @@
                         {{ t('http.api.property.tags') }}
                       </th>
                       <td>
-                        <TagList
-                          alignment="right"
-                          :tags="item.dataplane.networking.gateway.tags"
-                        />
+                        <XLayout
+                          variant="separated"
+                        >
+                          <XAction
+                            v-for="(value, key) in item.dataplane.networking.gateway.tags"
+                            :key="key"
+                            :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                              mesh: item.mesh,
+                              zone: item.zone,
+                              namespace: item.namespace,
+                              name: value.replaceAll('_', '~'),
+                            }, { defaultMessage: '' })"
+                          >
+                            <XBadge
+                              :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            >
+                              {{ key }}:<strong>{{ value }}</strong>
+                            </XBadge>
+                          </XAction>
+                        </XLayout>
                       </td>
                     </tr>
                     <tr>
@@ -290,10 +310,26 @@
                             {{ t('http.api.property.tags') }}
                           </th>
                           <td>
-                            <TagList
-                              alignment="right"
-                              :tags="inbound.tags"
-                            />
+                            <XLayout
+                              variant="separated"
+                            >
+                              <XAction
+                                v-for="(value, key) in inbound.tags"
+                                :key="key"
+                                :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                                  mesh: item.mesh,
+                                  zone: item.zone,
+                                  namespace: item.namespace,
+                                  name: value.replaceAll('_', '~'),
+                                }, { defaultMessage: '' })"
+                              >
+                                <XBadge
+                                  :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                                >
+                                  {{ key }}:<strong>{{ value }}</strong>
+                                </XBadge>
+                              </XAction>
+                            </XLayout>
                           </td>
                         </tr>
                         <tr>
@@ -345,10 +381,26 @@
                             {{ t('http.api.property.tags') }}
                           </th>
                           <td>
-                            <TagList
-                              alignment="right"
-                              :tags="outbound.tags"
-                            />
+                            <XLayout
+                              variant="separated"
+                            >
+                              <XAction
+                                v-for="(value, key) in outbound.tags"
+                                :key="key"
+                                :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                                  mesh: item.mesh,
+                                  zone: item.zone,
+                                  namespace: item.namespace,
+                                  name: value.replaceAll('_', '~'),
+                                }, { defaultMessage: '' })"
+                              >
+                                <XBadge
+                                  :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                                >
+                                  {{ key }}:<strong>{{ value }}</strong>
+                                </XBadge>
+                              </XAction>
+                            </XLayout>
                           </td>
                         </tr>
                         <tr>
@@ -414,7 +466,6 @@
 import { DataplaneOverview } from '../data'
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import TagList from '@/app/common/TagList.vue'
 
 const props = defineProps<{
   items: DataplaneOverview[]

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -194,7 +194,7 @@
                           }, { defaultMessage: '' })"
                         >
                           <XBadge
-                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                           >
                             {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>
@@ -234,7 +234,7 @@
                             }, { defaultMessage: '' })"
                           >
                             <XBadge
-                              :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                              :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                             >
                               {{ key }}:<strong>{{ value }}</strong>
                             </XBadge>
@@ -324,7 +324,7 @@
                                 }, { defaultMessage: '' })"
                               >
                                 <XBadge
-                                  :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                                  :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                                 >
                                   {{ key }}:<strong>{{ value }}</strong>
                                 </XBadge>
@@ -395,7 +395,7 @@
                                 }, { defaultMessage: '' })"
                               >
                                 <XBadge
-                                  :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                                  :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                                 >
                                   {{ key }}:<strong>{{ value }}</strong>
                                 </XBadge>

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       environment: String,
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t, uri, r }"
   >
     <AppView>
       <DataSource
@@ -53,10 +53,26 @@
                   {{ t('http.api.property.tags') }}
                 </dt>
                 <dd>
-                  <TagList
-                    :tags="service.tags"
-                    should-truncate
-                  />
+                  <XLayout
+                    variant="separated"
+                  >
+                    <XAction
+                      v-for="(value, key) in service.tags"
+                      :key="key"
+                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                        mesh: '',
+                        zone: '',
+                        namespace: '',
+                        name: value.replaceAll('_', '~'),
+                      }, { defaultMessage: '' })"
+                    >
+                      <XBadge
+                        :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                      >
+                        {{ key }}:<strong>{{ value }}</strong>
+                      </XBadge>
+                    </XAction>
+                  </XLayout>
                 </dd>
               </div>
             </XDl>
@@ -148,5 +164,4 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import TagList from '@/app/common/TagList.vue'
 </script>

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
@@ -67,7 +67,7 @@
                       }, { defaultMessage: '' })"
                     >
                       <XBadge
-                        :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                       >
                         {{ key }}:<strong>{{ value }}</strong>
                       </XBadge>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -8,7 +8,7 @@
       codeRegExp: false,
       environment: String,
     }"
-    v-slot="{ route, t, uri, can }"
+    v-slot="{ route, t, uri, can, r }"
   >
     <RouteTitle
       :title="t('hostname-generators.routes.items.title')"
@@ -122,13 +122,13 @@
                       <dd>
                         <XLayout
                           variant="separated"
-                          truncate
                         >
                           <XBadge
-                            v-for="([label, value], index) in Object.entries(labels)"
-                            :key="`${label}${value}${index}`"
+                            v-for="([key, value], index) in Object.entries(labels)"
+                            :key="`${key}${value}${index}`"
+                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                           >
-                            {{ label }}:{{ value }}
+                            {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>
                         </XLayout>
                       </dd>
@@ -136,33 +136,31 @@
                   </XDl>
                 </template>
                 <XDl>
-                  <template
-                    v-for="labels in [Object.entries(data.labels)]"
-                    :key="typeof labels"
-                  >
-                    <div v-if="labels.length">
-                      <dt>{{ t('hostname-generators.routes.item.labels') }}</dt>
-                      <dd>
-                        <XLayout
-                          variant="separated"
-                          truncate
+                  <div v-if="Object.keys(data.labels).length">
+                    <dt>{{ t('hostname-generators.routes.item.labels') }}</dt>
+                    <dd>
+                      <XLayout
+                        variant="separated"
+                      >
+                        <XAction
+                          v-for="(value, key) in data.labels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: '',
+                            zone: data.zone,
+                            namespace: data.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
                         >
-                          <template
-                            v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                            :key="typeof kumaRe"
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                           >
-                            <XBadge
-                              v-for="[key, value] in labels"
-                              :key="key"
-                              :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                            >
-                              {{ key }}:{{ value }}
-                            </XBadge>
-                          </template>
-                        </XLayout>
-                      </dd>
-                    </div>
-                  </template>
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
+                      </XLayout>
+                    </dd>
+                  </div>
                 </XDl>
               </XLayout>
             </DataLoader>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -126,7 +126,7 @@
                           <XBadge
                             v-for="([key, value], index) in Object.entries(labels)"
                             :key="`${key}${value}${index}`"
-                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                           >
                             {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>
@@ -153,7 +153,7 @@
                           }, { defaultMessage: '' })"
                         >
                           <XBadge
-                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                           >
                             {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -1,13 +1,15 @@
 common:
+  label:
+    href:
+      kuma~io/mesh: kri://kri_m____{name}_
+      kuma~io/zone: kri://kri_z____{name}_
+      kuma~io/workload: kri://kri_wl_{mesh}_{zone}_{namespace}_{name}_
+      kuma~io/service: kri://kri_~port_{mesh}_{zone}_{namespace}_{name}_
   kri:
     shortNames:
       mesh: m
       zone: z
       workload: wl
-    labelHrefs:
-      kuma~io/mesh: kri://kri_m____{name}_
-      kuma~io/zone: kri://kri_z____{name}_
-      kuma~io/workload: kri://kri_wl_{mesh}_{zone}_{namespace}_{name}_
   i18n:
     ignore-error: ""
   product:

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -4,7 +4,7 @@ common:
       kuma~io/mesh: kri://kri_m____{name}_
       kuma~io/zone: kri://kri_z____{name}_
       kuma~io/workload: kri://kri_wl_{mesh}_{zone}_{namespace}_{name}_
-      kuma~io/service: kri://kri_~port_{mesh}_{zone}_{namespace}_{name}_
+      kuma~io/service: kri://kri_~hostport_{mesh}_{zone}_{namespace}_{name}_
   kri:
     shortNames:
       mesh: m

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -8,7 +8,7 @@
       subscription: '',
     }"
     name="data-plane-detail-view"
-    v-slot="{ route, t, can, uri }"
+    v-slot="{ route, t, can, uri, r }"
   >
     <DataSource
       :src="uri(connectionSources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
@@ -204,6 +204,33 @@
                       />
                     </dd>
                   </div>
+
+                  <div v-if="Object.keys(props.data.labels).length > 0">
+                    <dt>{{ t('data-planes.routes.item.labels') }}</dt>
+                    <dd>
+                      <XLayout
+                        variant="separated"
+                      >
+                        <XAction
+                          v-for="(value, key) in props.data.labels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: props.data.mesh,
+                            zone: props.data.zone,
+                            namespace: props.data.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
+                        >
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                          >
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
+                      </XLayout>
+                    </dd>
+                  </div>
+
                   <div
                     v-if="props.data.dataplane.networking.gateway"
                   >
@@ -211,39 +238,28 @@
                       {{ t('http.api.property.tags') }}
                     </dt>
                     <dd>
-                      <TagList
-                        :tags="props.data.dataplane.networking.gateway.tags"
-                      />
+                      <XLayout
+                        variant="separated"
+                      >
+                        <XAction
+                          v-for="(value, key) in props.data.dataplane.networking.gateway.tags"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: props.data.mesh,
+                            zone: props.data.zone,
+                            namespace: props.data.namespace,
+                            name: value.replaceAll('_', '~'),
+                          }, { defaultMessage: '' })"
+                        >
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                          >
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
+                      </XLayout>
                     </dd>
                   </div>
-
-                  <template
-                    v-for="labels in [Object.entries(props.data.labels)]"
-                    :key="typeof labels"
-                  >
-                    <div v-if="labels.length > 0">
-                      <dt>{{ t('data-planes.routes.item.labels') }}</dt>
-                      <dd>
-                        <XLayout
-                          variant="separated"
-                          truncate
-                        >
-                          <template
-                            v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                            :key="typeof kumaRe"
-                          >
-                            <XBadge
-                              v-for="[key, value] in labels"
-                              :key="key"
-                              :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                            >
-                              {{ key }}:{{ value }}
-                            </XBadge>
-                          </template>
-                        </XLayout>
-                      </dd>
-                    </div>
-                  </template>
                 </XDl>
 
                 <XLayout
@@ -859,7 +875,6 @@
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import TagList from '@/app/common/TagList.vue'
 import ConnectionCard from '@/app/connections/components/connection-traffic/ConnectionCard.vue'
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -222,7 +222,7 @@
                           }, { defaultMessage: '' })"
                         >
                           <XBadge
-                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                           >
                             {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>
@@ -252,7 +252,7 @@
                           }, { defaultMessage: '' })"
                         >
                           <XBadge
-                            :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                           >
                             {{ key }}:<strong>{{ value }}</strong>
                           </XBadge>

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -6,7 +6,7 @@
       connection: '',
     }"
     :name="props.routeName"
-    v-slot="{ t, route, uri }"
+    v-slot="{ t, route, uri, r }"
   >
     <AppView>
       <XLayout
@@ -22,10 +22,26 @@
               Tags
             </th>
             <td>
-              <TagList
-                :tags="props.data.tags"
-                alignment="right"
-              />
+              <XLayout
+                variant="separated"
+              >
+                <XAction
+                  v-for="(value, key) in props.data.tags"
+                  :key="key"
+                  :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                    mesh: '',
+                    zone: '',
+                    namespace: '',
+                    name: value.replaceAll('_', '~'),
+                  }, { defaultMessage: '' })"
+                >
+                  <XBadge
+                    :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                  >
+                    {{ key }}:<strong>{{ value }}</strong>
+                  </XBadge>
+                </XAction>
+              </XLayout>
             </td>
           </tr>
           <tr>
@@ -213,7 +229,6 @@
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import TagList from '@/app/common/TagList.vue'
 import type { DataplaneInbound } from '@/app/data-planes/data'
 import { sources as policySources } from '@/app/policies/sources'
 import RuleMatchers from '@/app/rules/components/RuleMatchers.vue'

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -36,7 +36,7 @@
                   }, { defaultMessage: '' })"
                 >
                   <XBadge
-                    :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                    :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                   >
                     {{ key }}:<strong>{{ value }}</strong>
                   </XBadge>

--- a/packages/kuma-gui/src/app/meshes/components/MeshStatus.vue
+++ b/packages/kuma-gui/src/app/meshes/components/MeshStatus.vue
@@ -117,7 +117,7 @@
                 }, { defaultMessage: '' })"
               >
                 <XBadge
-                  :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                  :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                 >
                   {{ key }}:<strong>{{ value }}</strong>
                 </XBadge>

--- a/packages/kuma-gui/src/app/meshes/components/MeshStatus.vue
+++ b/packages/kuma-gui/src/app/meshes/components/MeshStatus.vue
@@ -100,43 +100,44 @@
           </dd>
         </div>
 
-        <template
-          v-for="labels in [Object.entries(props.mesh.labels)]"
-          :key="typeof labels"
-        >
-          <div v-if="labels.length > 0">
-            <dt>{{ t('services.routes.item.labels') }}</dt>
-            <dd>
-              <XLayout
-                variant="separated"
-                truncate
+        <div v-if="Object.keys(props.mesh.labels).length > 0">
+          <dt>{{ t('services.routes.item.labels') }}</dt>
+          <dd>
+            <XLayout
+              variant="separated"
+            >
+              <XAction
+                v-for="(value, key) in props.mesh.labels"
+                :key="key"
+                :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                  mesh: '',
+                  zone: '',
+                  namespace: '',
+                  name: value,
+                }, { defaultMessage: '' })"
               >
-                <template
-                  v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                  :key="typeof kumaRe"
+                <XBadge
+                  :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                 >
-                  <XBadge
-                    v-for="[key, value] in labels"
-                    :key="key"
-                    :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                  >
-                    {{ key }}:{{ value }}
-                  </XBadge>
-                </template>
-              </XLayout>
-            </dd>
-          </div>
-        </template>
+                  {{ key }}:<strong>{{ value }}</strong>
+                </XBadge>
+              </XAction>
+            </XLayout>
+          </dd>
+        </div>
       </XDl>
     </XCard>
   </XI18n>
 </template>
 <script lang="ts" setup>
 import type { Mesh } from '../data'
+import { useRegExp } from '@/app/application'
 import type { MeshIdentity } from '@/app/mesh-identities/data'
 const props = defineProps<{
   mesh: Mesh
   meshIdentities: MeshIdentity[]
   policies?: Record<string, { total: number }>
 }>()
+
+const { r } = useRegExp()
 </script>

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
@@ -10,7 +10,7 @@
       policyPath: '',
       proxy: '',
     }"
-    v-slot="{ route, t, uri, can, me }"
+    v-slot="{ route, t, uri, can, me, r }"
   >
     <AppView>
       <XCard
@@ -84,33 +84,31 @@
               </dd>
             </div>
 
-            <template
-              v-for="labels in [Object.entries(policy.labels)]"
-              :key="typeof labels"
-            >
-              <div v-if="labels.length > 0">
-                <dt>{{ t('policies.routes.item.labels') }}</dt>
-                <dd>
-                  <XLayout
-                    variant="separated"
-                    truncate
+            <div v-if="Object.keys(policy.labels).length > 0">
+              <dt>{{ t('policies.routes.item.labels') }}</dt>
+              <dd>
+                <XLayout
+                  variant="separated"
+                >
+                  <XAction
+                    v-for="(value, key) in policy.labels"
+                    :key="key"
+                    :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                      mesh: policy.mesh,
+                      zone: policy.zone,
+                      namespace: policy.namespace,
+                      name: value,
+                    }, { defaultMessage: '' })"
                   >
-                    <template
-                      v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                      :key="typeof kumaRe"
+                    <XBadge
+                      :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                     >
-                      <XBadge
-                        v-for="[key, value] in labels"
-                        :key="key"
-                        :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                      >
-                        {{ key }}:{{ value }}
-                      </XBadge>
-                    </template>
-                  </XLayout>
-                </dd>
-              </div>
-            </template>
+                      {{ key }}:<strong>{{ value }}</strong>
+                    </XBadge>
+                  </XAction>
+                </XLayout>
+              </dd>
+            </div>
           </XDl>
         </DataLoader>
       </XCard>

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
@@ -101,7 +101,7 @@
                     }, { defaultMessage: '' })"
                   >
                     <XBadge
-                      :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                      :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                     >
                       {{ key }}:<strong>{{ value }}</strong>
                     </XBadge>

--- a/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
@@ -116,7 +116,7 @@
                       }, { defaultMessage: '' })"
                     >
                       <XBadge
-                        :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                       >
                         {{ key }}:<strong>{{ value }}</strong>
                       </XBadge>

--- a/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
@@ -10,7 +10,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t, uri, can }"
+    v-slot="{ route, t, uri, can, r }"
   >
     <DataSource
       :src="uri(sources, '/resource/:kri', { kri: route.params.kri })"
@@ -99,33 +99,31 @@
                 </dd>
               </div>
 
-              <template
-                v-for="labels in [Object.entries(data.labels)]"
-                :key="typeof labels"
-              >
-                <div v-if="labels.length > 0">
-                  <dt>{{ t('resources.routes.item.about.labels') }}</dt>
-                  <dd>
-                    <XLayout
-                      variant="separated"
-                      truncate
+              <div v-if="Object.keys(data.labels).length > 0">
+                <dt>{{ t('resources.routes.item.about.labels') }}</dt>
+                <dd>
+                  <XLayout
+                    variant="separated"
+                  >
+                    <XAction
+                      v-for="(value, key) in data.labels"
+                      :key="key"
+                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                        mesh: data.mesh,
+                        zone: data.zone,
+                        namespace: data.namespace,
+                        name: value,
+                      }, { defaultMessage: '' })"
                     >
-                      <template
-                        v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                        :key="typeof kumaRe"
+                      <XBadge
+                        :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                       >
-                        <XBadge
-                          v-for="[key, value] in labels"
-                          :key="key"
-                          :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                        >
-                          {{ key }}:{{ value }}
-                        </XBadge>
-                      </template>
-                    </XLayout>
-                  </dd>
-                </div>
-              </template>
+                        {{ key }}:<strong>{{ value }}</strong>
+                      </XBadge>
+                    </XAction>
+                  </XLayout>
+                </dd>
+              </div>
             </XDl>
           </DataLoader>
         </XCard>

--- a/packages/kuma-gui/src/app/service-mesh/index.ts
+++ b/packages/kuma-gui/src/app/service-mesh/index.ts
@@ -47,7 +47,7 @@ const protocolHandler = (can: Can) => {
                   wl: Kri.toString({ shortName, mesh, zone, namespace, name }),
                 },
               }
-            case shortName === '~port':
+            case shortName === '~hostport':
               return {
                 name: 'data-plane-list-view',
                 query: {

--- a/packages/kuma-gui/src/app/service-mesh/index.ts
+++ b/packages/kuma-gui/src/app/service-mesh/index.ts
@@ -1,7 +1,6 @@
 import Kongponents from '@kong/kongponents'
 import { token } from '@kumahq/container'
 import X from '@kumahq/x'
-import { useLink } from 'vue-router'
 
 import type { Can } from '@/app/application'
 import { services as controlPlanes } from '@/app/control-planes'
@@ -9,6 +8,7 @@ import { services as hostnameGenerators } from '@/app/hostname-generators'
 import { Kri } from '@/app/kuma'
 import { services as me } from '@/app/me'
 import { services as meshes } from '@/app/meshes'
+import { useRouter } from '@/app/vue'
 import { services as zones } from '@/app/zones'
 import type { ServiceDefinition, Token } from '@kumahq/container'
 
@@ -17,9 +17,10 @@ const protocolHandler = (can: Can) => {
     const kriProto = 'kri://'
     switch (true) {
       case href.startsWith(kriProto): {
-        const { mesh, name, zone, namespace, shortName } = Kri.fromString(href.substring(kriProto.length))
+        const { mesh, name: encodedName, zone, namespace, shortName } = Kri.fromString(href.substring(kriProto.length))
+        // old style names can have _ in them that are replaced with `~`
+        const name = encodedName.replaceAll('~', '_')
         const id = `${name}${namespace !== '' ? `.${namespace}`: '' }`
-
         const to = (() => {
           switch (true) {
             case shortName === 'm':
@@ -44,6 +45,13 @@ const protocolHandler = (can: Can) => {
                 name: 'workload-detail-view',
                 params: {
                   wl: Kri.toString({ shortName, mesh, zone, namespace, name }),
+                },
+              }
+            case shortName === '~port':
+              return {
+                name: 'data-plane-list-view',
+                query: {
+                  s: `tag:service:${name}`,
                 },
               }
             case shortName === 'msvc':
@@ -75,8 +83,15 @@ const protocolHandler = (can: Can) => {
           }
         })()
         if (to) {
-          const link = useLink({ to })
-          return link.href.value
+          const router = useRouter()
+          try {
+            return router.resolve(to).href
+          } catch(e) {
+            // log the error, don't throw it
+            // anything errors we just don't show the link
+            console.error(e)
+            return ''
+          }
         }
         return ''
       }

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
@@ -9,7 +9,7 @@
       proxy: '',
       s: '',
     }"
-    v-slot="{ route, t, uri, me, can }"
+    v-slot="{ route, t, uri, me, can, r }"
   >
     <RouteTitle
       :render="false"
@@ -66,33 +66,31 @@
                 </dd>
               </div>
 
-              <template
-                v-for="labels in [Object.entries(props.data.labels)]"
-                :key="typeof labels"
-              >
-                <div v-if="labels.length > 0">
-                  <dt>{{ t('workloads.routes.item.about.labels') }}</dt>
-                  <dd>
-                    <XLayout
-                      variant="separated"
-                      truncate
+              <div v-if="Object.keys(props.data.labels).length > 0">
+                <dt>{{ t('workloads.routes.item.about.labels') }}</dt>
+                <dd>
+                  <XLayout
+                    variant="separated"
+                  >
+                    <XAction
+                      v-for="(value, key) in props.data.labels"
+                      :key="key"
+                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                        mesh: props.data.mesh,
+                        zone: props.data.zone,
+                        namespace: props.data.namespace,
+                        name: value,
+                      }, { defaultMessage: '' })"
                     >
-                      <template
-                        v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                        :key="typeof kumaRe"
+                      <XBadge
+                        :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                       >
-                        <XBadge
-                          v-for="[key, value] in labels"
-                          :key="key"
-                          :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                        >
-                          {{ key }}:{{ value }}
-                        </XBadge>
-                      </template>
-                    </XLayout>
-                  </dd>
-                </div>
-              </template>
+                        {{ key }}:<strong>{{ value }}</strong>
+                      </XBadge>
+                    </XAction>
+                  </XLayout>
+                </dd>
+              </div>
             </XDl>
           </template>
         </DataLoader>

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
@@ -83,7 +83,7 @@
                       }, { defaultMessage: '' })"
                     >
                       <XBadge
-                        :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                       >
                         {{ key }}:<strong>{{ value }}</strong>
                       </XBadge>

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -163,7 +163,7 @@
                         }, { defaultMessage: '' })"
                       >
                         <XBadge
-                          :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
+                          :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                         >
                           {{ key }}:<strong>{{ value }}</strong>
                         </XBadge>

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -5,7 +5,7 @@
       zone: '',
       subscription: '',
     }"
-    v-slot="{ t, uri }"
+    v-slot="{ t, uri, r }"
   >
     <RouteTitle
       :render="false"
@@ -146,33 +146,31 @@
                     </XBadge>
                   </dd>
                 </div>
-                <template
-                  v-for="labels in [Object.entries(zone.labels)]"
-                  :key="typeof labels"
-                >
-                  <div v-if="labels.length > 0">
-                    <dt>{{ t('services.routes.item.labels') }}</dt>
-                    <dd>
-                      <XLayout
-                        variant="separated"
-                        truncate
+                <div v-if="Object.keys(zone.labels).length > 0">
+                  <dt>Labels</dt>
+                  <dd>
+                    <XLayout
+                      variant="separated"
+                    >
+                      <XAction
+                        v-for="(value, key) in zone.labels"
+                        :key="key"
+                        :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                          mesh: '',
+                          zone: '',
+                          namespace: '',
+                          name: value,
+                        }, { defaultMessage: '' })"
                       >
-                        <template
-                          v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                          :key="typeof kumaRe"
+                        <XBadge
+                          :variant="r('kuma.label').test(key) ? 'kuma-label' : 'label'"
                         >
-                          <XBadge
-                            v-for="[key, value] in labels"
-                            :key="key"
-                            :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                          >
-                            {{ key }}:{{ value }}
-                          </XBadge>
-                        </template>
-                      </XLayout>
-                    </dd>
-                  </div>
-                </template>
+                          {{ key }}:<strong>{{ value }}</strong>
+                        </XBadge>
+                      </XAction>
+                    </XLayout>
+                  </dd>
+                </div>
               </XDl>
 
               <XLayout

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -366,7 +366,7 @@ export interface DataPlaneOverview extends MeshEntity {
   labels?: {
     'kuma.io/display-name'?: string
     'k8s.kuma.io/namespace'?: string
-    [key: string]: string | undefined
+    [key: string]: string
   }
   dataplane: {
     networking: DataplaneNetworking

--- a/packages/kuma-http-api/mocks/fs.ts
+++ b/packages/kuma-http-api/mocks/fs.ts
@@ -169,7 +169,7 @@ export const fs = {
   '/mesh-insights': _13,
   '/mesh-insights/:mesh': _14,
   '/meshes': _15,
-  '/meshes/:mesh': _16,
+  '/meshes/:name': _16,
   '/meshes/:mesh/dataplanes/_overview': _21,
   '/meshes/:mesh/dataplanes/:name': _19,
   '/meshes/:mesh/dataplanes/:name/_overview': _22,

--- a/packages/kuma-http-api/mocks/src/meshes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_.ts
@@ -1,7 +1,5 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
-  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
-
   // this template can be called via the /_kri/kri_<shortName>_:kri endpoint or
   // the legacy endpoint
   const kri = req.params.kri ? `kri_m_${req.params.kri}` : undefined

--- a/packages/kuma-http-api/mocks/src/meshes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_.ts
@@ -1,12 +1,26 @@
 import type { Dependencies, ResponseHandler } from '#mocks'
 export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
-  const kri = req.params.kri as string | undefined
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+
+  // this template can be called via the /_kri/kri_<shortName>_:kri endpoint or
+  // the legacy endpoint
+  const kri = req.params.kri ? `kri_m_${req.params.kri}` : undefined
   const [
-    _mesh,
-    _zone,
-    _namespace,
-    name = req.params.mesh as string,
-  ] = kri?.split('_') ?? ''
+    _prefix,
+    shortName,
+    mesh,
+    zone,
+    nspace,
+    displayName,
+  ] = kri ? kri.split('_') : [
+    'kri', // prefix
+    'm', // shortName
+    '', // mesh
+    '', // zone
+    // with k8s the request.name MUST be use the correct `name.ns` format
+    ...['', String(req.params.name)], // nspace, displayName
+  ]
+  const name = kri ? `${displayName}${nspace ? `.${nspace}` : ''}` : String(req.params.name)
 
   const isMtlsEnabledOverride = env('KUMA_MTLS_ENABLED', '')
   const isMtlsEnabled = isMtlsEnabledOverride !== '' ? isMtlsEnabledOverride === 'true' : fake.datatype.boolean()
@@ -21,9 +35,11 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
       type: 'Mesh',
       creationTime: '2020-06-19T12:18:02.097986-04:00',
       modificationTime: '2020-07-19T12:18:02.097986-04:00',
-      labels: {
-        'kuma.io/display-name': name,
-      },
+      kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, displayName }),
+      // meshes only seem to have displayName
+      labels: fake.kuma.labels({
+        name: displayName,
+      }),
       meshServices: {
         mode: env('KUMA_MESHSERVICE_MODE', 'Everywhere'),
       },

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -84,8 +84,10 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
           ...(name.includes('ingress') && { 'kuma.io/listener-zoneingress': 'enabled' }),
           ...(name.includes('egress') && { 'kuma.io/listener-zoneegress': 'enabled' }),
           name: displayName,
+          mesh,
           ...(zone ? { zone } : {}),
           ...(k8s ? { namespace: nspace } : {}),
+          ...(k8s ? { env: 'kubernetes' } : { env: 'universal'}),
         }),
       },
       ...((modificationTime) => ({

--- a/packages/routing/src/index.ts
+++ b/packages/routing/src/index.ts
@@ -4,6 +4,9 @@ interface DependencyDefaults {
   i18n: {
     t: (...args: any[]) => string
   }
+  regexp: {
+    r: (str: string) => RegExp
+  }
 }
 
 export interface Dependencies extends DependencyDefaults {}

--- a/packages/routing/src/vue/components/route-view/RouteView.vue
+++ b/packages/routing/src/vue/components/route-view/RouteView.vue
@@ -37,6 +37,7 @@
         :id="UniqueId"
         name="default"
         :t="t"
+        :r="r"
         :env="env"
         :me="{ data: me, set: submit, get: (uri: string, d: unknown = {}) => get(me, uri, d) }"
         :can="can"
@@ -73,7 +74,7 @@ import {
 } from '../../../index'
 import type { URLParamDefinition, URLParamNormalized } from '../../../index'
 import { sources } from '../../../sources'
-import { useCan, useI18n, useEnv } from '../../index'
+import { useCan, useI18n, useEnv, useRegExp } from '../../index'
 import type { RouteViewService } from '../index'
 import type { RouteRecordRaw, RouteLocationNormalizedLoaded, RouteLocationAsRelativeGeneric } from 'vue-router'
 
@@ -96,6 +97,7 @@ const can = useCan()
 const uri = useUri()
 const htmlAttrs = useAttrs()
 const { t } = useI18n()
+const { r } = useRegExp()
 const route = useRoute()
 const router = useRouter()
 const sym = Symbol('route-view')

--- a/packages/routing/src/vue/index.ts
+++ b/packages/routing/src/vue/index.ts
@@ -45,15 +45,18 @@ const deps: Dependencies = {
   can: () => false,
   env: () => '',
   i18n: { t: () => '' },
+  regexp: { r: () => new RegExp('') },
 }
 const tokens = {
   can: uri<Dependencies['can']>('routing.can'),
   env: uri<Dependencies['env']>('routing.env'),
   i18n: uri<Dependencies['i18n']>('routing.i18n'),
+  regexp: uri<Dependencies['regexp']>('routing.regexp'),
 }
-export const [ useCan, useI18n, useEnv] = [
+export const [ useCan, useI18n, useRegExp, useEnv] = [
   singleton(tokens.can, () => deps.can),
   singleton(tokens.i18n, () => deps.i18n),
+  singleton(tokens.regexp, () => deps.regexp),
   singleton(tokens.env, () => deps.env),
 ]
 const plugin: Plugin = {

--- a/packages/x/src/components/x-badge/XBadge.vue
+++ b/packages/x/src/components/x-badge/XBadge.vue
@@ -22,7 +22,7 @@ import { inject, computed } from 'vue'
 import type { BadgeAppearance } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   maxWidth?: string
-  variant?: 'label' | 'kuma-label' | 'default'
+  variant?: 'reserved-kv' | 'kv' | 'default'
   appearance?: BadgeAppearance | string
 }>(), {
   maxWidth: 'auto',
@@ -31,9 +31,9 @@ const props = withDefaults(defineProps<{
 const xAction = inject<{} | undefined>('x-action', undefined)
 const appearance = computed<BadgeAppearance>(() => {
   switch(props.variant) {
-    case 'label':
+    case 'kv':
       return 'neutral' as BadgeAppearance
-    case 'kuma-label':
+    case 'reserved-kv':
       return 'info' as BadgeAppearance
     default:
       return props.appearance as BadgeAppearance
@@ -41,7 +41,7 @@ const appearance = computed<BadgeAppearance>(() => {
 })
 </script>
 <style lang="scss" scoped>
-.variant-label, .variant-kuma-label {
+.variant-kv, .variant-reserved-kv {
   &.k-badge {
     font-weight: var(--x-font-weight-regular);
   }

--- a/packages/x/src/components/x-badge/XBadge.vue
+++ b/packages/x/src/components/x-badge/XBadge.vue
@@ -1,7 +1,9 @@
 <template>
   <KBadge
+    :class="`variant-${props.variant}`"
     :max-width="props.maxWidth"
     :icon-before="false"
+    :appearance="appearance"
   >
     <slot name="default" />
     <template #icon>
@@ -15,11 +17,36 @@
 
 <script lang="ts" setup>
 import { KBadge } from '@kong/kongponents'
-import { inject } from 'vue'
+import { inject, computed } from 'vue'
+
+import type { BadgeAppearance } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   maxWidth?: string
+  variant?: 'label' | 'kuma-label' | 'default'
+  appearance?: BadgeAppearance | string
 }>(), {
   maxWidth: 'auto',
+  variant: 'default',
 })
 const xAction = inject<{} | undefined>('x-action', undefined)
+const appearance = computed<BadgeAppearance>(() => {
+  switch(props.variant) {
+    case 'label':
+      return 'neutral' as BadgeAppearance
+    case 'kuma-label':
+      return 'info' as BadgeAppearance
+    default:
+      return props.appearance as BadgeAppearance
+  }
+})
 </script>
+<style lang="scss" scoped>
+.variant-label, .variant-kuma-label {
+  &.k-badge {
+    font-weight: var(--x-font-weight-regular);
+  }
+  :slotted(strong) {
+    font-weight: var(--x-font-weight-semibold);
+  }
+}
+</style>

--- a/packages/x/src/components/x-badge/XBadge.vue
+++ b/packages/x/src/components/x-badge/XBadge.vue
@@ -27,6 +27,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   maxWidth: 'auto',
   variant: 'default',
+  appearance: undefined,
 })
 const xAction = inject<{} | undefined>('x-action', undefined)
 const appearance = computed<BadgeAppearance>(() => {


### PR DESCRIPTION
This PR is unfortunately a little larger than I would like, but I'm half putting the finishing touches to the KRI label links whilst half rolling it out elsewhere.

### Finishing touches

- Replicate font `regular:bold` style of the exiting tag component
- Allow linking by old style `kuma.io/service` to support the old tags
- Replicate coloring of old tags (blue kuma links, grey non-kuma links)
- Regex helper (`r`, like `t`) so we don't need to use `<template>` for Regexp precompiling.

### Rolling out

- Attempts to find and rollout the new pattern to all detail pages we have either labels or tags, using the same pattern for both.
- I mainly searched for `TagList` and replaced this component with the new pattern apart from couple of areas which are almost "dead areas" which we barely touch. Therefore I mostly removed TagList in all detail and summary routes.

I think I have one more PR to make here as I noticed a lot of places where there are no labels in summary panels and there probably should be. I plan on one last follow up PR adding missing labels to summary panels (and if I spot anymore in detail views I will add those in the follow up also)

Lastly, a lot of this has been explained in a sync but I welcome any extra questions here, I can also add some inlines here if more explanation is needed.