### PR TITLE
fix(dataplanes): don't show static outbounds if there aren't any

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -312,6 +312,7 @@
                 <DataCollection
                   v-if="item.dataplaneType === 'standard'"
                   :items="item.dataplane.networking.outbounds"
+                  :empty="false"
                   v-slot="{ items: outbounds }"
                 >
                   <XLayout


### PR DESCRIPTION
Generally its less often that users define outbounds in their configs.

Moreover, we usually display outbounds based on Envoy stats, not actual user defined YAMLs/configs (these can show the _result of_ user defined configs)

I noticed that when `outbounds` are not user defined, we just show an empty state, with no title (see before). Note: it kinda looks like the word `Address` is the title, with an empty state.

I considered changing things to always show an `Outbounds` title with an empty state, but seeing as `outbounds` are one of the only areas we were quite often don't mind if they aren't defined, I figured it would be best to just not show an empty state at all. So, no empty state, no title, no nothing.

I guess a picture (or two) is worth a thousand words:


### Before

<img width="581" height="882" alt="Screenshot 2026-06-02 at 17 15 18" src="https://github.com/user-attachments/assets/c97b94a5-5306-4005-9172-536c2ec9a355" />


### After

<img width="568" height="887" alt="Screenshot 2026-06-02 at 17 15 31" src="https://github.com/user-attachments/assets/e3ab3f04-2c3a-4e8a-9985-c8da811af43d" />

