### PR TITLE
chore(config/renovate): undo widen peers

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -105,21 +105,6 @@
     },
     {
       "description": [
-        " [EXPERIMENTAL]: widening peers"
-      ],
-      "matchCategories": [
-        "js"
-      ],
-      "matchPackageNames": [
-        "*"
-      ],
-      "matchDepTypes": [
-        "peerDependencies"
-      ],
-      "rangeStrategy": "widen"
-    },
-    {
-      "description": [
         " Group vue and @vue/shared"
       ],
       "groupName": "vue",


### PR DESCRIPTION
Removes our renovate config test about widen peer dependencies. I'm leaving the kongponents peer in to keep testing if the [recent change in our base config](https://github.com/Kong/public-shared-renovate/pull/75) works the same way.