### PR TITLE
scratch(deps): widen peers

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -105,6 +105,21 @@
     },
     {
       "description": [
+        " [EXPERIMENTAL]: widening peers"
+      ],
+      "matchCategories": [
+        "js"
+      ],
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchDepTypes": [
+        "!peerDependencies"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": [
         " Group vue and @vue/shared"
       ],
       "groupName": "vue",

--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -26,6 +26,7 @@
     "@kong/design-tokens": "^1.23.0"
   },
   "peerDependencies": {
-    "vue": "*"
+    "vue": "*",
+    "@kong/kongponents": "^9.59.0"
   }
 }


### PR DESCRIPTION
This is an experiment to see how renovate treats `peerDependencies` with a `rangeStrategy` of `widen`.

The peer on `kongponents` in x will be removed soon again.