### PR TITLE
fix: remove double "visit" for services test

### DIFF
--- a/packages/kuma-gui/features/mesh/services/Index.feature
+++ b/packages/kuma-gui/features/mesh/services/Index.feature
@@ -54,7 +54,6 @@ Feature: mesh / services / index
     Then the "$item" element exists 1 times
 
   Scenario: Searching by name
-    When I visit the "/meshes/default/services/internal" URL
     Then the "$input-search" element exists
     When I "type" "foo kuma.io/service-name:bar" into the "$input-search" element
     And I "type" "{enter}" into the "$input-search" element


### PR DESCRIPTION
This test has a `Background` that already "visits" the page to be tested, so this secondary one isn't required.

Moreover, I found that have this actually causes an error and now a test failure since we added https://github.com/kumahq/kuma-gui/pull/5012

I'm thinking this is because the first visit starts a HTTP request, which is then cancelled (HTTP0 🎉 ) by the second "visit" which causes an error and fails the test before it even gets started.

(note: `master` is currently failing due to this)