### PR TITLE
chore: use github-buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6728,9 +6728,9 @@
       }
     },
     "node_modules/github-buttons": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/github-buttons/-/github-buttons-2.29.1.tgz",
-      "integrity": "sha512-TV3YgAKda5hPz75n7QXmGCsSzgVya1vvmBieebg3EB5ScmashTZ0FldViG1aU2d4V5rcAGrtQ7k5uAaCo0A4PA==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/github-buttons/-/github-buttons-2.32.0.tgz",
+      "integrity": "sha512-DbKam2n7JGbccpbAoQ7UHhxH2XYlumCakTM4Ln7v8A9TzMaaEgKV6S7A+Suyx3EVBE1DPEqA6QSgyCoGJamymg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/glob-parent": {
@@ -12999,15 +12999,6 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/vue-github-button": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vue-github-button/-/vue-github-button-3.1.3.tgz",
-      "integrity": "sha512-ZdOnUuYJL/wUsxISsC96TARzCdf1twaWooZoI14+g4RHsJltPY+Agw6Ox6pjuMqMX0uhSK1JOMFUFNCQGlcZGA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "github-buttons": "^2.22.0"
-      }
-    },
     "node_modules/vue-global-events": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/vue-global-events/-/vue-global-events-3.0.1.tgz",
@@ -13690,13 +13681,13 @@
         "@kumahq/x": "*",
         "@vueuse/core": "^14.3.0",
         "deepmerge": "^4.3.1",
+        "github-buttons": "^2.32.0",
         "js-yaml": "^4.1.1",
         "openapi-fetch": "^0.15.0",
         "pretty-bytes": "^7.1.0",
         "shiki": "^4.2.0",
         "urlpattern-polyfill": "^10.1.0",
         "vue": "^3.5.35",
-        "vue-github-button": "^3.1.3",
         "vue-router": "^5.1.0"
       },
       "devDependencies": {
@@ -13775,6 +13766,7 @@
         "@kumahq/config": "*"
       },
       "peerDependencies": {
+        "@kong/kongponents": "^9.59.0",
         "vue": "*"
       }
     }

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -21,13 +21,13 @@
     "@kumahq/x": "*",
     "@vueuse/core": "^14.3.0",
     "deepmerge": "^4.3.1",
+    "github-buttons": "^2.32.0",
     "js-yaml": "^4.1.1",
     "openapi-fetch": "^0.15.0",
     "pretty-bytes": "^7.1.0",
     "shiki": "^4.2.0",
     "urlpattern-polyfill": "^10.1.0",
     "vue": "^3.5.35",
-    "vue-github-button": "^3.1.3",
     "vue-router": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -16,13 +16,14 @@
             <slot name="home" />
           </XAction>
 
-          <GithubButton
+          <a
+            ref="gh"
+            aria-label="Star kumahq/kuma on GitHub"
             class="gh-star"
             href="https://github.com/kumahq/kuma"
-            aria-label="Star kumahq/kuma on GitHub"
           >
             Star
-          </GithubButton>
+          </a>
 
           <div class="upgrade-check-wrapper">
             <DataSource
@@ -152,7 +153,9 @@
   </div>
 </template>
 <script lang="ts" setup>
-import GithubButton from 'vue-github-button'
+import { render } from 'github-buttons'
+import { useTemplateRef, onMounted } from 'vue'
+
 
 import { useEnv, useI18n } from '@/app/application'
 
@@ -160,6 +163,15 @@ const slots = defineSlots()
 
 const env = useEnv()
 const { t } = useI18n()
+
+const gh = useTemplateRef<HTMLAnchorElement>('gh')
+
+onMounted(() => {
+  const $gh = gh.value
+  if($gh) {
+    render($gh, (el) => $gh.parentNode?.replaceChild(el, $gh))
+  }
+})
 
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
Instead of `vue-github-button` (which depended on `github-buttons`) and therefore removes one dependency.

(I've also forever noticed that sometimes during dev at least, the way `vue-github-button` works means that sometimes the button doesn't load properly and produces console errors etc)