### PR TITLE
chore(x/deps): remove kongponents peer

### DIFF
--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -26,7 +26,6 @@
     "@kong/design-tokens": "^1.23.0"
   },
   "peerDependencies": {
-    "vue": "*",
-    "@kong/kongponents": "^9.59.0"
+    "vue": "*"
   }
 }


### PR DESCRIPTION
Removes the peer of kongponents from the peers in x that we used to test renovate widen peers.