### PR TITLE
chore: stop using kong/design-tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13256,7 +13256,6 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^10.5.0",
-        "@kong/design-tokens": "^3.0.1",
         "@kumahq/config": "*",
         "@kumahq/fake-api": "*",
         "@kumahq/gherkin-web": "*",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^10.5.0",
-    "@kong/design-tokens": "^3.0.1",
     "@kumahq/config": "*",
     "@kumahq/fake-api": "*",
     "@kumahq/gherkin-web": "*",

--- a/packages/kuma-gui/src/app/common/TargetRef.vue
+++ b/packages/kuma-gui/src/app/common/TargetRef.vue
@@ -12,7 +12,6 @@
     <XBadge v-else>
       <slot />
     </XBadge>
-
     <TagList
       v-if="props.targetRef.kind === 'MeshServiceSubset' && props.targetRef.tags"
       :tags="props.targetRef.tags"
@@ -26,16 +25,13 @@
       <img
         src="@/assets/images/icon-weight.svg?url"
         alt="Weight"
-        :width="KUI_ICON_SIZE_30"
       >
-
       {{ props.targetRef.weight }}
     </span>
   </span>
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { computed } from 'vue'
 
 import TagList from '@/app/common/TagList.vue'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -634,7 +634,7 @@
                                         <XIcon
                                           v-if="inbound?.state !== 'Ready'"
                                           name="danger"
-                                          :size="KUI_ICON_SIZE_40"
+                                          :size="`var(--x-icon-size-40)`"
                                           placement="right"
                                         >
                                           {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound?.port }) }}
@@ -670,7 +670,7 @@
                                           >
                                             <XIcon
                                               name="warning"
-                                              :size="KUI_ICON_SIZE_40"
+                                              :size="`var(--x-icon-size-40)`"
                                               placement="right"
                                             />
                                           </XAction>
@@ -822,7 +822,7 @@
                                       >
                                         <XIcon
                                           name="warning"
-                                          :size="KUI_ICON_SIZE_40"
+                                          :size="`var(--x-icon-size-40)`"
                                           placement="right"
                                         />
                                       </XAction>
@@ -935,7 +935,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import { ref } from 'vue'
 
 import { sources } from '../sources'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -44,7 +44,7 @@
               <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated' | 'zone-ingress' | 'zone-egress' }">
                 <XIcon
                   v-if="item !== 'all'"
-                  :size="KUI_ICON_SIZE_40"
+                  :size="`var(--x-icon-size-40)`"
                   :name="item"
                 />
                 {{ t(`data-planes.type.${item}`) }}
@@ -325,8 +325,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -598,7 +598,7 @@
                                     <XIcon
                                       v-if="item.state !== 'Ready'"
                                       name="danger"
-                                      :size="KUI_ICON_SIZE_40"
+                                      :size="`var(--x-icon-size-40)`"
                                       placement="right"
                                     >
                                       {{ t('data-planes.routes.item.unhealthy_inbound', { port: item.port }) }}
@@ -634,7 +634,7 @@
                                       >
                                         <XIcon
                                           name="warning"
-                                          :size="KUI_ICON_SIZE_40"
+                                          :size="`var(--x-icon-size-40)`"
                                           placement="right"
                                         />
                                       </XAction>
@@ -798,7 +798,7 @@
                                         >
                                           <XIcon
                                             name="warning"
-                                            :size="KUI_ICON_SIZE_40"
+                                            :size="`var(--x-icon-size-40)`"
                                             placement="right"
                                           />
                                         </XAction>
@@ -872,8 +872,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import ConnectionCard from '@/app/connections/components/connection-traffic/ConnectionCard.vue'
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'

--- a/packages/x/src/components/x-action/XAction.vue
+++ b/packages/x/src/components/x-action/XAction.vue
@@ -100,7 +100,7 @@
       >
         <XIcon
           name="docs"
-          :size="KUI_ICON_SIZE_40"
+          :size="`var(--x-icon-size-40)`"
         />
         <slot
           name="default"
@@ -162,7 +162,7 @@
       >
         <XIcon
           name="docs"
-          :size="KUI_ICON_SIZE_40"
+          :size="`var(--x-icon-size-40)`"
         />
       </template>
       <span><slot name="default" /></span>
@@ -247,7 +247,6 @@ const pool = new SharedPool<Router, (e: Event) => void>((state, router, item) =>
 })
 </script>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import { KDropdownItem, KButton } from '@kong/kongponents'
 import { computed, watch, inject, provide, useAttrs, onMounted, onBeforeUnmount } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'

--- a/packages/x/src/components/x-empty-state/XEmptyState.vue
+++ b/packages/x/src/components/x-empty-state/XEmptyState.vue
@@ -43,8 +43,8 @@
             >
               <component
                 :is="iconMapping[type]"
-                :color="KUI_COLOR_TEXT_DECORATIVE_AQUA"
-                :size="KUI_ICON_SIZE_50"
+                :color="`var(--x-color-decorative-aqua)`"
+                :size="`var(--x-icon-size-50)`"
               />
             </div>
             <AnalyticsIcon v-else />
@@ -95,7 +95,7 @@
                 <XIcon
                   v-if="t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }) === 'docs'"
                   name="docs"
-                  :size="KUI_ICON_SIZE_40"
+                  :size="`var(--x-icon-size-40)`"
                 />
                 {{ t(`${prefix}x-empty-state.action.label`, undefined, { defaultMessage: '' }) }}
               </XAction>
@@ -108,7 +108,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_DECORATIVE_AQUA, KUI_ICON_SIZE_40, KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 import { LocationIcon, AnalyticsIcon, MeshIcon } from '@kong/icons'
 import { KEmptyState } from '@kong/kongponents'
 

--- a/packages/x/src/components/x-error-state/XErrorState.vue
+++ b/packages/x/src/components/x-error-state/XErrorState.vue
@@ -10,7 +10,7 @@
         <template #icon>
           <XIcon
             :name="props.appearance"
-            :color="props.appearance === 'danger' ? KUI_COLOR_TEXT_DANGER : undefined"
+            :color="props.appearance === 'danger' ? `var(--x-color-text-danger)` : undefined"
           />
         </template>
 
@@ -89,7 +89,6 @@
 </template>
 
 <script lang="ts" setup generic="T extends Error & Partial<{ type: string, status: number, title: string, detail: string, instance: string, invalid_parameters: { field: string, reason: string, source: 'body' | 'header', rule?: string }[] }>">
-import { KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
 import { inject } from 'vue'
 
 const props = withDefaults(defineProps<{

--- a/packages/x/src/components/x-icon/XIcon.vue
+++ b/packages/x/src/components/x-icon/XIcon.vue
@@ -30,7 +30,6 @@
   </component>
 </template>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import {
   ForwardIcon,
   GatewayIcon,
@@ -114,7 +113,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   placement: 'auto',
   color: undefined,
-  size: KUI_ICON_SIZE_30,
+  size: 'var(--x-icon-size-30)',
 })
 </script>
 <style lang="scss" scoped>

--- a/packages/x/src/components/x-progress/XProgress.vue
+++ b/packages/x/src/components/x-progress/XProgress.vue
@@ -7,7 +7,7 @@
       <XIcon
         class="mb-3"
         name="progress"
-        :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
+        :color="`var(--x-color-text-neutral-weak)`"
       />
     </template>
 
@@ -19,7 +19,7 @@
     v-else-if="props.variant === 'spinner'"
     name="progress"
     data-testid="spinner"
-    :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
+    :color="`var(--x-color-text-neutral-weak)`"
   />
   <KSkeleton
     v-else-if="props.variant === 'list'"
@@ -45,7 +45,6 @@
   </XLayout>
 </template>
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
 import { KEmptyState } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   variant?: 'list' | 'line' | 'spinner' | 'legacy' | 'header'

--- a/packages/x/src/components/x-theme/XTheme.vue
+++ b/packages/x/src/components/x-theme/XTheme.vue
@@ -207,6 +207,7 @@ import '@kong-ui-public/app-layout/dist/style.css'
   --x-border-width-10: var(--kui-border-width-10, #{$kui-border-width-10});
   --x-border-width-20: var(--kui-border-width-20, #{$kui-border-width-20});
 
+
   /* color-background */
   --x-color-background: var(--kui-color-background, #{$kui-color-background});
   --x-color-background-transparent: var(--kui-color-background-transparent, #{$kui-color-background-transparent});
@@ -238,6 +239,7 @@ import '@kong-ui-public/app-layout/dist/style.css'
   --x-color-text-disabled: var(--kui-color-text-disabled, #{$kui-color-text-disabled});
   --x-color-text-inverse: var(--kui-color-text-inverse, #{$kui-color-text-inverse});
   --x-color-text-neutral: var(--kui-color-text-neutral, #{$kui-color-text-neutral});
+  --x-color-text-neutral-weak: var(--kui-color-text-neutral-weak, #{$kui-color-text-neutral-weak});
   --x-color-text-neutral-strong: var(--kui-color-text-neutral-strong, #{$kui-color-text-neutral-strong});
   --x-color-text-neutral-stronger: var(--kui-color-text-neutral-stronger, #{$kui-color-text-neutral-stronger});
   --x-color-text-primary: var(--kui-color-text-primary, #{$kui-color-text-primary});
@@ -268,6 +270,7 @@ import '@kong-ui-public/app-layout/dist/style.css'
   /* icon-size */
   --x-icon-size-30: var(--kui-icon-size-30, #{$kui-icon-size-30});
   --x-icon-size-40: var(--kui-icon-size-40, #{$kui-icon-size-40});
+  --x-icon-size-50: var(--kui-icon-size-50, #{$kui-icon-size-50});
 
   /* line-height */
   --x-line-height-20: var(--kui-line-height-20, #{$kui-line-height-20});


### PR DESCRIPTION
Similar to https://github.com/kumahq/kuma-gui/pull/5042, we use @kumahq/x now instead and have done for quite a while.

Note: I plan on adding https://stylelint.io/user-guide/rules/no-unknown-custom-properties/ very soon as a follow up.