### PR TITLE
chore: remove copy title buttons

### DIFF
--- a/packages/kuma-gui/features/application/Titles.feature
+++ b/packages/kuma-gui/features/application/Titles.feature
@@ -9,34 +9,41 @@ Feature: application / titles
     Then the page title contains "<Title>"
 
     Examples:
-      | URL                                                                  | Title               |
-      | /                                                                    | Overview            |
-      | /configuration                                                       | Configuration       |
-      | /zones                                                               | Zone control planes |
-      | /zones/zone-cp-name/overview                                         | zone-cp-name        |
-      | /zones/zone-cp-name/ingresses                                        | Ingresses           |
-      | /zones/zone-cp-name/ingresses/zone-ingress-name/overview             | zone-ingress-name   |
-      | /zones/zone-cp-name/egresses                                         | Egresses            |
-      | /zones/zone-cp-name/egresses/zone-egress-name/overview               | zone-egress-name    |
-      | /meshes                                                              | Meshes              |
-      | /meshes/default/overview                                             | Mesh overview       |
-      | /meshes/default/services/internal                                    | Services            |
-      | /meshes/default/services/internal/service-name/overview              | service-name        |
-      | /meshes/default/services/external                                    | ExternalServices    |
-      | /meshes/default/services/external/service-name/overview              | service-name        |
-      | /meshes/default/services/mesh-services                               | MeshServices        |
-      | /meshes/default/gateways/builtin                                     | Built-in gateways   |
-      | /meshes/default/gateways/builtin/gateway.namespace/overview          | gateway             |
-      | /meshes/default/gateways/delegated                                   | Delegated gateways  |
-      | /meshes/default/gateways/delegated/gateway/overview                  | gateway             |
-      | /meshes/default/data-planes                                          | Data plane proxies  |
-      | /meshes/default/data-planes/data-plane-name/overview                 | data-plane-name     |
-      | /meshes/default/policies/circuit-breakers                            | Policies            |
-      | /meshes/default/policies/circuit-breakers/program-0/overview         | program-0           |
-      | /meshes/default/workloads                                            | Workloads           |
-      | /meshes/default/workloads/kri_wl_default_z1_ns1_workload-1_/overview | workload-1          |
-      | /hostname-generators                                                 | HostnameGenerators  |
-      | /hostname-generators/hg-name/overview                                | hg-name             |
+      | URL                                                                                                                   | Title                     |
+      | /                                                                                                                     | Overview                  |
+      | /configuration                                                                                                        | Configuration             |
+      | /zones                                                                                                                | Zone control planes       |
+      | /zones/zone-cp-name/overview                                                                                          | zone-cp-name              |
+      | /zones/zone-cp-name/ingresses                                                                                         | Ingresses                 |
+      | /zones/zone-cp-name/ingresses/zone-ingress-name/overview                                                              | zone-ingress-name         |
+      | /zones/zone-cp-name/egresses                                                                                          | Egresses                  |
+      | /zones/zone-cp-name/egresses/zone-egress-name/overview                                                                | zone-egress-name          |
+      | /meshes                                                                                                               | Meshes                    |
+      | /meshes/default/overview                                                                                              | Mesh overview             |
+      | /meshes/default/services/internal                                                                                     | Services                  |
+      | /meshes/default/services/internal/service-name/overview                                                               | service-name              |
+      | /meshes/default/services/external                                                                                     | ExternalServices          |
+      | /meshes/default/services/external/service-name/overview                                                               | service-name              |
+      | /meshes/default/gateways/builtin                                                                                      | Built-in gateways         |
+      | /meshes/default/gateways/builtin/gateway.namespace/overview                                                           | gateway                   |
+      | /meshes/default/gateways/delegated                                                                                    | Delegated gateways        |
+      | /meshes/default/gateways/delegated/gateway/overview                                                                   | gateway                   |
+      | /meshes/default/services/mesh-services                                                                                | MeshServices              |
+      | /meshes/default/services/mesh-services/service-name/overview                                                          | service-name              |
+      | /meshes/default/services/mesh-multi-zone-services                                                                     | MeshMultiZoneServices     |
+      | /meshes/default/services/mesh-multi-zone-services/service-name/overview                                               | service-name              |
+      | /meshes/default/services/mesh-external-services                                                                       | MeshExternalServices      |
+      | /meshes/default/services/mesh-external-services/service-name/overview                                                 | service-name              |
+      | /meshes/default/data-planes                                                                                           | Data plane proxies        |
+      | /meshes/default/data-planes/data-plane-name/overview                                                                  | data-plane-name           |
+      | /meshes/default/policies/circuit-breakers                                                                             | Policies                  |
+      | /meshes/default/policies/circuit-breakers/program-0/overview                                                          | program-0                 |
+      | /meshes/default/resources/meshfaultinjections                                                                         | Resources                 |
+      | /meshes/default/resources/meshfaultinjections/kri_mfi_default_adviser_kuma-system_pension-0-959cb35ab-xtzqf_/overview | pension-0-959cb35ab-xtzqf |
+      | /meshes/default/workloads                                                                                             | Workloads                 |
+      | /meshes/default/workloads/kri_wl_default_z1_ns1_workload-1_/overview                                                  | workload-1                |
+      | /hostname-generators                                                                                                  | HostnameGenerators        |
+      | /hostname-generators/hg-name/overview                                                                                 | hg-name                   |
 
   Scenario Outline: Visiting the "<Title>" page in "zone" Mode
     Given the environment

--- a/packages/kuma-gui/features/mesh/delegated-gateways/Item.feature
+++ b/packages/kuma-gui/features/mesh/delegated-gateways/Item.feature
@@ -5,7 +5,7 @@ Feature: mesh / delegated-gateways / item
       | Alias       | Selector                                           |
       | tabs-view   | [data-testid='delegated-gateway-detail-tabs-view'] |
       | detail-view | [data-testid='delegated-gateway-detail-view']      |
-    Given the URL "/meshes/default/service-insights/service-1" responds with
+    Given the URL "/meshes/default/service-insights/gateway-1" responds with
       """
       body:
         name: gateway-1
@@ -19,8 +19,8 @@ Feature: mesh / delegated-gateways / item
       """
 
   Scenario: Overview tab has expected content
-    When I visit the "/meshes/default/gateways/delegated/service-1/overview" URL
-    Then the "$tabs-view" element contains "service-1"
+    When I visit the "/meshes/default/gateways/delegated/gateway-1/overview" URL
+    Then the "$tabs-view" element contains "gateway-1"
     Then the "$detail-view" elements contain
       | Value              |
       |       1.2.3.4:8000 |

--- a/packages/kuma-gui/playwright.config.ts
+++ b/packages/kuma-gui/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(
     ...(headed ? { workers: 1, fullyParallel: false, maxFailures: 0, forbidOnly: false } : {}),
     use: {
       ...(headed ? { headless: false } : {}),
-      baseURL: process.env.KUMA_BASE_URL || 'http://localhost:5681/gui',
+      baseURL: process.env.KUMA_BASE_URL || 'http://localhost:8080/gui',
     },
     shard: {
       current: parseInt(process.env.KUMA_E2E_SHARD_CURRENT || '1'),

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -38,19 +38,10 @@
           size="small"
         >
           <h1>
-            <XCopyButton
-              :text="props.data.name"
-            >
-              <RouteTitle
-                :title="t('data-planes.routes.item.title', { name: props.data.name })"
-              />
-            </XCopyButton>
+            <RouteTitle
+              :title="t('data-planes.routes.item.title', { name: props.data.name })"
+            />
           </h1>
-          <XBadge
-            :appearance="t(`common.status.appearance.${props.data.status}`, undefined, { defaultMessage: 'neutral' })"
-          >
-            {{ t(`http.api.value.${props.data.status}`) }}
-          </XBadge>
         </XLayout>
         <XNotification
           :notify="props.data.status === 'offline'"

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailTabsView.vue
@@ -32,9 +32,7 @@
     >
       <template #title>
         <h1>
-          <XCopyButton :text="route.params.service">
-            <RouteTitle :title="t('external-services.routes.item.title', { name: route.params.service })" />
-          </XCopyButton>
+          <RouteTitle :title="t('external-services.routes.item.title', { name: route.params.service })" />
         </h1>
       </template>
 

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDetailTabsView.vue
@@ -46,13 +46,9 @@
             v-slot="{ data: [data] }"
           >
             <h1>
-              <XCopyButton
-                :text="data.name"
-              >
-                <RouteTitle
-                  :title="t('builtin-gateways.routes.item.title', { name: data.name })"
-                />
-              </XCopyButton>
+              <RouteTitle
+                :title="t('builtin-gateways.routes.item.title', { name: data.name })"
+              />
             </h1>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
@@ -45,15 +45,10 @@
               size="small"
             >
               <h1>
-                <XCopyButton :text="route.params.service">
-                  <RouteTitle :title="t('delegated-gateways.routes.item.title', { name: route.params.service })" />
-                </XCopyButton>
+                <RouteTitle
+                  :title="t('delegated-gateways.routes.item.title', { name: data.name })"
+                />
               </h1>
-              <XBadge
-                :appearance="t(`common.status.appearance.${data.status}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${data.status}`) }}
-              </XBadge>
             </XLayout>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -39,13 +39,9 @@
             v-slot="{ data: [data] }"
           >
             <h1>
-              <XCopyButton
-                :text="data.name"
-              >
-                <RouteTitle
-                  :title="t('hostname-generators.routes.item.title', { name: data.name })"
-                />
-              </XCopyButton>
+              <RouteTitle
+                :title="t('hostname-generators.routes.item.title', { name: data.name })"
+              />
             </h1>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailTabsView.vue
@@ -9,13 +9,9 @@
     <AppView>
       <template #title>
         <h1>
-          <XCopyButton
-            :text="route.params.mesh"
-          >
-            <RouteTitle
-              :title="t('meshes.routes.item.title', { name: route.params.mesh })"
-            />
-          </XCopyButton>
+          <RouteTitle
+            :title="t('meshes.routes.item.title', { name: route.params.mesh })"
+          />
         </h1>
       </template>
       <template

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
@@ -46,13 +46,9 @@
             v-slot="{ data: [policy] }"
           >
             <h1>
-              <XCopyButton
-                :text="policy.name"
-              >
-                <RouteTitle
-                  :title="t('policies.routes.item.title', { name: policy.name })"
-                />
-              </XCopyButton>
+              <RouteTitle
+                :title="t('policies.routes.item.title', { name: policy.name })"
+              />
             </h1>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
@@ -48,13 +48,9 @@
             v-slot="{ data: [data] }"
           >
             <h1>
-              <XCopyButton
-                :text="data.name"
-              >
-                <RouteTitle
-                  :title="t('resources.routes.item.title', { name: data.name })"
-                />
-              </XCopyButton>
+              <RouteTitle
+                :title="t('resources.routes.item.title', { name: data.name })"
+              />
             </h1>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailTabsView.vue
@@ -44,11 +44,9 @@
             v-slot="{ data: [service] }"
           >
             <h1>
-              <XCopyButton :text="service.name">
-                <RouteTitle
-                  :title="t('services.routes.item.title', { name: service.name })"
-                />
-              </XCopyButton>
+              <RouteTitle
+                :title="t('services.routes.item.title', { name: service.name })"
+              />
             </h1>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailTabsView.vue
@@ -44,11 +44,9 @@
             v-slot="{ data: [service] }"
           >
             <h1>
-              <XCopyButton :text="service.name">
-                <RouteTitle
-                  :title="t('services.routes.item.title', { name: service.name })"
-                />
-              </XCopyButton>
+              <RouteTitle
+                :title="t('services.routes.item.title', { name: service.name })"
+              />
             </h1>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailTabsView.vue
@@ -48,17 +48,10 @@
               size="small"
             >
               <h1>
-                <XCopyButton :text="service.name">
-                  <RouteTitle
-                    :title="t('services.routes.item.title', { name: service.name })"
-                  />
-                </XCopyButton>
+                <RouteTitle
+                  :title="t('services.routes.item.title', { name: service.name })"
+                />
               </h1>
-              <XBadge
-                :appearance="t(`common.status.appearance.${service.spec.state}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${service.spec.state}`) }}
-              </XBadge>
             </XLayout>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailTabsView.vue
@@ -41,24 +41,17 @@
           <DataLoader
             :data="[data]"
             variant="header"
-            v-slot="{ data: [service] }"
+            v-slot="{ data: [item] }"
           >
             <XLayout
               variant="y-stack"
               size="small"
             >
               <h1>
-                <XCopyButton :text="route.params.service">
-                  <RouteTitle
-                    :title="t('services.routes.item.title', { name: route.params.service })"
-                  />
-                </XCopyButton>
+                <RouteTitle
+                  :title="t('services.routes.item.title', { name: item.name })"
+                />
               </h1>
-              <XBadge
-                :appearance="t(`common.status.appearance.${service.status}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${service.status}`) }}
-              </XBadge>
             </XLayout>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
@@ -48,8 +48,8 @@
               size="small"
             >
               <h1>
-                <XCopyButton
-                  :text="workload.name"
+                <RouteTitle
+                  :title="workload.name"
                 />
               </h1>
               <XBadge

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -57,11 +57,9 @@
               size="small"
             >
               <h1>
-                <XCopyButton :text="zoneEgress.name">
-                  <RouteTitle
-                    :title="t('zone-egresses.routes.item.title', { name: zoneEgress.name })"
-                  />
-                </XCopyButton>
+                <RouteTitle
+                  :title="t('zone-egresses.routes.item.title', { name: zoneEgress.name })"
+                />
               </h1>
               <XBadge
                 :appearance="t(`common.status.appearance.${zoneEgress.state}`, undefined, { defaultMessage: 'neutral' })"

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -52,21 +52,11 @@
             variant="header"
             v-slot="{ data: [zoneEgress] }"
           >
-            <XLayout
-              variant="y-stack"
-              size="small"
-            >
-              <h1>
-                <RouteTitle
-                  :title="t('zone-egresses.routes.item.title', { name: zoneEgress.name })"
-                />
-              </h1>
-              <XBadge
-                :appearance="t(`common.status.appearance.${zoneEgress.state}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${zoneEgress.state}`) }}
-              </XBadge>
-            </XLayout>
+            <h1>
+              <RouteTitle
+                :title="t('zone-egresses.routes.item.title', { name: zoneEgress.name })"
+              />
+            </h1>
           </DataLoader>
         </template>
 

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -55,13 +55,9 @@
               size="small"
             >
               <h1>
-                <XCopyButton
-                  :text="zoneIngress.name"
-                >
-                  <RouteTitle
-                    :title="t('zone-ingresses.routes.item.title', { name: zoneIngress.name })"
-                  />
-                </XCopyButton>
+                <RouteTitle
+                  :title="t('zone-ingresses.routes.item.title', { name: zoneIngress.name })"
+                />
               </h1>
               <XBadge
                 :appearance="t(`common.status.appearance.${zoneIngress.state}`, undefined, { defaultMessage: 'neutral' })"

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -28,32 +28,11 @@
             variant="header"
             v-slot="{ data: [zone] }"
           >
-            <XLayout
-              variant="y-stack"
-              size="small"
-            >
-              <XLayout variant="separated">
-                <template
-                  v-for="env in [(['kubernetes', 'universal'] as const).find(env => env === zone.zoneInsight.environment) ?? 'kubernetes']"
-                  :key="env"
-                >
-                  <XIcon
-                    :name="env"
-                    :size="KUI_ICON_SIZE_50"
-                  >
-                    {{ t(`common.product.environment.${env}`) }}
-                  </XIcon>
-                </template>
-                <h1>
-                  <XCopyButton :text="zone.name" />
-                </h1>
-              </XLayout>
-              <XBadge
-                :appearance="t(`common.status.appearance.${zone.state}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${zone.state}`) }}
-              </XBadge>
-            </XLayout>
+            <h1>
+              <RouteTitle
+                :title="zone.name"
+              />
+            </h1>
           </DataLoader>
         </template>
 
@@ -106,7 +85,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 
 import { useZoneActionGroup } from '../'
 import { sources } from '../sources'

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -23,17 +23,11 @@
         ]"
       >
         <template #title>
-          <DataLoader
-            :data="[data]"
-            variant="header"
-            v-slot="{ data: [zone] }"
-          >
-            <h1>
-              <RouteTitle
-                :title="zone.name"
-              />
-            </h1>
-          </DataLoader>
+          <h1>
+            <RouteTitle
+              :title="route.params.zone"
+            />
+          </h1>
         </template>
 
         <template

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -106,7 +106,7 @@
                     {{ t('zone-cps.routes.item.version') }}
                   </dt>
                   <dd>
-                    <XLayout variant="separated">
+                    <XLayout variant="x-stack">
                       <XBadge
                         :appearance="version?.outdated === true ? 'warning' : 'decorative'"
                       >
@@ -131,7 +131,9 @@
                     {{ t('http.api.property.type') }}
                   </dt>
                   <dd>
-                    <XBadge appearance="decorative">
+                    <XBadge
+                      appearance="decorative"
+                    >
                       {{ t(`common.product.environment.${zone.zoneInsight.environment || 'unknown'}`) }}
                     </XBadge>
                   </dd>


### PR DESCRIPTION
This PR mainly removes the XCopyButtons from around the page titles of detail pages.

There are a couple of other amends here to remove extra graphical elements around the title in a couple of other places:

- Any `status` elements like online/offline etc
- Any icons like `kubernetes`/`universal` for zones

Lastly I also noticed a couple of other places where we weren't using RouteTitle on detail pages to set the title of the page. So I added those here also.