### PR TITLE
chore(ci): make playwright fail on any error or console.error

### DIFF
--- a/packages/gherkin-web/src/playwright/steps/index.ts
+++ b/packages/gherkin-web/src/playwright/steps/index.ts
@@ -18,6 +18,17 @@ export const test = base.extend<{
   baseURL: async ({ baseURL }, use) => {
     await use(baseURL)
   },
+  page: async ({ page }, use) => {
+    page.on('pageerror', (err) => {
+      throw err
+    })
+    page.on('console', (msg) => {
+      if(['error'].includes(msg.type()) && msg.args().length !== 0) {
+        throw new Error(msg.text())
+      }
+    })
+    await use(page)
+  },
 })
 
 export async function setupSteps({ dependencies, fs, negativeTimeout = 4000, client = getClient() }: Options) {


### PR DESCRIPTION
We used to have Cypress plugins to do this sort of thing for us.

With Playwright it looks to be just `pageerror` and `console` listener/passthroughs

This conversation made me thing about this https://github.com/kumahq/kuma-gui/pull/4997#discussion_r3396571856