### PR TITLE
chore: stop using kongponents

### DIFF
--- a/packages/config/src/eslint.js
+++ b/packages/config/src/eslint.js
@@ -237,21 +237,20 @@ export function createEslintConfig(
             'search',
             // vue-router
             'RouterView',
-            // @kong/kongponents
-            'K[A-Z].*',
-            //
+            // @kumhq/x
             'X[A-Z].*',
+            // @kumahq/kuma-gui
             'Kuma[A-Z].*',
-            // @kong-ui-public/i18n
-            'I18nT',
-            // Application
-            'AppView',
+            // @kumahq/data
             'DataLoader',
             'DataSource',
             'DataSink',
-            'DataCollection',
+            // @kumahq/routing
             'RouteView',
             'RouteTitle',
+            // Application
+            'AppView',
+            'DataCollection',
             ...componentIgnorePatterns,
           ],
         }],

--- a/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
@@ -43,6 +43,7 @@
 </template>
 
 <script lang="ts" setup generic="Row extends {}">
+// @TODO: Why are we using kongponents?
 import { KTableView } from '@kong/kongponents'
 import { ref, onMounted } from 'vue'
 

--- a/packages/kuma-gui/src/app/application/components/data-collection/DataCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/data-collection/DataCollection.vue
@@ -88,8 +88,10 @@
   </template>
 </template>
 <script lang="ts" generic="T" setup>
+import { KPagination } from '@kong/kongponents'
 import { useThrottleFn } from '@vueuse/core'
 import { computed, useSlots } from 'vue'
+// @TODO: Why are we using kongponents?
 
 import { useDataEmptyState } from '../../'
 

--- a/packages/kuma-gui/src/app/policies/components/PolicyTypeEntryList.vue
+++ b/packages/kuma-gui/src/app/policies/components/PolicyTypeEntryList.vue
@@ -116,6 +116,7 @@
 
 <script lang="ts" setup>
 
+// @TODO: Why are we using kongponents?
 import { KTableView } from '@kong/kongponents'
 
 import type { PolicyResourceType } from '../data'

--- a/packages/kuma-gui/src/app/service-mesh/index.ts
+++ b/packages/kuma-gui/src/app/service-mesh/index.ts
@@ -1,4 +1,3 @@
-import Kongponents from '@kong/kongponents'
 import { token } from '@kumahq/container'
 import X from '@kumahq/x'
 
@@ -106,7 +105,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     [token('service-mesh.plugins'), {
       service: (i18n, can) => {
         return [
-          [Kongponents],
           [X, {
             i18n,
             protocolHandler: protocolHandler(can),

--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -8,6 +8,9 @@
   "main": "src/index.ts",
   "module": "src/index.ts",
   "types": "src/index.ts",
+  "files": [
+    "src/index.scss"
+  ],
   "scripts": {
     "help": "make help"
   },

--- a/packages/x/src/components/x-drawer/XDrawer.vue
+++ b/packages/x/src/components/x-drawer/XDrawer.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script lang="ts" setup>
+import { KSlideout } from '@kong/kongponents'
 import { onClickOutside } from '@vueuse/core'
 import { provide, useId, onMounted, nextTick } from 'vue'
 

--- a/packages/x/src/components/x-error-state/XErrorState.vue
+++ b/packages/x/src/components/x-error-state/XErrorState.vue
@@ -90,6 +90,7 @@
 
 <script lang="ts" setup generic="T extends Error & Partial<{ type: string, status: number, title: string, detail: string, instance: string, invalid_parameters: { field: string, reason: string, source: 'body' | 'header', rule?: string }[] }>">
 import { KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
+import { KEmptyState } from '@kong/kongponents'
 import { inject } from 'vue'
 
 const props = withDefaults(defineProps<{

--- a/packages/x/src/components/x-progress/XProgress.vue
+++ b/packages/x/src/components/x-progress/XProgress.vue
@@ -49,7 +49,7 @@
 </template>
 <script lang="ts" setup>
 import { KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
-import { KEmptyState } from '@kong/kongponents'
+import { KEmptyState, KSkeletonBox, KSkeleton } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   variant?: 'list' | 'line' | 'spinner' | 'legacy' | 'header'
 }>(), {

--- a/packages/x/src/components/x-search/XSearch.vue
+++ b/packages/x/src/components/x-search/XSearch.vue
@@ -143,6 +143,7 @@
 </template>
 
 <script setup lang="ts">
+import { KPop } from '@kong/kongponents'
 import { useResizeObserver } from '@vueuse/core'
 import { ref, watch } from 'vue'
 

--- a/packages/x/src/index.scss
+++ b/packages/x/src/index.scss
@@ -1,5 +1,3 @@
-@use "fonts";
-@use "base";
-
 /* this can't be componentized because it affects global styles for at least popup */
-@use "@kumahq/x/src/index";
+@import "@kong/kongponents/dist/style.css";
+


### PR DESCRIPTION
Stop using kongponents i.e. don't install them globally anymore

We use `@kumahq/x` now instead and have done for quite a while.


---

I also did some checking here on bundle reduction size:

```
# master
dist/assets/index-BqGd6Mxt.js                                              1,435.59 kB │ gzip: 439.39 kB
```

```
# this PR
dist/assets/index-D2BHdZfV.js                                              1,110.26 kB │ gzip: 343.58 kB

```

savings of 100kb gzipped and the parsing etc of that 🎉 
