### PR TITLE
fix(x-layout): x-stack elements dont take available space

### DIFF
--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -25,7 +25,7 @@
         >
           <XLayout
             variant="x-stack"
-            size="max"
+            size="large"
           >
             <XCard
               class="policy-type-list"
@@ -121,6 +121,10 @@ import { sources } from '@/app/policies/sources'
   top: calc(var(--AppHeaderHeight) + var(--x-space-70));
   align-self: flex-start;
   max-width: 500px;
+
+  & + * {
+    flex: 1;
+  }
 }
 ul {
   list-style-type: none;

--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -25,7 +25,7 @@
         >
           <XLayout
             variant="x-stack"
-            size="large"
+            size="max"
           >
             <XCard
               class="policy-type-list"

--- a/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
@@ -27,7 +27,7 @@
           >
             <XLayout
               variant="x-stack"
-              size="max"
+              size="large"
             >
               <XCard class="resource-type-collection">
                 <template #actions>
@@ -178,6 +178,10 @@ import { sources } from '@/app/resources/sources'
 .resource-type-collection {
   max-width: 500px;
   align-self: flex-start;
+
+  & + * {
+    flex: 1;
+  }
 }
 
 ul {

--- a/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
@@ -27,7 +27,7 @@
           >
             <XLayout
               variant="x-stack"
-              size="large"
+              size="max"
             >
               <XCard class="resource-type-collection">
                 <template #actions>

--- a/packages/x/src/components/x-layout/XLayout.vue
+++ b/packages/x/src/components/x-layout/XLayout.vue
@@ -47,12 +47,6 @@ const justify = computed(() => table?.props.variant === 'kv' || props.variant ==
   display: flex;
   width: 100%;
   flex-wrap: nowrap;
-
-  &.max {
-    > * {
-      flex: 1;
-    }
-  }
 }
 .action-group {
   display: flex;
@@ -76,7 +70,6 @@ const justify = computed(() => table?.props.variant === 'kv' || props.variant ==
   &.normal {
     gap: var(--x-space-40);
   }
-  &.max,
   &.large {
     gap: var(--x-space-80);
   }

--- a/packages/x/src/components/x-layout/XLayout.vue
+++ b/packages/x/src/components/x-layout/XLayout.vue
@@ -47,6 +47,12 @@ const justify = computed(() => table?.props.variant === 'kv' || props.variant ==
   display: flex;
   width: 100%;
   flex-wrap: nowrap;
+
+  &.max {
+    > * {
+      flex: 1;
+    }
+  }
 }
 .action-group {
   display: flex;
@@ -70,6 +76,7 @@ const justify = computed(() => table?.props.variant === 'kv' || props.variant ==
   &.normal {
     gap: var(--x-space-40);
   }
+  &.max,
   &.large {
     gap: var(--x-space-80);
   }


### PR DESCRIPTION
In `Resources` and `Policies` we have nested views that are being layed out via `XLayout` and `x-stack`. That caused that the nested views only take the space that it needed. On wide screens that meant some white space.
~I've changed the `size` attribute on these `XLayout`s to `max` and for that case let children grow. So far we've only used `size=max` in summary views for `variant=separated`, which will not conflict.~

**Before**
<img width="3011" height="1332" alt="Screenshot 2026-06-09 at 12 09 50" src="https://github.com/user-attachments/assets/26b65c0b-de7b-48c5-bf51-7ef2b67a1b83" />

<img width="2996" height="1335" alt="Screenshot 2026-06-09 at 12 09 56" src="https://github.com/user-attachments/assets/fb37cc0c-ce57-4132-ba1d-359d9aaebbfb" />

**After**

<img width="3012" height="1334" alt="Screenshot 2026-06-09 at 12 08 23" src="https://github.com/user-attachments/assets/aa91c3ae-9d23-4323-a7c2-8981c497b6df" />

<img width="2998" height="1335" alt="Screenshot 2026-06-09 at 12 08 07" src="https://github.com/user-attachments/assets/da03b87e-a2c9-4b79-ab07-a72ab978b13c" />
