### PR TITLE
fix(resources): fix i18n based fallbacks

### DIFF
--- a/packages/kuma-gui/features/mesh/resources/Index.feature
+++ b/packages/kuma-gui/features/mesh/resources/Index.feature
@@ -38,7 +38,7 @@ Feature: mesh / resources / index
 
   Scenario: Listing has expected content
     When I visit the "/meshes/default/resources/meshaccesslogs" URL
-    # Then the "$button-docs" element exists
+    Then the "$button-docs" element exists
     Then the "$items-header" element exists 4 times
     And the "$item" element exists 2 times
     And the "$item:nth-child(1)" element contains

--- a/packages/kuma-gui/features/mesh/resources/Item.feature
+++ b/packages/kuma-gui/features/mesh/resources/Item.feature
@@ -39,18 +39,18 @@ Feature: mesh / resources / item
       When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview" URL
       Then the "$config-universal" element exists
 
-    Scenario: Visiting with format=universal shows the universal codeblock
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview?format=universal" URL
+    Scenario: Visiting with environment=universal shows the universal codeblock
+      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview?environment=universal" URL
       Then the "$config-universal" element exists
 
-    Scenario: Visiting with format=k8s shows the k8s codeblock
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview?format=k8s" URL
+    Scenario: Visiting with environment=k8s shows the k8s codeblock
+      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview?environment=k8s" URL
       Then the "$config-k8s" element exists
 
-    Scenario: Switching to k8s format shows the k8s codeblock
+    Scenario: Switching to k8s environment shows the k8s codeblock
       When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview" URL
       Then the "$config-universal" element exists
       Then I click the "$select-environment" element
       Then I click the "[data-testid='select-item-k8s'] button" element
       Then the "$config-k8s" element exists
-      And the URL contains "format=k8s"
+      And the URL contains "environment=k8s"

--- a/packages/kuma-gui/features/mesh/resources/Summary.feature
+++ b/packages/kuma-gui/features/mesh/resources/Summary.feature
@@ -54,5 +54,5 @@ Feature: mesh / resources / summary
       When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_" URL
       And I click the "$select-preference" element
       And I click the "[data-testid='select-item-k8s'] button" element
-      Then the URL contains "format=k8s"
+      Then the URL contains "environment=k8s"
       And the "$summary [data-testid='codeblock-yaml-k8s']" element exists

--- a/packages/kuma-gui/src/app/kuma/debug.ts
+++ b/packages/kuma-gui/src/app/kuma/debug.ts
@@ -15,7 +15,9 @@ export const locales = (app: Record<string, Token>): ServiceDefinition[] => [
       return {
         common: {
           product: {
-            docs: 'https://kuma.io/docs/dev',
+            // ensure all variables in kuma/locales/en.us/index.yaml are also
+            // used here
+            docs: 'https://kuma.io/docs/dev{ major, select, other {}}{ minor, select, other {}}',
           },
         },
       }

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -14,6 +14,7 @@ common:
     ignore-error: ""
   product:
     name: Kuma
+    # any variables here MUST be added to the debug overwrite in kuma/debug.ts
     docs: |
       https://kuma.io/docs/{ major, select,
         0 {dev}

--- a/packages/kuma-gui/src/app/resources/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/resources/locales/en-us/index.yaml
@@ -29,22 +29,29 @@ resources:
           href:
             docs: '{KUMA_DOCS_URL}/resources/{name}?{KUMA_UTM_QUERY_PARAMS}'
           description: !!text/markdown |
-            Use mesh-scoped resources to configure services and infrastructure within a specific mesh. These resources like data planes and services are managed by the control plane and define the behavior and properties of components operating within their designated mesh boundary.
+            Use mesh-scoped resources to configure services and infrastructure
+            within a specific mesh. These resources like data planes and
+            services are managed by the control plane and define the behavior
+            and properties of components operating within their designated mesh
+            boundary.
         global:
           title: Global scoped
           href:
             docs: '{KUMA_DOCS_URL}/resources/{name}?{KUMA_UTM_QUERY_PARAMS}'
           description: !!text/markdown |
-            Use global resources to configure cross-mesh infrastructure and mesh management itself. These resources like meshes and zones operate at the cluster level and are managed by the global control plane to coordinate behavior across the entire service mesh deployment.
+            Use global resources to configure cross-mesh infrastructure and
+            mesh management itself. These resources like meshes and zones
+            operate at the cluster level and are managed by the global control
+            plane to coordinate behavior across the entire service mesh
+            deployment.
         others:
           title: Other
-        default:
-          title: '{name}'
           href:
             docs: '{KUMA_DOCS_URL}/resources/{name}?{KUMA_UTM_QUERY_PARAMS}'
           description: !!text/markdown |
-            This resource type is not categorized yet. Please refer to the documentation for more details.
-        
+            This resource type is not categorized yet. Please refer to the
+            documentation for more details.
+
         collection:
           title: 'About {name}'
           inbound: Inbound

--- a/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
@@ -40,10 +40,9 @@
                 >
                   {{ t('resources.routes.items.types.collection.outbound') }}
                 </XBadge>
-
                 <XAction
                   action="docs"
-                  :href="t(`resources.routes.items.types.${type.group}.href.docs`, { name: type.name }, { defaultMessage: t('common.product.docs')})"
+                  :href="t(`resources.routes.items.types.${type.group}.href.docs`, { name: type.name }, { defaultMessage: t(`resources.routes.items.types.others.href.docs`, { name: type.name })})"
                   data-testid="policy-documentation-link"
                 >
                   <span class="visually-hidden">{{ t('common.documentation') }}</span>
@@ -57,7 +56,7 @@
             </header>
             <XI18n
               :path="`resources.routes.items.types.${type.group}.description`"
-              default-path="resources.routes.items.types.default.description"
+              default-path="resources.routes.items.types.others.description"
             />
           </XCard>
           <XCard>
@@ -119,7 +118,7 @@
                     >
                       <XAction
                         action="docs"
-                        :href="t(`resources.routes.items.types.${type.group}.href.docs`, { name: type.name })"
+                        :href="t(`resources.routes.items.types.${type.group}.href.docs`, { name: type.name }, { defaultMessage: t(`resources.routes.items.types.others.href.docs`, { name: type.name })})"
                       >
                         {{ t('common.documentation') }}
                       </XAction>


### PR DESCRIPTION
### Improvement
The default "group" for `ResourceTypeDescriptor` if its not set is `others` (it can also be `policy` and `mesh` and `global`, plus anything else that could be added via the backend in the future):

https://github.com/kumahq/kuma-gui/blob/5a21d2dbb1372ee97ccac094d57f52d855a9beed/packages/kuma-gui/src/app/resources/data/ResourceTypeDescriptor.ts#L53

We then use this `type.group` key to discover several i18n keys including a documentation paragraph and `href`

Thing is `others` doesn't have a `description` nor `href` key.

We sometimes used a `default` fallback which in some places would solve the issue of "future groups" coming from the backend, but not if its not set. I guess it highly unlikely that we end up with a `type.group=others` but we've coded for it so we should support it.

I removed the `default` section and used `others` for a default (like we do in the datalayer)

### Fix

I also found a place where we were defaulting to `t('common.product.docs')` which is a bit of a legacy i18n key, which we only really use to set the `KUMA_DOCS_URL` i18n env var:

https://github.com/kumahq/kuma-gui/blob/5a21d2dbb1372ee97ccac094d57f52d855a9beed/packages/kuma-gui/src/app/application/services/i18n/I18n.ts#L45-L48

We also mock out this key only at dev time because we could never get the docs redirects implemented to avoid us having mock this value out.

The mocked key/value didn't make use of the same variables as the non-mocked key, which meant _during dev_ you wouldn't see an i18n error if you did not pass the required variables to the call for `t`. The issue would then fail in CI only, causing a bit of confusion https://github.com/kumahq/kuma-gui/pull/4997#discussion_r3396571856

The fix involves:

- Changing the `common.product.docs` key to something else, I used the "fallback" `others` key.
- I also thought of how we can prevent this weirdness happening in the future and decided to add the same variabels to the debug URL. Whilst these are "noops" they force you to pass the same variables through. I also added comments to "ensure" that if we add any new vars here (unlikely) we are prompted to sync the variables.

A better fix would be to remove or somehow prevent the `common.product.docs` from being used outside of setting `KUMA_DOCS_URL`. Whilst I would prefer this, its needs better thought/less haste.

---

This desc is a little rough, so let me know if there are any further questions.

Lastly, I think it would be a good idea to have a closer look over the new `resources` section with the above in mind to triple check there are no similar issues. I had a relatively "ok" look myself but I'd rather have a second pair of eyes.






