### PR TITLE
chore: adds labels to almost all remaining summaries

### DIFF
--- a/packages/kuma-gui/features/mesh/MeshIdentity.feature
+++ b/packages/kuma-gui/features/mesh/MeshIdentity.feature
@@ -2,10 +2,10 @@ Feature: mesh / mesh-identity
 
   Background:
     Given the CSS selectors
-      | Alias     | Selector                           |
-      | mesh-mtls | [data-testid="mesh-mtls"]          |
-      | summary   | [data-testid="slideout-container"] |
-      | summary-title      | $summary [data-testid='slideout-title']  |
+      | Alias         | Selector                                |
+      | mesh-mtls     | [data-testid="mesh-mtls"]               |
+      | summary       | [data-testid="slideout-container"]      |
+      | summary-title | $summary [data-testid='slideout-title'] |
     And the environment
       """
       KUMA_MTLS_ENABLED: false

--- a/packages/kuma-gui/features/mesh/MeshTrust.feature
+++ b/packages/kuma-gui/features/mesh/MeshTrust.feature
@@ -2,11 +2,11 @@ Feature: mesh / mesh-trust
 
   Background:
     Given the CSS selectors
-      | Alias              | Selector                            |
-      | meshtrusts-listing | [data-testid="mesh-trusts-listing"] |
-      | item               | $meshtrusts-listing tbody tr        |
-      | summary            | [data-testid="slideout-container"]  |
-      | summary-title      | $summary [data-testid='slideout-title']  |
+      | Alias              | Selector                                |
+      | meshtrusts-listing | [data-testid="mesh-trusts-listing"]     |
+      | item               | $meshtrusts-listing tbody tr            |
+      | summary            | [data-testid="slideout-container"]      |
+      | summary-title      | $summary [data-testid='slideout-title'] |
 
   Scenario: MeshTrusts are listed in mesh overview
     Given the URL "/meshes/default/meshtrusts" responds with

--- a/packages/kuma-gui/features/mesh/legacy-dataplanes/Navigation.feature
+++ b/packages/kuma-gui/features/mesh/legacy-dataplanes/Navigation.feature
@@ -75,8 +75,8 @@ Feature: mesh / dataplanes / navigation
           - name: monitor-proxy-0
             labels:
               kuma.io/display-name: monitor-proxy-0
-
-
+        
+        
         """
 
     Scenario Outline: clicking the detail link

--- a/packages/kuma-gui/src/app/gateways/data/MeshGateway.ts
+++ b/packages/kuma-gui/src/app/gateways/data/MeshGateway.ts
@@ -1,25 +1,36 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
-import type { PaginatedApiListResponse } from '@/types/api.d'
-import type {
-  MeshGateway as PartialMeshGateway,
-} from '@/types/index.d'
-type PartialMeshGatewayList = PaginatedApiListResponse<PartialMeshGateway>
+import type { components } from '@kumahq/kuma-http-api'
+
+type KumaMeshGatewayList = components['responses']['MeshGatewayList']['content']['application/json']
+type KumaMeshGateway = components['schemas']['MeshGatewayItem']
 
 export const MeshGateway = {
   search(query: string) {
     return Resource.search(query)
   },
 
-  fromObject(item: PartialMeshGateway) {
-    const labels = typeof item.labels !== 'undefined' ? item.labels : {}
+  fromObject(item: KumaMeshGateway) {
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
     return {
       ...item,
+      kri: 'kri' in item ? item.kri ?? Kri.toString({ shortName: 'mgw', mesh, zone, namespace, name }) : '',
+      name,
+      mesh,
       labels,
-      id: item.name,
-      zone: labels['kuma.io/zone'] ?? '',
+      creationTime: String('creationTime' in item ? item.creationTime ?? '' : ''),
+      modificationTime: String('modificationTime' in item ? item.modificationTime ?? '' : ''),
+      // aliases
+      id,
+      namespace,
+      zone,
       origin: labels['kuma.io/origin'] ?? '',
-      name: labels['kuma.io/display-name'] ?? item.name,
-      namespace: labels['k8s.kuma.io/namespace'] ?? '',
       config: item,
       selectors: Array.isArray(item.selectors) ? item.selectors : [],
       conf: ((item = {}) => ({
@@ -30,7 +41,7 @@ export const MeshGateway = {
               ...item,
               // An omitted hostname implies the wildcard hostname (meaning any hostname applies).
               hostname: item.hostname ?? '*',
-              protocol: item.protocol ?? 'TCP',
+              protocol: typeof item.protocol !== 'undefined' ? String(item.protocol) : 'TCP',
             }
           })
           : [],
@@ -38,7 +49,7 @@ export const MeshGateway = {
     }
   },
 
-  fromCollection(collection: PartialMeshGatewayList) {
+  fromCollection(collection: KumaMeshGatewayList) {
     const items = Array.isArray(collection.items) ? collection.items.map(MeshGateway.fromObject) : []
     return {
       ...collection,

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -34,7 +34,7 @@
             <DataLoader
               :src="uri(dataplaneSources, '/meshes/:mesh/dataplanes/for/service-insight/:service', {
                 mesh: route.params.mesh,
-                service: gatewayData.selectors[0].match['kuma.io/service'],
+                service: gatewayData.selectors[0].match?.['kuma.io/service'] ?? '',
               }, {
                 page: route.params.page,
                 size: route.params.size,

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewaySummaryView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewaySummaryView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -142,45 +142,6 @@
                     <td>{{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}</td>
                   </tr>
                   <tr
-                    v-if="Object.keys(item.labels).length > 0"
-                  >
-                    <th scope="row">
-                      {{ t('gateways.routes.item.labels') }}
-                    </th>
-                    <td>
-                      <XLayout
-                        variant="separated"
-                        justify="end"
-                      >
-                        <template
-                          v-for="([key, value]) in Object.entries(item.labels)"
-                          :key="`${key}:${value}`"
-                        >
-                          <XBadge
-                            appearance="info"
-                            class="label"
-                          >
-                            <template v-if="key.includes('kuma.io/zone')">
-                              <XAction
-                                :to="{
-                                  name: 'builtin-gateway-list-view',
-                                  query: {
-                                    s: `zone:${value}`,
-                                  },
-                                }"
-                              >
-                                {{ key }}:{{ value }}
-                              </XAction>
-                            </template>
-                            <template v-else>
-                              {{ key }}:{{ value }}
-                            </template>
-                          </XBadge>
-                        </template>
-                      </XLayout>
-                    </td>
-                  </tr>
-                  <tr
                     v-if="item.selectors.length > 0"
                   >
                     <th scope="row">
@@ -192,12 +153,41 @@
                         justify="end"
                       >
                         <XBadge
-                          v-for="([key, value]) in Object.entries(item.selectors[0].match)"
+                          v-for="([key, value]) in Object.entries(item.selectors[0].match ?? {})"
                           :key="`${key}:${value}`"
                           appearance="info"
                         >
                           {{ key }}:{{ value }}
                         </XBadge>
+                      </XLayout>
+                    </td>
+                  </tr>
+                  <tr
+                    v-if="Object.keys(item.labels).length > 0"
+                  >
+                    <th scope="row">
+                      Labels
+                    </th>
+                    <td>
+                      <XLayout
+                        variant="separated"
+                      >
+                        <XAction
+                          v-for="(value, key) in item.labels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: '',
+                            zone: item.zone,
+                            namespace: item.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
+                        >
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                          >
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
                       </XLayout>
                     </td>
                   </tr>

--- a/packages/kuma-gui/src/app/hostname-generators/data/HostnameGenerator.ts
+++ b/packages/kuma-gui/src/app/hostname-generators/data/HostnameGenerator.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import type { components } from '@kumahq/kuma-http-api'
 
@@ -11,18 +12,22 @@ export const HostnameGenerator = {
 
   fromObject(item: HostnameGeneratorItem) {
     const labels = item.labels ?? {}
-    const name = labels['kuma.io/display-name'] ?? item.name
+    const id = item.name
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
 
     return {
       ...item,
-      id: item.name,
+      kri: item.kri ?? Kri.toString({ shortName: 'hg', mesh: '', zone, namespace, name }),
       name,
-      namespace,
-      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
+      labels,
       creationTime: item.creationTime ?? '',
       modificationTime: item.modificationTime ?? '',
-      labels,
+      // aliases
+      id,
+      namespace,
+      zone,
       spec: ((item = { template: '' }) => {
         return {
           ...item,

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
@@ -8,7 +8,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, can, uri }"
+    v-slot="{ route, t, can, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -110,6 +110,35 @@
                     {{ t('hostname-generators.common.template') }}
                   </th>
                   <td>{{ item.spec.template }}</td>
+                </tr>
+                <tr
+                  v-if="Object.keys(item.labels).length > 0"
+                >
+                  <th scope="row">
+                    Labels
+                  </th>
+                  <td>
+                    <XLayout
+                      variant="separated"
+                    >
+                      <XAction
+                        v-for="(value, key) in item.labels"
+                        :key="key"
+                        :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                          mesh: '',
+                          zone: item.zone,
+                          namespace: item.namespace,
+                          name: value,
+                        }, { defaultMessage: '' })"
+                      >
+                        <XBadge
+                          :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                        >
+                          {{ key }}:<strong>{{ value }}</strong>
+                        </XBadge>
+                      </XAction>
+                    </XLayout>
+                  </td>
                 </tr>
               </XTable>
             </template>

--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/KumaApi.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/KumaApi.ts
@@ -13,7 +13,6 @@ import type {
   DataPlaneOverview,
   ExternalService,
   InspectRulesForDataplane,
-  MeshGateway,
   MeshGatewayDataplane,
   PolicyDataplane,
   PolicyEntity,
@@ -26,6 +25,9 @@ import type {
   ZoneIngressOverview,
   ZoneOverview,
 } from '@/types/index.d'
+import type { components } from '@kumahq/kuma-http-api'
+type KumaMeshGateway = components['schemas']['MeshGatewayItem']
+type KumaMeshGatewayList = components['responses']['MeshGatewayList']['content']['application/json']
 
 
 export default class KumaApi extends Api {
@@ -208,11 +210,11 @@ export default class KumaApi extends Api {
     return this.client.get(`/meshes/${mesh}/${path}/${name}`, { params })
   }
 
-  getAllMeshGatewaysFromMesh({ mesh }: { mesh: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<MeshGateway>> {
+  getAllMeshGatewaysFromMesh({ mesh }: { mesh: string }, params?: PaginationParameters): Promise<KumaMeshGatewayList> {
     return this.client.get(`/meshes/${mesh}/meshgateways`, { params })
   }
 
-  getMeshGateway({ mesh, name }: { mesh: string, name: string }, params?: SingleResourceParameters): Promise<MeshGateway> {
+  getMeshGateway({ mesh, name }: { mesh: string, name: string }, params?: SingleResourceParameters): Promise<KumaMeshGateway> {
     return this.client.get(`/meshes/${mesh}/meshgateways/${name}`, { params })
   }
 

--- a/packages/kuma-gui/src/app/mesh-identities/data/MeshIdentity.ts
+++ b/packages/kuma-gui/src/app/mesh-identities/data/MeshIdentity.ts
@@ -1,8 +1,8 @@
 import { Kri } from '@/app/kuma/kri'
 import type { components } from '@kumahq/kuma-http-api'
 
-export type KumaMeshIdentityList = components['responses']['MeshIdentityList']['content']['application/json']
-export type KumaMeshIdentity = components['schemas']['MeshIdentityItem']
+type KumaMeshIdentityList = components['responses']['MeshIdentityList']['content']['application/json']
+type KumaMeshIdentity = components['schemas']['MeshIdentityItem']
 
 export const MeshIdentity = {
   fromObject: (item: KumaMeshIdentity) => {

--- a/packages/kuma-gui/src/app/mesh-identities/sources.ts
+++ b/packages/kuma-gui/src/app/mesh-identities/sources.ts
@@ -1,10 +1,11 @@
 import createClient from 'openapi-fetch'
 
 import { MeshIdentity } from './data'
-import type { KumaMeshIdentity } from './data'
 import { defineSources } from '@/app/application'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
-import type { paths } from '@kumahq/kuma-http-api'
+import type { paths, components } from '@kumahq/kuma-http-api'
+
+type KumaMeshIdentity = components['schemas']['MeshIdentityItem']
 
 export const sources = (api: KumaApi) => {
   const http = createClient<paths>({
@@ -14,7 +15,7 @@ export const sources = (api: KumaApi) => {
   return defineSources({
     '/meshes/:mesh/meshidentities': async (params) => {
       const { mesh } = params
-  
+
       const res = await http.GET('/meshes/{mesh}/meshidentities', {
         params: {
           path: {
@@ -22,13 +23,13 @@ export const sources = (api: KumaApi) => {
           },
         },
       })
-  
+
       return MeshIdentity.fromCollection(res.data!)
     },
 
     '/meshidentities/:mid': async (params) => {
       const { mid } = params
-  
+
       const res = await http.GET('/_kri/{kri}', {
         params: {
           path: {
@@ -36,13 +37,13 @@ export const sources = (api: KumaApi) => {
           },
         },
       })
-  
+
       return MeshIdentity.fromObject(res.data as KumaMeshIdentity)
     },
 
     '/meshidentities/:mid/as/kubernetes': async (params) => {
       const { mid } = params
-  
+
       const res = await http.GET('/_kri/{kri}', {
         params: {
           path: {
@@ -54,7 +55,7 @@ export const sources = (api: KumaApi) => {
           },
         },
       })
-  
+
       return res.data
     },
   })

--- a/packages/kuma-gui/src/app/mesh-trusts/data/MeshTrust.ts
+++ b/packages/kuma-gui/src/app/mesh-trusts/data/MeshTrust.ts
@@ -1,8 +1,8 @@
 import { Kri } from '@/app/kuma/kri'
 import type { components } from '@kumahq/kuma-http-api'
 
-export type KumaMeshTrustList = components['responses']['MeshTrustList']['content']['application/json']
-export type KumaMeshTrust = components['schemas']['MeshTrustItem']
+type KumaMeshTrustList = components['responses']['MeshTrustList']['content']['application/json']
+type KumaMeshTrust = components['schemas']['MeshTrustItem']
 
 export const MeshTrust = {
   fromObject: (item: KumaMeshTrust) => {

--- a/packages/kuma-gui/src/app/mesh-trusts/sources.ts
+++ b/packages/kuma-gui/src/app/mesh-trusts/sources.ts
@@ -1,10 +1,11 @@
 import createClient from 'openapi-fetch'
 
 import { MeshTrust } from './data'
-import type { KumaMeshTrust } from './data'
 import { defineSources } from '@/app/application'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
-import type { paths } from '@kumahq/kuma-http-api'
+import type { paths, components } from '@kumahq/kuma-http-api'
+
+type KumaMeshTrust = components['schemas']['MeshTrustItem']
 
 export const sources = (api: KumaApi) => {
   const http = createClient<paths>({
@@ -14,7 +15,7 @@ export const sources = (api: KumaApi) => {
   return defineSources({
     '/meshes/:mesh/meshtrusts': async (params) => {
       const { mesh } = params
-  
+
       const res = await http.GET('/meshes/{mesh}/meshtrusts', {
         params: {
           path: {
@@ -22,13 +23,13 @@ export const sources = (api: KumaApi) => {
           },
         },
       })
-  
+
       return MeshTrust.fromCollection(res.data!)
     },
 
     '/meshtrusts/:mtrust': async (params) => {
       const { mtrust } = params
-  
+
       const res = await http.GET('/_kri/{kri}', {
         params: {
           path: {
@@ -36,13 +37,13 @@ export const sources = (api: KumaApi) => {
           },
         },
       })
-  
+
       return MeshTrust.fromObject(res.data as KumaMeshTrust)
     },
 
     '/meshtrusts/:mtrust/as/kubernetes': async (params) => {
       const { mtrust } = params
-  
+
       const res = await http.GET('/_kri/{kri}', {
         params: {
           path: {
@@ -54,7 +55,7 @@ export const sources = (api: KumaApi) => {
           },
         },
       })
-  
+
       return res.data
     },
   })

--- a/packages/kuma-gui/src/app/policies/components/PolicySummary.vue
+++ b/packages/kuma-gui/src/app/policies/components/PolicySummary.vue
@@ -60,6 +60,35 @@
             </XAction>
           </td>
         </tr>
+        <tr
+          v-if="Object.keys(props.policy.labels).length > 0"
+        >
+          <th scope="row">
+            Labels
+          </th>
+          <td>
+            <XLayout
+              variant="separated"
+            >
+              <XAction
+                v-for="(value, key) in props.policy.labels"
+                :key="key"
+                :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                  mesh: props.policy.mesh,
+                  zone: props.policy.zone,
+                  namespace: props.policy.namespace,
+                  name: value,
+                }, { defaultMessage: '' })"
+              >
+                <XBadge
+                  :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                >
+                  {{ key }}:<strong>{{ value }}</strong>
+                </XBadge>
+              </XAction>
+            </XLayout>
+          </td>
+        </tr>
       </XTable>
       <XCodeBlock
         language="yaml"
@@ -92,9 +121,10 @@
 <script lang="ts" setup>
 
 import type { Policy } from '../data'
-import { useI18n, useCan, YAML } from '@/app/application'
+import { useI18n, useCan, useRegExp, YAML } from '@/app/application'
 
 const { t } = useI18n()
+const { r } = useRegExp()
 const can = useCan()
 
 const props = defineProps<{

--- a/packages/kuma-gui/src/app/policies/data/Policy.ts
+++ b/packages/kuma-gui/src/app/policies/data/Policy.ts
@@ -17,14 +17,25 @@ export const Policy = {
   },
 
   fromObject(item: KumaPolicy) {
-    const labels = typeof item.labels !== 'undefined' ? item.labels : {}
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
     return {
       ...item,
+      kri: 'kri' in item ? item.kri ?? '' : '',
+      name,
+      mesh,
       labels,
-      id: item.name,
-      name: labels['kuma.io/display-name'] ?? item.name,
-      namespace: labels['k8s.kuma.io/namespace'] ?? '',
-      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
       // ideally this would be done upstream, or we add it to our overlays. For now we check at runtime
       role: (['producer', 'consumer', 'system', 'workload-owner'] as const).find((item) => item === labels['kuma.io/policy-role']) ?? 'system',
       config: item,

--- a/packages/kuma-gui/src/app/resources/data/Resource.ts
+++ b/packages/kuma-gui/src/app/resources/data/Resource.ts
@@ -6,7 +6,7 @@ import type { paths } from '@kumahq/kuma-http-api'
  * Therefore we are only assuming that it's an object of unknown entries and we shape it to what we expect in the data layer.
  */
 type KumaResourceCollection = Record<string, unknown>
-export type KumaResource = paths['/_kri/{kri}']['get']['responses']['200']['content']['application/json']
+type KumaResource = paths['/_kri/{kri}']['get']['responses']['200']['content']['application/json']
 
 
 /**

--- a/packages/kuma-gui/src/app/services/data/MeshExternalService.ts
+++ b/packages/kuma-gui/src/app/services/data/MeshExternalService.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import type { components } from '@kumahq/kuma-http-api'
 type GeneratedMeshExternalService = components['schemas']['MeshExternalServiceItem']
@@ -10,15 +11,24 @@ export const MeshExternalService = {
 
   fromObject(item: GeneratedMeshExternalService) {
     const labels = item.labels ?? {}
-    const name = labels['kuma.io/display-name'] ?? item.name
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
     return {
       ...item,
-      id: item.name,
+      kri: item.kri ?? Kri.toString({ shortName: 'extsvc', mesh, zone, namespace, name }),
       name,
-      namespace,
+      mesh,
       labels,
-      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
       status: ((item = {}) => {
         return {
           ...item,

--- a/packages/kuma-gui/src/app/services/data/MeshMultiZoneService.ts
+++ b/packages/kuma-gui/src/app/services/data/MeshMultiZoneService.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import type { components } from '@kumahq/kuma-http-api'
 type Generated = components['schemas']['MeshMultiZoneServiceItem']
@@ -10,14 +11,24 @@ const Entity = {
 
   fromObject(item: Generated) {
     const labels = item.labels ?? {}
-    const name = labels['kuma.io/display-name'] ?? item.name
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
     return {
       ...item,
-      id: item.name,
+      kri: item.kri ?? Kri.toString({ shortName: 'mzsvc', mesh, zone, namespace, name }),
       name,
-      namespace,
+      mesh,
       labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
       spec: ((item) => {
         return {
           ...item,

--- a/packages/kuma-gui/src/app/services/data/MeshService.ts
+++ b/packages/kuma-gui/src/app/services/data/MeshService.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import type { components } from '@kumahq/kuma-http-api'
 type GeneratedMeshService = components['schemas']['MeshServiceItem']
@@ -10,15 +11,23 @@ export const MeshService = {
 
   fromObject(item: GeneratedMeshService) {
     const labels = item.labels ?? {}
-    const name = labels['kuma.io/display-name'] ?? item.name
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
     return {
       ...item,
-      id: item.name,
+      kri: item.kri ?? Kri.toString({ shortName: 'msvc', mesh, zone, namespace, name }),
       name,
-      namespace,
+      mesh,
       labels,
-      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
       spec: ((item) => {
         return {
           ...item,

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceSummaryView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, can, uri }"
+    v-slot="{ route, t, can, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -126,6 +126,35 @@
                     >
                       {{ item.spec.tls?.enabled ? 'Enabled' : 'Disabled' }}
                     </XBadge>
+                  </td>
+                </tr>
+                <tr
+                  v-if="Object.keys(item.labels).length > 0"
+                >
+                  <th scope="row">
+                    Labels
+                  </th>
+                  <td>
+                    <XLayout
+                      variant="separated"
+                    >
+                      <XAction
+                        v-for="(value, key) in item.labels"
+                        :key="key"
+                        :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                          mesh: item.mesh,
+                          zone: item.zone,
+                          namespace: item.namespace,
+                          name: value,
+                        }, { defaultMessage: '' })"
+                      >
+                        <XBadge
+                          :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                        >
+                          {{ key }}:<strong>{{ value }}</strong>
+                        </XBadge>
+                      </XAction>
+                    </XLayout>
                   </td>
                 </tr>
               </XTable>

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -84,7 +84,6 @@
                   <td>
                     <XLayout
                       variant="separated"
-                      truncate
                     >
                       <KumaPort
                         v-for="connection in item.spec.ports"
@@ -104,7 +103,6 @@
                   <td>
                     <XLayout
                       variant="separated"
-                      truncate
                     >
                       <XBadge
                         v-for="(value, key) in item.spec.selector.meshService.matchLabels"
@@ -113,6 +111,35 @@
                       >
                         {{ key }}:{{ value }}
                       </XBadge>
+                    </XLayout>
+                  </td>
+                </tr>
+                <tr
+                  v-if="Object.keys(item.labels).length > 0"
+                >
+                  <th scope="row">
+                    Labels
+                  </th>
+                  <td>
+                    <XLayout
+                      variant="separated"
+                    >
+                      <XAction
+                        v-for="(value, key) in item.labels"
+                        :key="key"
+                        :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                          mesh: item.mesh,
+                          zone: item.zone,
+                          namespace: item.namespace,
+                          name: value,
+                        }, { defaultMessage: '' })"
+                      >
+                        <XBadge
+                          :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                        >
+                          {{ key }}:<strong>{{ value }}</strong>
+                        </XBadge>
+                      </XAction>
                     </XLayout>
                   </td>
                 </tr>

--- a/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, can, uri }"
+    v-slot="{ route, t, can, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -131,7 +131,6 @@
                   <td>
                     <XLayout
                       variant="separated"
-                      truncate
                     >
                       <KumaPort
                         v-for="connection in item.spec.ports"
@@ -151,7 +150,6 @@
                   <td>
                     <XLayout
                       variant="separated"
-                      truncate
                     >
                       <XBadge
                         v-for="(value, key) in item.spec.selector.dataplaneTags"
@@ -160,6 +158,35 @@
                       >
                         {{ key }}:{{ value }}
                       </XBadge>
+                    </XLayout>
+                  </td>
+                </tr>
+                <tr
+                  v-if="Object.keys(item.labels).length > 0"
+                >
+                  <th scope="row">
+                    Labels
+                  </th>
+                  <td>
+                    <XLayout
+                      variant="separated"
+                    >
+                      <XAction
+                        v-for="(value, key) in item.labels"
+                        :key="key"
+                        :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                          mesh: item.mesh,
+                          zone: item.zone,
+                          namespace: item.namespace,
+                          name: value,
+                        }, { defaultMessage: '' })"
+                      >
+                        <XBadge
+                          :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                        >
+                          {{ key }}:<strong>{{ value }}</strong>
+                        </XBadge>
+                      </XAction>
                     </XLayout>
                   </td>
                 </tr>

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
@@ -210,34 +210,4 @@ describe('ZoneEgressOverview', () => {
       },
     )
   })
-
-  describe('zoneIngressOverview.config', () => {
-    test('config is derived from name, timestamps, mesh and zoneIngress of item', async ({ fixture }) => {
-      const expected = {
-        type: 'ZoneEgress',
-        name: 'zone-egress-name.zone-egress-namespace',
-        mesh: 'mesh-0',
-        zone: 'zone-0',
-        creationTime: '2021-07-13T08:40:59Z',
-        modificationTime: '2021-07-13T08:40:59Z',
-        networking: {
-          address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
-          port: 58936,
-        },
-      }
-      const actual = await fixture.setup((item) => {
-        item.name = expected.name
-        item.mesh = expected.mesh
-        item.creationTime = expected.creationTime
-        item.modificationTime = expected.modificationTime
-        item.zoneEgress = {
-          networking: expected.networking,
-          zone: expected.zone,
-        }
-
-        return item
-      })
-      expect(actual.config).toStrictEqual(expected)
-    })
-  })
 })

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import { DiscoverySubscriptionCollection, Subscription } from '@/app/subscriptions/data'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
@@ -27,6 +28,7 @@ export const ZoneEgress = {
 export const ZoneEgressInsight = {
   fromObject: (item: PartialZoneEgressInsight | undefined) => {
     const collection = DiscoverySubscriptionCollection.fromArray(item?.subscriptions)
+
     return {
       ...item,
       ...collection,
@@ -64,25 +66,43 @@ export const ZoneEgressOverview = {
   fromObject: (item: PartialZoneEgressOverview) => {
     const zoneEgressInsight = ZoneEgressInsight.fromObject(item.zoneEgressInsight)
     const zoneEgress = InternalZoneEgress.fromObject(item.zoneEgress)
-    const zoneEgressConfig = ZoneEgress.fromObject({
-      type: 'ZoneEgress',
-      name: item.name,
-      creationTime: item.creationTime,
-      modificationTime: item.modificationTime,
-      mesh: item.mesh,
-      ...item.zoneEgress,
-    }).config
-    const labels = typeof item.labels !== 'undefined' ? item.labels : {}
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
+
+    const kri = Kri.toString({ shortName: 'ze', mesh, zone, namespace, name })
 
     return {
       ...item,
-      config: zoneEgressConfig,
-      id: item.name,
-      name: labels['kuma.io/display-name'] ?? item.name,
-      namespace: labels['k8s.kuma.io/namespace'] ?? '',
+      kri,
+      name,
+      mesh,
       labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
+
       zoneEgressInsight,
       zoneEgress,
+      config: {
+        ...ZoneEgress.fromObject({
+          type: 'ZoneEgress',
+          name: item.name,
+          mesh: item.mesh,
+          kri,
+          creationTime: item.creationTime,
+          modificationTime: item.modificationTime,
+          ...item.zoneEgress,
+        }).config,
+        ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
+      },
       // it is possible to have zoneEgresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least
       state: typeof zoneEgressInsight.connectedSubscription !== 'undefined' ? 'online' as const : 'offline' as const,

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -8,7 +8,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -131,6 +131,35 @@
                       <template v-else>
                         {{ t('common.detail.none') }}
                       </template>
+                    </td>
+                  </tr>
+                  <tr
+                    v-if="Object.keys(item.labels).length > 0"
+                  >
+                    <th scope="row">
+                      Labels
+                    </th>
+                    <td>
+                      <XLayout
+                        variant="separated"
+                      >
+                        <XAction
+                          v-for="(value, key) in item.labels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: '',
+                            zone: item.zone,
+                            namespace: item.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
+                        >
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                          >
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
+                      </XLayout>
                     </td>
                   </tr>
                 </XTable>

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
@@ -283,45 +283,4 @@ describe('ZoneIngressOverview', () => {
       },
     )
   })
-  describe('zoneIngressOverview.config', () => {
-    test('config is derived from name, timestamps, mesh and zoneIngress of item', async ({ fixture }) => {
-      const expected = {
-        type: 'ZoneIngress',
-        name: 'zone-ingress-name.zone-ingress-namespace',
-        mesh: 'mesh-0',
-        zone: 'zone-0',
-        creationTime: '2021-07-13T08:40:59Z',
-        modificationTime: '2021-07-13T08:40:59Z',
-        availableServices: [{
-          instances: 50,
-          mesh: 'mesh-0',
-          tags: {
-            app: 'programm-app',
-            'kuma.io/zone': 'zone-0',
-            'kuma.io/service': 'program-app_alarm_svc_36676',
-          },
-        }],
-        networking: {
-          address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
-          advertisedAddress: '190.26.201.59',
-          advertisedPort: 58329,
-          port: 58936,
-        },
-      }
-      const actual = await fixture.setup((item) => {
-        item.name = expected.name
-        item.mesh = expected.mesh
-        item.creationTime = expected.creationTime
-        item.modificationTime = expected.modificationTime
-        item.zoneIngress = {
-          availableServices: expected.availableServices,
-          networking: expected.networking,
-          zone: expected.zone,
-        }
-
-        return item
-      })
-      expect(actual.config).toStrictEqual(expected)
-    })
-  })
 })

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import { DiscoverySubscriptionCollection, Subscription } from '@/app/subscriptions/data'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
@@ -72,25 +73,42 @@ export const ZoneIngressOverview = {
   fromObject: (item: PartialZoneIngressOverview) => {
     const zoneIngressInsight = ZoneIngressInsight.fromObject(item.zoneIngressInsight)
     const zoneIngress = InternalZoneIngress.fromObject(item.zoneIngress)
-    const zoneIngressConfig = ZoneIngress.fromObject({
-      type: 'ZoneIngress',
-      name: item.name,
-      creationTime: item.creationTime,
-      modificationTime: item.modificationTime,
-      mesh: item.mesh,
-      ...item.zoneIngress,
-    }).config
-    const labels = typeof item.labels !== 'undefined' ? item.labels : {}
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
+    const kri = Kri.toString({ shortName: 'zi', mesh, zone, namespace, name })
 
     return {
       ...item,
-      id: item.name,
-      name: labels['kuma.io/display-name'] ?? item.name,
-      namespace: labels['k8s.kuma.io/namespace'] ?? '',
+      kri,
+      name,
+      mesh,
       labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
+
       zoneIngressInsight,
       zoneIngress,
-      config: zoneIngressConfig,
+      config: {
+        ...ZoneIngress.fromObject({
+          type: 'ZoneIngress',
+          name: item.name,
+          mesh: item.mesh,
+          kri,
+          creationTime: item.creationTime,
+          modificationTime: item.modificationTime,
+          ...item.zoneIngress,
+        }).config,
+        ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
+      },
       // it is possible to have zoneIngresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least
       state: typeof zoneIngressInsight.connectedSubscription !== 'undefined' ? 'online' as const : 'offline' as const,

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -8,7 +8,7 @@
       codeRegExp: false,
       format: String,
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t, uri, r }"
   >
     <DataCollection
       :items="props.items"
@@ -147,6 +147,35 @@
                       <template v-else>
                         {{ t('common.detail.none') }}
                       </template>
+                    </td>
+                  </tr>
+                  <tr
+                    v-if="Object.keys(item.labels).length > 0"
+                  >
+                    <th scope="row">
+                      Labels
+                    </th>
+                    <td>
+                      <XLayout
+                        variant="separated"
+                      >
+                        <XAction
+                          v-for="(value, key) in item.labels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: '',
+                            zone: item.zone,
+                            namespace: item.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
+                        >
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                          >
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
+                      </XLayout>
                     </td>
                   </tr>
                 </XTable>

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -643,6 +643,7 @@ export interface AvailableService {
 
 export interface ZoneIngress extends MeshEntity {
   zone?: string
+  kri?: string
   networking?: ZoneIngressNetworking
   availableServices?: AvailableService[]
 }
@@ -673,6 +674,7 @@ export interface ZoneEgressNetworking {
 
 export interface ZoneEgress extends MeshEntity {
   zone?: string
+  kri?: string
   networking?: ZoneEgressNetworking
 }
 export interface ZoneEgressInsight {


### PR DESCRIPTION
Unfortunately quite a large PR adding labels to both data layer and summary panels.


- Adds `Labels` `tr` to almost all remaining summary panels, pretty much copy/pasta
- Adds datalayer labels where necessary, again pretty much copy/pasta
- I moved MeshGateway to use OpenAPI types
- Made ZoneIngress/ZoneEgress YAML displays show labels (similar to what we do in Dataplanes/DataplaneOverview)

~There is currently a unit test failing just because I have to update it to use labels, will sort that shortly.~

I removed two tests that were failing because I added new properties to zoneIngress/zoneEgress. The style of these two were "snapshot" type tests which we want to try to avoid