### PR TITLE
fix(dataplanes): inconsistent casing for zone-proxies

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Index.feature
@@ -302,7 +302,7 @@ Feature: mesh / dataplanes / index
       And the "$item:nth-child(1)" element contains
         | Value               |
         | fake-zone-ingress-0 |
-        | Zone ingress        |
+        | ZoneIngress        |
 
     Scenario: Filtering by "zone-egress"
       Given the environment
@@ -334,4 +334,4 @@ Feature: mesh / dataplanes / index
       And the "$item:nth-child(1)" element contains
         | Value              |
         | fake-zone-egress-0 |
-        | Zone egress        |
+        | ZoneEgress         |

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Index.feature
@@ -35,5 +35,5 @@ Feature: mesh / dataplanes / item / overview
     Then the "$about-section" element exists
     And the "$about-section" element contains "zone-1"
     And the "$about-section" element contains "kuma.io/origin:zone"
-    And the "$about-section" element contains "Zone ingress"
-    And the "$about-section" element contains "Zone egress"
+    And the "$about-section" element contains "ZoneIngress"
+    And the "$about-section" element contains "ZoneEgress"

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -172,5 +172,5 @@ data-planes:
     builtin: 'Built-in gateway'
     delegated: 'Delegated gateway'
     zone-proxy: 'Zone proxy'
-    zone-ingress: 'Zone ingress'
-    zone-egress: 'Zone egress'
+    zone-ingress: 'ZoneIngress'
+    zone-egress: 'ZoneEgress'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -172,7 +172,7 @@
                     </div>
                     <div v-if="props.data.zoneProxyTypes.length > 0">
                       <dt>
-                        {{ t('http.api.property.zone-proxy') }}
+                        {{ t('data-planes.type.zone-proxy') }}
                       </dt>
                       <dd>
                         <XLayout

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -146,7 +146,7 @@
                   </tr>
                   <tr v-if="item.zoneProxyTypes.length > 0">
                     <th scope="row">
-                      {{ t('http.api.property.zone-proxy') }}
+                      {{ t('data-planes.type.zone-proxy') }}
                     </th>
                     <td>
                       <XLayout


### PR DESCRIPTION
Ensures consistent casing for `ZoneIngress`, `ZoneEgress` and changes `Zone-proxy` title to `Zone proxy`.

Closes https://github.com/kumahq/kuma-gui/issues/4999