### PR TITLE
refactor(dataplanes): merge listeners with inbounds

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Traffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Traffic.feature
@@ -6,7 +6,6 @@ Feature: mesh / dataplanes / connections / Traffic
       | traffic         | [data-testid='dataplane-traffic']                                          |
       | inbound         | [data-testid='dataplane-inbound']                                          |
       | outbound        | [data-testid='dataplane-outbound']                                         |
-      | listener        | [data-testid='dataplane-listener']                                         |
       | warning         | [data-testid*='abnormal-traffic-stats']                                    |
       | loading-warning | [data-testid^='notification-data-planes.notifications.stats-not-enhanced'] |
       | about-section   | [data-testid='dataplane-about-section']                                    |
@@ -37,7 +36,7 @@ Feature: mesh / dataplanes / connections / Traffic
       body:
         listeners:
           - kri: kri_dp_default_numeric_kuma-system_service-less_12345
-            port: 12345
+            port: 12323
             proxyResourceName: self_zoneingress_dp_12345
             type: ZoneIngress
         inbounds:
@@ -53,16 +52,15 @@ Feature: mesh / dataplanes / connections / Traffic
       """
     When I visit the "/meshes/default/data-planes/service-less/overview" URL
     Then the "$traffic" element exists
-    # TODO: These need correcting so that the mock produces a single inbound
-    # and outbound if that is what the intention of the test is
-    # for the moment :nth-child(1) existing 1 time isn't testing anything
-    # and previous to adding :nth-child(1) the element existed 13 times
-    And the "$inbound:nth-child(1)" element exists 1 times
-    And the "$outbound:nth-child(1)" element exists 1 times
-    # end TODO
-    And the "$listener" element exists 1 times
-    And the "$listener" element contains "12345"
+    # inbounds and listeners
+    And the "$inbound" element exists 2 times
     And the "$inbound:nth-child(1)" element contains "12345"
+    And the "$inbound:nth-child(1)" element contains "HTTP"
+    And the "$inbound:nth-child(2)" element contains "12323"
+    And the "$inbound:nth-child(2)" element contains "TCP"
+    And the "$inbound:nth-child(2)" element contains "ZoneIngress"
+    # outbounds
+    And the "$outbound" element exists 1 times
     And the "$outbound:nth-child(1)" element contains "Port 54321 (ipv6)"
     And the "$outbound:nth-child(1)" element contains "Mesh default"
     And the "$outbound:nth-child(1)" element contains "Zone scenario"

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Traffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Traffic.feature
@@ -130,6 +130,7 @@ Feature: mesh / dataplanes / connections / Traffic
   Scenario: Listener traffic shows expected content
     Given the environment
       """
+      KUMA_DATAPLANEINBOUND_COUNT: 0
       KUMA_DATAPLANELISTENER_COUNT: 2
       """
     And the URL "/meshes/default/dataplanes/service-less/_layout" responds with
@@ -176,17 +177,17 @@ Feature: mesh / dataplanes / connections / Traffic
       """
     When I visit the "/meshes/default/data-planes/service-less/overview" URL
     Then the "$traffic" element exists
-    And the "$listener" element exists 2 times
-    And the "$listener:nth-child(1)" element contains
+    And the "$inbound" element exists 2 times
+    And the "$inbound:nth-child(1)" element contains
       | Value                 |
       | TCP                   |
-      | :12345                |
       | ZoneIngress           |
+      | :12345                |
       | Total connections 20  |
       | Active connections 10 |
-    And the "$listener:nth-child(2)" element contains
+    And the "$inbound:nth-child(2)" element contains
       | Value                |
-      | :54321               |
       | ZoneEgress           |
+      | :54321               |
       | Total connections 10 |
       | Active connections 5 |

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Listener.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Listener.feature
@@ -12,6 +12,7 @@ Feature: mesh / dataplanes / overview / summary / Listener
       KUMA_DATAPLANE_TYPE: standard
       """
 
+  # Note: A listener is currently treated exactly like an inbound
   Scenario: Listener summary overview shows expected content
     Given the URL "/meshes/default/dataplanes/service-less/_layout" responds with
       """
@@ -33,9 +34,9 @@ Feature: mesh / dataplanes / overview / summary / Listener
                 type: ZoneIngress
                 address: 10.244.0.21
       """
-    When I visit the "/meshes/default/data-planes/service-less/overview/listener/self_zoneingress_dp_12345/overview" URL
+    When I visit the "/meshes/default/data-planes/service-less/overview/inbound/self_zoneingress_dp_12345/overview" URL
     And the "$summary" element exists
-    And the "$summary" element contains "Listener :12345"
+    And the "$summary" element contains "Inbound :12345"
     And the "$summary" element contains "TCP"
     And the "$summary" element contains "10.244.0.21"
     And the "$summary" element contains "12345"

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Listener.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Listener.feature
@@ -11,8 +11,8 @@ Feature: mesh / dataplanes / overview / summary / Listener
       KUMA_DATAPLANELISTENER_COUNT: 1
       KUMA_DATAPLANE_TYPE: standard
       """
-
   # Note: A listener is currently treated exactly like an inbound
+
   Scenario: Listener summary overview shows expected content
     Given the URL "/meshes/default/dataplanes/service-less/_layout" responds with
       """

--- a/packages/kuma-gui/features/mesh/legacy-dataplanes/Navigation.feature
+++ b/packages/kuma-gui/features/mesh/legacy-dataplanes/Navigation.feature
@@ -75,8 +75,6 @@ Feature: mesh / dataplanes / navigation
           - name: monitor-proxy-0
             labels:
               kuma.io/display-name: monitor-proxy-0
-        
-        
         """
 
     Scenario Outline: clicking the detail link

--- a/packages/kuma-gui/src/app/connections/routes.ts
+++ b/packages/kuma-gui/src/app/connections/routes.ts
@@ -66,26 +66,5 @@ export const routes = (prefix: string): RouteRecordRaw[] => {
         },
       ],
     },
-    {
-      path: 'listener/:connection',
-      name: `${prefix}-connection-listener-summary-view`,
-      // component: () => import('@/app/connections/views/ConnectionListenerSummaryView.vue'),
-      children: [
-        {
-          path: 'stats',
-          name: `${prefix}-connection-listener-summary-stats-view`,
-          // Note: This uses the same component as the inbound summary stats view because they are practically the same,
-          // but for now we have to handle them as different summary views. This will likely change in the future.
-          component: () => import('@/app/connections/views/ConnectionInboundSummaryStatsView.vue'),
-        },
-        {
-          path: 'xds-config',
-          name: `${prefix}-connection-listener-summary-xds-config-view`,
-          // Note: This uses the same component as the inbound summary xds view because they are practically the same,
-          // but for now we have to handle them as different summary views. This will likely change in the future.
-          component: () => import('@/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue'),
-        },
-      ],
-    },
   ]
 }

--- a/packages/kuma-gui/src/app/connections/sources.ts
+++ b/packages/kuma-gui/src/app/connections/sources.ts
@@ -79,6 +79,11 @@ export const sources = (api: KumaApi) => {
           ...Object.fromEntries(Object.entries(connections.listener).filter(([key]) => key.startsWith('self_zone'))),
         }
 
+        inbounds = {
+          ...inbounds,
+          ...listeners,
+        }
+
         outbounds = Object.fromEntries(Object.entries(connections.cluster).filter(([key, _value]) => ![
           // if we don't exclude localhost_ we end up with  a `localhost_`
           // outbound, which is the cluster of the inbound. Whilst we don't want
@@ -98,7 +103,6 @@ export const sources = (api: KumaApi) => {
         inbounds = Object.fromEntries(Object.entries(connections.listener).filter(([key, _value]) => key.startsWith(socketAddress.replace(':', '_'))))
         outbounds = connections.cluster
         passthrough = {}
-        listeners = {}
       }
 
       return {
@@ -106,7 +110,6 @@ export const sources = (api: KumaApi) => {
         passthrough,
         inbounds,
         outbounds,
-        listeners,
         $raw: res,
         raw: res,
       }

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -61,6 +61,7 @@ export const DataplaneNetworkingLayout = {
         const kri = Kri.fromString(item.kri)
         return {
           ...item,
+          type: '',
           stat_prefix: item.proxyResourceName,
           portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
         }

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -7,27 +7,56 @@ type KumaDataplaneListener = NonNullable<NonNullable<NonNullable<components['sch
 type KumaDataplaneOutbound = NonNullable<NonNullable<NonNullable<components['schemas']['DataplaneOverviewWithMeta']['dataplane']>['networking']>['outbound']>[number]
 type KumaDataplaneNetworkingLayout = components['schemas']['DataplaneNetworkingLayout']
 
+const DataplaneLayoutInbound = {
+  fromObject(item: KumaDataplaneNetworkingLayout['inbounds'][number]) {
+    const kri = Kri.fromString(item.kri)
+    return {
+      ...item,
+      type: '' as 'ZoneIngress' | 'ZoneEgress',
+      stat_prefix: item.proxyResourceName,
+      portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
+    }
+  },
+
+  fromCollection(items: KumaDataplaneNetworkingLayout['inbounds']) {
+    // don't show a card for anything on port 49151 as those are service-less inbounds
+    // we currently only do this on the layout endpoint
+    return Array.isArray(items) ? items.filter(item => item.port !== 49151).map(item => DataplaneLayoutInbound.fromObject(item)) : []
+  },
+}
+
+const DataplaneLayoutListener = {
+  fromObject(item: KumaDataplaneNetworkingLayout['listeners'][number]) {
+    const kri = Kri.fromString(item.kri)
+    return {
+      ...item,
+      // protocol of ZoneIngress listeners is always tcp, for ZoneEgress it depends and therefore it's not set
+      protocol: item.type === 'ZoneIngress' ? 'tcp' : '',
+      stat_prefix: item.proxyResourceName,
+      portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
+    }
+  },
+
+  fromCollection(items: KumaDataplaneNetworkingLayout['listeners']) {
+    return Array.isArray(items) ? items.map(item => DataplaneLayoutListener.fromObject(item)) : []
+  },
+}
+
 export const DataplaneNetworkingLayout = {
   fromObject(dataplaneNetworkingLayout: KumaDataplaneNetworkingLayout) {
+    const { inbounds, listeners, ...rest } = dataplaneNetworkingLayout
     // `stat_prefix` corresponds to the stat_prefix used in the Envoy stats.
     // proxyResourceName.sectionName can either be a portName or port, so we
     // make sure its always the port as this is what the Envoy stat_prefix
     // uses. Once the following issue is resolved we won't have to do this
     // https://github.com/kumahq/kuma/issues/14469
     return {
-      ...dataplaneNetworkingLayout,
+      ...rest,
       spiffeId: dataplaneNetworkingLayout.spiffeId ?? '',
-      // don't show a card for anything on port 49151 as those are service-less inbounds
-      // we currently only do this on the layout endpoint
-      inbounds: dataplaneNetworkingLayout.inbounds.filter(item => item.port !== 49151).map(item => {
-        const kri = Kri.fromString(item.kri)
-        return {
-          ...item,
-          type: '',
-          stat_prefix: item.proxyResourceName,
-          portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
-        }
-      }),
+      inbounds: [
+        ...DataplaneLayoutInbound.fromCollection(dataplaneNetworkingLayout.inbounds),
+        ...DataplaneLayoutListener.fromCollection(dataplaneNetworkingLayout.listeners),
+      ] satisfies GenericDataplaneLayoutInbound[],
       outbounds: dataplaneNetworkingLayout.outbounds.map(item => {
         const kri = Kri.fromString(item.kri)
         return {
@@ -36,17 +65,7 @@ export const DataplaneNetworkingLayout = {
           portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
         }
       }),
-      listeners: dataplaneNetworkingLayout.listeners.map(item => {
-        const kri = Kri.fromString(item.kri)
-        return {
-          ...item,
-          // protocol of ZoneIngress listeners is always tcp, for ZoneEgress it depends and therefore it's not set
-          protocol: item.type === 'ZoneIngress' ? 'tcp' : '',
-          stat_prefix: item.proxyResourceName,
-          portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
-        }
-      }),
-    } satisfies KumaDataplaneNetworkingLayout
+    }
   },
 }
 
@@ -203,3 +222,7 @@ export type DataplaneInbound = ReturnType<typeof DataplaneInbound['fromObject']>
 export type DataplaneListener = ReturnType<typeof DataplaneListener['fromObject']>
 export type GatewayDataplaneInbound = ReturnType<typeof GatewayDataplaneInbound['fromObject']>
 export type GenericDataplaneInbound = DataplaneInbound & DataplaneListener & GatewayDataplaneInbound
+
+export type DataplaneLayoutInbound = ReturnType<typeof DataplaneLayoutInbound['fromObject']>
+export type DataplaneLayoutListener = ReturnType<typeof DataplaneLayoutListener['fromObject']>
+export type GenericDataplaneLayoutInbound = DataplaneLayoutInbound & DataplaneLayoutListener

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -23,6 +23,7 @@ export const DataplaneNetworkingLayout = {
         const kri = Kri.fromString(item.kri)
         return {
           ...item,
+          type: '',
           stat_prefix: item.proxyResourceName,
           portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
         }
@@ -192,7 +193,6 @@ export const DataplaneNetworking = {
         }
       })() satisfies GenericDataplaneInbound[],
       outbounds: DataplaneOutbound.fromCollection(outbounds),
-      listeners: DataplaneListener.fromCollection(networking.listeners),
     }
   },
 }

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
@@ -72,7 +72,7 @@ export const DataplaneOverview = {
           return state
         }
 
-        const networkEndpoints = [...networking.inbounds, ...networking.listeners]
+        const networkEndpoints = networking.inbounds
         const unhealthy = networkEndpoints.filter((endpoint) => endpoint.state !== 'Ready')
         switch (true) {
           case unhealthy.length === 0:

--- a/packages/kuma-gui/src/app/data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/data-planes/routes.ts
@@ -87,22 +87,6 @@ export const dataplaneRoutes = (): RouteRecordRaw[] => {
                   },
                 )
               }
-              if (item.name === 'data-plane-connection-listener-summary-view' && item.children) {
-                item.component = () => import('@/app/data-planes/views/DataPlaneTrafficSummaryView.vue')
-                // temporarily exclude all children but overview
-                // item.children = [{
-                //   path: 'overview',
-                //   name: 'data-plane-connection-listener-summary-overview-view',
-                //   component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
-                // }]
-                item.children.unshift(
-                  {
-                    path: 'overview',
-                    name: 'data-plane-connection-listener-summary-overview-view',
-                    component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
-                  },
-                )
-              }
               return item
             }),
             {

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -635,7 +635,6 @@
                                           port: `${item.port}`,
                                         }
                                       "
-
                                       data-actionable
                                     >
                                       <template #state>
@@ -927,7 +926,7 @@
                 >
                   <component
                     :is="child.Component"
-                    :data="(child.route.name as string).includes('-inbound-') ? [...sourceDataplaneLayout?.inbounds, ...sourceDataplaneLayout?.listeners] : sourceDataplaneLayout?.outbounds"
+                    :data="(child.route.name as string).includes('-inbound-') ? sourceDataplaneLayout?.inbounds.concat(sourceDataplaneLayout?.listeners ?? []) : sourceDataplaneLayout?.outbounds"
                     :data-plane-overview="props.data"
                     :networking="props.data.dataplane.networking"
                     :policies="resources?.policies"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -602,7 +602,7 @@
                           :key="port"
                         >
                           <template
-                            v-for="inbounds in [dataplaneLayout.inbounds]"
+                            v-for="inbounds in [[...dataplaneLayout.inbounds, ...dataplaneLayout.listeners]]"
                             :key="typeof inbounds"
                           >
                             <ConnectionGroup
@@ -626,7 +626,9 @@
                                       :protocol="item.protocol"
                                       :port-name="inbound?.portName"
                                       :traffic="typeof trafficError === 'undefined' ?
-                                        traffic?.inbounds[item.stat_prefix] :
+                                        item.type === 'ZoneIngress' || item.type === 'ZoneEgress' ?
+                                          traffic?.listeners[item.stat_prefix] :
+                                          traffic?.inbounds[item.stat_prefix] :
                                         {
                                           name: '',
                                           protocol: item.protocol,
@@ -682,83 +684,22 @@
                                           </XAction>
                                         </template>
                                       </template>
+
+                                      <template #empty>
+                                        No traffic data available for this inbound
+                                      </template>
+
+                                      <XBadge
+                                        v-if="item.type?.length > 0"
+                                        appearance="info"
+                                      >
+                                        {{ item.type }}
+                                      </XBadge>
+
                                       <XAction
                                         data-action
                                         :to="{
                                           name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
-                                          params: {
-                                            connection: item.proxyResourceName,
-                                          },
-                                          query: {
-                                            inactive: route.params.inactive,
-                                          },
-                                        }"
-                                      >
-                                        :{{ item.port }}
-                                      </XAction>
-                                    </ConnectionCard>
-                                  </template>
-                                </template>
-                              </XLayout>
-                            </ConnectionGroup>
-                          </template>
-                        </template>
-
-                        <template
-                          v-for="(listenersByPort, port) in [Object.groupBy(props.data.dataplane.networking.listeners.filter((item) => !!item.port), (item) => item.port!)]"
-                          :key="port"
-                        >
-                          <template
-                            v-for="listeners in [dataplaneLayout.listeners]"
-                            :key="typeof listeners"
-                          >
-                            <ConnectionGroup
-                              type="inbound"
-                              data-testid="dataplane-listeners"
-                            >
-                              <XLayout
-                                variant="y-stack"
-                                size="small"
-                              >
-                                <template
-                                  v-for="item in listeners"
-                                  :key="`${item.proxyResourceName}`"
-                                >
-                                  <template
-                                    v-for="listener in [listenersByPort[item.port]?.[0]]"
-                                    :key="listener?.port"
-                                  >
-                                    <ConnectionCard
-                                      data-testid="dataplane-listener"
-                                      :protocol="item.protocol"
-                                      :traffic="traffic?.listeners[item.proxyResourceName]"
-                                      data-actionable
-                                    >
-                                      <template #state>
-                                        <XIcon
-                                          v-if="listener?.state !== 'Ready'"
-                                          name="danger"
-                                          :size="KUI_ICON_SIZE_40"
-                                          placement="right"
-                                        >
-                                          {{ t('data-planes.routes.item.unhealthy_inbound', { port: listener?.port }) }}
-                                        </XIcon>
-                                      </template>
-
-                                      <template #body>
-                                        <XBadge appearance="decorative">
-                                          {{ item.type }}
-                                        </XBadge>
-                                      </template>
-
-                                      <template #empty>
-                                        No traffic data available for this listener
-                                      </template>
-
-                                      <XAction
-                                        data-action
-                                        :to="{
-                                          name: 'data-plane-connection-listener-summary-overview-view',
                                           params: {
                                             connection: item.proxyResourceName,
                                           },
@@ -986,7 +927,7 @@
                 >
                   <component
                     :is="child.Component"
-                    :data="(child.route.name as string).includes('-inbound-') ? sourceDataplaneLayout?.inbounds : (child.route.name as string).includes('-listener-') ? sourceDataplaneLayout?.listeners : sourceDataplaneLayout?.outbounds"
+                    :data="(child.route.name as string).includes('-inbound-') ? [...sourceDataplaneLayout?.inbounds, ...sourceDataplaneLayout?.listeners] : sourceDataplaneLayout?.outbounds"
                     :data-plane-overview="props.data"
                     :networking="props.data.dataplane.networking"
                     :policies="resources?.policies"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -626,9 +626,7 @@
                                       :protocol="item.protocol"
                                       :port-name="inbound?.portName"
                                       :traffic="typeof trafficError === 'undefined' ?
-                                        item.type === 'ZoneIngress' || item.type === 'ZoneEgress' ?
-                                          traffic?.listeners[item.stat_prefix] :
-                                          traffic?.inbounds[item.stat_prefix] :
+                                        traffic?.inbounds[item.stat_prefix] :
                                         {
                                           name: '',
                                           protocol: item.protocol,

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -602,7 +602,7 @@
                           :key="port"
                         >
                           <template
-                            v-for="inbounds in [[...dataplaneLayout.inbounds, ...dataplaneLayout.listeners]]"
+                            v-for="inbounds in [dataplaneLayout.inbounds]"
                             :key="typeof inbounds"
                           >
                             <ConnectionGroup
@@ -926,7 +926,7 @@
                 >
                   <component
                     :is="child.Component"
-                    :data="(child.route.name as string).includes('-inbound-') ? sourceDataplaneLayout?.inbounds.concat(sourceDataplaneLayout?.listeners ?? []) : sourceDataplaneLayout?.outbounds"
+                    :data="(child.route.name as string).includes('-inbound-') ? sourceDataplaneLayout?.inbounds : sourceDataplaneLayout?.outbounds"
                     :data-plane-overview="props.data"
                     :networking="props.data.dataplane.networking"
                     :policies="resources?.policies"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -235,7 +235,7 @@ import { Kri } from '@/app/kuma'
 import { sources as policySources } from '@/app/policies/sources'
 
 const props = defineProps<{
-  data: DataplaneNetworkingLayout['inbounds'][number] | DataplaneNetworkingLayout['listeners'][number]
+  data: DataplaneNetworkingLayout['inbounds'][number]
   dataPlaneOverview: DataplaneOverview
   routeName: string
 }>()

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
@@ -39,9 +39,8 @@
           <XTabs
             :selected="route.child()?.name"
           >
-            <!-- v-for="{ name } in (items[0].type.startsWith('Zone') ? route.children.filter((item) => !item.name.includes('clusters')) : route.children)" -->
             <template
-              v-for="{ name } in route.children"
+              v-for="{ name } in (items[0].type.startsWith('Zone') ? route.children.filter((item) => !item.name.includes('clusters')) : route.children)"
               :key="name"
               #[`${name}-tab`]
             >

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
@@ -24,7 +24,7 @@
               size="small"
             >
               <h2>
-                {{ props.routeName.includes('inbound') ? `Inbound ${'port' in items[0] ? `:${items[0].port}` : route.params.connection}` : props.routeName.includes('listener') ? `Listener ${'port' in items[0] ? `:${items[0].port}` : route.params.connection}` : `Outbound ${Kri.fromString(route.params.connection).name}` }}
+                {{ props.routeName.includes('inbound') ? `Inbound ${'port' in items[0] ? `:${items[0].port}` : route.params.connection}` : `Outbound ${Kri.fromString(route.params.connection).name}` }}
               </h2>
               <template v-if="'state' in items[0]">
                 <XBadge
@@ -39,6 +39,7 @@
           <XTabs
             :selected="route.child()?.name"
           >
+            <!-- v-for="{ name } in (items[0].type.startsWith('Zone') ? route.children.filter((item) => !item.name.includes('clusters')) : route.children)" -->
             <template
               v-for="{ name } in route.children"
               :key="name"
@@ -71,7 +72,7 @@
   </RouteView>
 </template>
 
-<script lang="ts" generic="T extends { proxyResourceName: string }" setup>
+<script lang="ts" generic="T extends { proxyResourceName: string, type: string }" setup>
 import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
 import { Kri } from '@/app/kuma'
 

--- a/packages/kuma-gui/src/app/legacy-data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/legacy-data-planes/routes.ts
@@ -73,24 +73,6 @@ export const legacyDataplaneRoutes = (): RouteRecordRaw[] => {
                   },
                 )
               }
-
-              /**
-               * The legacy data planes are not using the listener summary view, but the router requires
-               * the route to be defined, otherwise a deep-link would always lead to the /404 route.
-               * In order to allow deep-linking to the listener summary view in case the dp has `feature-unified-resource-naming` enabled,
-               * we define the route here, but it will never be used in the legacy data planes.
-               * The actual handling of this happens in the `DataPlaneRouteGuard: router.beforeResolve`.
-               */
-              if (item.name === 'data-plane-connection-listener-summary-view' && item.children) {
-                item.component = () => import('@/app/data-planes/views/DataPlaneTrafficSummaryView.vue')
-                item.children.unshift(
-                  {
-                    path: 'overview',
-                    name: 'data-plane-connection-listener-summary-overview-view',
-                    component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
-                  },
-                )
-              }
               return item
             }),
 


### PR DESCRIPTION
Merges `inbounds` and `listeners` of `DataplaneOverview.dataplane.networking` and `DataplaneLayout` by aligning the shape in the data-layer such that we can treat them both exactly the same in the views.

Closes https://github.com/kumahq/kuma-gui/issues/4889