### PR TITLE
chore: adds more KRIs to Overview-like things

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
@@ -1,6 +1,7 @@
 import { Dataplane } from './Dataplane'
 import { DataplaneInsight } from './DataplaneInsight'
 import { DataplaneNetworking } from './DataplaneNetworking'
+import { Kri } from '@/app/kuma/kri'
 import type { PaginatedApiListResponse } from '@/types/api.d'
 import type {
   DataPlaneOverview as PartialDataplaneOverview,
@@ -29,7 +30,16 @@ export const DataplaneOverview = {
     const isCertExpired = getIsCertExpired(dataplaneInsight)
     const isCertExpiresSoon = getIsCertExpiresSoon(dataplaneInsight)
 
-    const labels = typeof item.labels !== 'undefined' ? item.labels : {}
+    const labels = item.labels ?? {}
+    const id = item.name
+    const mesh = item.mesh
+    // check for label first, fallback to tags
+    const zone = labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : tags.find((tag) => tag.label === 'kuma.io/zone')?.value ?? ''
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    const name = labels['kuma.io/display-name'] ?? item.name
+
+    const kri = Kri.toString({ shortName: 'dp', mesh, zone, namespace, name })
+
 
     // get all tags and labels with kuma.io/service
     // uniquify and and sort
@@ -38,20 +48,25 @@ export const DataplaneOverview = {
       ...(labels['kuma.io/service'] ? [labels['kuma.io/service']] : []),
     ])).sort((a, b) => a.localeCompare(b))
 
-    // check for label first, fallback to tags
-    const zone = labels['kuma.io/zone'] || tags.find((tag) => tag.label === 'kuma.io/zone')?.value
 
 
     return {
       ...item,
-      id: item.name,
-      name: labels['kuma.io/display-name'] || item.name,
-      namespace: labels['k8s.kuma.io/namespace'] ?? '',
+      kri,
+      name,
+      mesh,
+      labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+      namespace,
+      zone,
+
+      dataplaneInsight,
       dataplane: {
         networking,
       },
-      labels,
-      dataplaneInsight,
       dataplaneType: (() => {
         switch (true) {
           case networking.type === 'gateway':
@@ -92,7 +107,6 @@ export const DataplaneOverview = {
       isCertExpired,
       isCertExpiresSoon,
       services,
-      zone,
       config: {
         ...Dataplane.fromObject({
           type: 'Dataplane',
@@ -100,9 +114,8 @@ export const DataplaneOverview = {
           mesh: item.mesh,
           ...item.dataplane,
         }).config,
+        kri,
         ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
-        creationTime: item.creationTime,
-        modificationTime: item.modificationTime,
       },
     }
   },

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
@@ -38,6 +38,7 @@ export const DataplaneOverview = {
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
     const name = labels['kuma.io/display-name'] ?? item.name
 
+    // temporarily make a KRI until we have those from the backend
     const kri = Kri.toString({ shortName: 'dp', mesh, zone, namespace, name })
 
 
@@ -107,15 +108,27 @@ export const DataplaneOverview = {
       isCertExpired,
       isCertExpiresSoon,
       services,
+      // config should only contain non-defaulted values
+      // because we want to show what the API responded with
+      // we then copy over things that should be on the Entity, but
+      // are only on the EntityOverview
       config: {
         ...Dataplane.fromObject({
+          // bare minimum props to keep TS happy
+          // plus a splat of the original Entity
           type: 'Dataplane',
           name: item.name,
           mesh: item.mesh,
           ...item.dataplane,
         }).config,
+
+        // the things we copy over
+        // kri is always missing and we always purposefully add and generate ourselves
         kri,
+        // we only copy these over if they exist
         ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
+        ...(typeof item.creationTime !== 'undefined' ? { creationTime: item.creationTime } : {}),
+        ...(typeof item.modificationTime !== 'undefined' ? { modificationTime: item.modificationTime } : {}),
       },
     }
   },

--- a/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
@@ -364,12 +364,13 @@ describe('DataplaneOverview', () => {
   })
   describe('dataplane.config', () => {
     test(
-      'config is derived from Dataplane and based on DataplaneOverview data',
+      'config (used for display) contains the correct fields, no more, no less',
       async ({ fixture }) => {
         const expected = {
           type: 'Dataplane',
           name: 'dp-name',
           mesh: 'dp-mesh',
+          kri: 'kri_dp_dp-mesh___dp-name_',
           labels: {
             'kuma.io/display-name': 'dp-name',
           },
@@ -387,6 +388,7 @@ describe('DataplaneOverview', () => {
         const actual = await fixture.setup((item) => {
           item.name = expected.name
           item.mesh = expected.mesh
+          // item.kri = expected.kri
           item.creationTime = expected.creationTime
           item.modificationTime = expected.modificationTime
           item.dataplane.networking = expected.networking

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
@@ -210,4 +210,41 @@ describe('ZoneEgressOverview', () => {
       },
     )
   })
+  describe('zoneEgressOverview.config', () => {
+    test('config (used for display) contains the correct fields, no more, no less', async ({ fixture }) => {
+
+      const expected = {
+        type: 'ZoneEgress',
+        name: 'zone-egress-name.zone-egress-namespace',
+        mesh: 'mesh-0',
+        kri: 'kri_ze_mesh-0___zone-egress-name_',
+        labels: {
+          'kuma.io/display-name': 'zone-egress-name',
+        },
+        zone: 'zone-0',
+        creationTime: '2021-07-13T08:40:59Z',
+        modificationTime: '2021-07-13T08:40:59Z',
+        networking: {
+          address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
+          port: 58936,
+        },
+      }
+      const actual = await fixture.setup((item) => {
+        item.name = expected.name
+        item.mesh = expected.mesh
+        // item.kri = expected.kri
+        item.labels = expected.labels
+        item.creationTime = expected.creationTime
+        item.modificationTime = expected.modificationTime
+        item.zoneEgress = {
+          networking: expected.networking,
+          zone: expected.zone,
+        }
+
+        return item
+      })
+      expect(actual.config).toStrictEqual(expected)
+    })
+  })
+
 })

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.ts
@@ -96,11 +96,11 @@ export const ZoneEgressOverview = {
           type: 'ZoneEgress',
           name: item.name,
           mesh: item.mesh,
-          kri,
           creationTime: item.creationTime,
           modificationTime: item.modificationTime,
           ...item.zoneEgress,
         }).config,
+        kri,
         ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
       },
       // it is possible to have zoneEgresses on a 'disabled' zone but we don't

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.ts
@@ -74,6 +74,7 @@ export const ZoneEgressOverview = {
     const name = labels['kuma.io/display-name'] ?? item.name
 
 
+    // temporarily make a KRI until we have those from the backend
     const kri = Kri.toString({ shortName: 'ze', mesh, zone, namespace, name })
 
     return {
@@ -91,17 +92,26 @@ export const ZoneEgressOverview = {
 
       zoneEgressInsight,
       zoneEgress,
+      // config should only contain non-defaulted values
+      // because we want to show what the API responded with
+      // we then copy over things that should be on the Entity, but
+      // are only on the EntityOverview
       config: {
         ...ZoneEgress.fromObject({
+          // bare minimum props to keep TS happy
+          // plus a splat of the original Entity
           type: 'ZoneEgress',
           name: item.name,
           mesh: item.mesh,
-          creationTime: item.creationTime,
-          modificationTime: item.modificationTime,
           ...item.zoneEgress,
         }).config,
+        // the things we copy over
+        // kri is always missing and we always purposefully add and generate ourselves
         kri,
+        // we only copy these over if they exist
         ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
+        ...(typeof item.creationTime !== 'undefined' ? { creationTime: item.creationTime } : {}),
+        ...(typeof item.modificationTime !== 'undefined' ? { modificationTime: item.modificationTime } : {}),
       },
       // it is possible to have zoneEgresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
@@ -283,4 +283,51 @@ describe('ZoneIngressOverview', () => {
       },
     )
   })
+  describe('zoneIngressOverview.config', () => {
+    test('config (used for display) contains the correct fields, no more, no less', async ({ fixture }) => {
+      const expected = {
+        type: 'ZoneIngress',
+        name: 'zone-ingress-name.zone-ingress-namespace',
+        mesh: 'mesh-0',
+        kri: 'kri_zi_mesh-0___zone-ingress-name_',
+        labels: {
+          'kuma.io/display-name': 'zone-ingress-name',
+        },
+        zone: 'zone-0',
+        creationTime: '2021-07-13T08:40:59Z',
+        modificationTime: '2021-07-13T08:40:59Z',
+        availableServices: [{
+          instances: 50,
+          mesh: 'mesh-0',
+          tags: {
+            app: 'programm-app',
+            'kuma.io/zone': 'zone-0',
+            'kuma.io/service': 'program-app_alarm_svc_36676',
+          },
+        }],
+        networking: {
+          address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
+          advertisedAddress: '190.26.201.59',
+          advertisedPort: 58329,
+          port: 58936,
+        },
+      }
+      const actual = await fixture.setup((item) => {
+        item.name = expected.name
+        item.mesh = expected.mesh
+        // item.kri = expected.kri
+        item.labels = expected.labels
+        item.creationTime = expected.creationTime
+        item.modificationTime = expected.modificationTime
+        item.zoneIngress = {
+          availableServices: expected.availableServices,
+          networking: expected.networking,
+          zone: expected.zone,
+        }
+
+        return item
+      })
+      expect(actual.config).toStrictEqual(expected)
+    })
+  })
 })

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -80,6 +80,7 @@ export const ZoneIngressOverview = {
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
     const name = labels['kuma.io/display-name'] ?? item.name
 
+    // temporarily make a KRI until we have those from the backend
     const kri = Kri.toString({ shortName: 'zi', mesh, zone, namespace, name })
 
     return {
@@ -97,8 +98,14 @@ export const ZoneIngressOverview = {
 
       zoneIngressInsight,
       zoneIngress,
+      // config should only contain non-defaulted values
+      // because we want to show what the API responded with
+      // we then copy over things that should be on the Entity, but
+      // are only on the EntityOverview
       config: {
         ...ZoneIngress.fromObject({
+          // bare minimum props to keep TS happy
+          // plus a splat of the original Entity
           type: 'ZoneIngress',
           name: item.name,
           mesh: item.mesh,
@@ -106,8 +113,13 @@ export const ZoneIngressOverview = {
           modificationTime: item.modificationTime,
           ...item.zoneIngress,
         }).config,
+
+        // the things we copy over
+        // kri is always missing and we always purposefully add and generate ourselves
         kri,
         ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
+        ...(typeof item.creationTime !== 'undefined' ? { creationTime: item.creationTime } : {}),
+        ...(typeof item.modificationTime !== 'undefined' ? { modificationTime: item.modificationTime } : {}),
       },
       // it is possible to have zoneIngresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -102,11 +102,11 @@ export const ZoneIngressOverview = {
           type: 'ZoneIngress',
           name: item.name,
           mesh: item.mesh,
-          kri,
           creationTime: item.creationTime,
           modificationTime: item.modificationTime,
           ...item.zoneIngress,
         }).config,
+        kri,
         ...(typeof item.labels !== 'undefined' ? { labels: item.labels } : {}),
       },
       // it is possible to have zoneIngresses on a 'disabled' zone but we don't

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -87,7 +87,7 @@ export const ZoneOverview = {
 
     const labels = item.labels ?? {}
     const id = item.name
-    // check for label first, fallback to tags
+
     const name = labels['kuma.io/display-name'] ?? item.name
 
     // temporarily make a KRI until we have those from the backend

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -90,6 +90,7 @@ export const ZoneOverview = {
     // check for label first, fallback to tags
     const name = labels['kuma.io/display-name'] ?? item.name
 
+    // temporarily make a KRI until we have those from the backend
     const kri = Kri.toString({ shortName: 'z', mesh: '', zone: '', namespace: '', name })
 
     const insight = ZoneInsight.fromObject(item.zoneInsight)

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -1,4 +1,5 @@
 import { get } from '@/app/application'
+import { Kri } from '@/app/kuma/kri'
 import { Resource } from '@/app/resources/data/Resource'
 import { Subscription, SubscriptionCollection } from '@/app/subscriptions/data'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
@@ -83,6 +84,14 @@ export const ZoneOverview = {
   },
 
   fromObject: (item: PartialZoneOverview) => {
+
+    const labels = item.labels ?? {}
+    const id = item.name
+    // check for label first, fallback to tags
+    const name = labels['kuma.io/display-name'] ?? item.name
+
+    const kri = Kri.toString({ shortName: 'z', mesh: '', zone: '', namespace: '', name })
+
     const insight = ZoneInsight.fromObject(item.zoneInsight)
     const zone = Zone.fromObject(item.zone)
     const state = {
@@ -92,8 +101,14 @@ export const ZoneOverview = {
     } as const
     return {
       ...item,
-      id: item.name,
-      labels: item.labels ?? {},
+      kri,
+      name,
+      labels,
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      // aliases
+      id,
+
       zoneInsight: insight,
       zone,
       // first check see if the zone is disabled, if not look for the connectedSubscription

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -341,8 +341,8 @@ export interface LabelValue {
 export interface Entity {
   type: string
   name: string
-  creationTime: string
-  modificationTime: string
+  creationTime?: string
+  modificationTime?: string
 }
 
 export interface MeshEntity extends Entity {


### PR DESCRIPTION
Adds/ensures KRIs are carried through to the summary YAML views.

There is also a bit of copy/pasting for consistency reasons between Dataplanes/ZoneProxies. There are reasons for formatting decisions in the code here and I commented it up quite a bit to explain why rather than just depend on the formatting to be self-explanatory (that alone it not explanatory enough I don't think)

I renamed the Dataplane tests and added back the ZoneProxy tests but renamed them all to make it clearer what they are testing. Usually we avoid mocking/setting up full data objects to test against, but in this case its the most straight-forwards way to assert that we have neither too many fields or not enough fields. If I think of a different way thats just as straight-forwards but also clearer I might tweak this in the future.

Note: We are now expected KRIs to be added to the top-level DataplaneOverviews via the backend. Depending on when this PR gets merged we can either consider this in this PR or a follow up PR once the backend PR is complete.