### PR TITLE
chore(deps): enable @kong-ui-public/app-layout upgrades via renovate

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -81,11 +81,9 @@
     {
       "description": [
         " Disable:",
-        " - `@kong-ui-public/app-layout`: downstream conflicts due to pinned versions",
         " - `escape-string-regexp`: need to stick with current version because of esm vs cjs"
       ],
       "matchPackageNames": [
-        "@kong-ui-public/app-layout",
         "escape-string-regexp"
       ],
       "enabled": false


### PR DESCRIPTION
Whilst we need tighter control over `@kong-ui-public/app-layout` (which we have in-place) we still want renovate to do the upgrade for us.

In practice the renovate PR for this upgrade will probably hang around for a while until we choose to upgrade.