### PR TITLE
fix(kuma-http-api/mocks): next query param separator

### DIFF
--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/Navigation.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/Navigation.feature
@@ -3,7 +3,7 @@ Feature: zones / ingresses / navigation
   Background:
     Given the CSS selectors
       | Alias         | Selector                                                                    |
-      | row           | [data-testid$='-collection'] tbody tr:first-child                                 |
+      | row           | [data-testid$='-collection'] tbody tr:first-child                           |
       | action-group  | $row [data-testid='x-action-group-control']                                 |
       | view          | $row [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
       | action        | $row [data-action]                                                          |

--- a/packages/kuma-http-api/mocks/index.ts
+++ b/packages/kuma-http-api/mocks/index.ts
@@ -27,7 +27,7 @@ export const pager = (total: string | number, req: RestRequest, self: string) =>
 
   const remaining = ttal - offset
   const pageTotal = Math.min(size, remaining)
-  const next = remaining <= size ? undefined : `${baseUrl}${self}?size=${size}offset=${offset + size}`
+  const next = remaining <= size ? null : `${baseUrl}${self}?size=${size}&offset=${offset + size}`
   return {
     next,
     pageTotal,

--- a/packages/kuma-http-api/mocks/index.ts
+++ b/packages/kuma-http-api/mocks/index.ts
@@ -27,7 +27,7 @@ export const pager = (total: string | number, req: RestRequest, self: string) =>
 
   const remaining = ttal - offset
   const pageTotal = Math.min(size, remaining)
-  const next = remaining <= size ? null : `${baseUrl}${self}?size=${size}&offset=${offset + size}`
+  const next = remaining <= size ? undefined : `${baseUrl}${self}?size=${size}&offset=${offset + size}`
   return {
     next,
     pageTotal,


### PR DESCRIPTION
There was no query param separator `&` in the URL for `next`