### PR TITLE
chore(ci): small follow ups to new connect mock server

### DIFF
--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -6,6 +6,18 @@ type PluginOptions<TDependencies extends object = {}> = {
   fs: FS<TDependencies>
   dependencies: Dependencies<TDependencies>
 }
+const Cookie = {
+  parse: (str: string, { prefix = '' } = { prefix: '' }) => {
+    return Object.fromEntries(str.split(';')
+      .map((item) => item.trim())
+      .filter((item) => item !== '')
+      .map((item) => {
+        const [key, ...value] = item.split('=')
+        return [key, value.join('=')] as [string, string]
+      })
+      .filter(([key, value]) => key.startsWith(prefix)))
+  },
+}
 
 export default <TDependencies extends object = {}>(opts: PluginOptions<TDependencies>): Plugin => {
 
@@ -43,6 +55,12 @@ export default <TDependencies extends object = {}>(opts: PluginOptions<TDependen
         res.setHeader('Content-Type', type)
         res.setHeader('Status-Code', response.headers.get('Status-Code') ?? '200')
         const resp = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
+
+        const cookies = Cookie.parse(req.headers?.cookie ?? '', { prefix: 'KUMA_' })
+        if (cookies.KUMA_LATENCY) {
+          await new Promise((resolve) => setTimeout(resolve, parseInt(cookies.KUMA_LATENCY)))
+        }
+
         if(response.headers.get('Transfer-Encoding') === 'chunked') {
           res.write(resp)
           res.end()

--- a/packages/gherkin-web/src/playwright/steps/index.ts
+++ b/packages/gherkin-web/src/playwright/steps/index.ts
@@ -84,13 +84,6 @@ export async function setupSteps({
         value: 'false',
         url: `${baseURL}`,
       },
-      ...(config.passthrough ? [
-        {
-          name: 'KUMA_API_URL',
-          value: 'http://localhost:5681',
-          url: `${baseURL}`,
-        },
-      ] : []),
     ])
     const p = Object.keys(fs).map(route => {
       return context.route(
@@ -113,9 +106,6 @@ export async function setupSteps({
               },
             })
 
-            if (env.KUMA_LATENCY) {
-              await new Promise((resolve) => setTimeout(resolve, parseInt(env.KUMA_LATENCY)))
-            }
             if(config.passthrough) {
               await route.fallback({ headers })
             } else {
@@ -125,6 +115,9 @@ export async function setupSteps({
               })
               const type = response.headers.get('Content-Type') ?? 'application/json'
               const body = type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text())
+              if (env.KUMA_LATENCY) {
+                await new Promise((resolve) => setTimeout(resolve, parseInt(env.KUMA_LATENCY)))
+              }
               await route.fulfill({
                 status: parseInt(response.headers.get('Status-Code') ?? '200'),
                 contentType: type,

--- a/packages/kuma-gui/vite.config.preview.ts
+++ b/packages/kuma-gui/vite.config.preview.ts
@@ -1,4 +1,4 @@
-import { replicateKumaServer } from '@kumahq/config/vite'
+import { replicateKumaServer, playwrightBdd } from '@kumahq/config/vite'
 import fakeApi from '@kumahq/fake-api/vite'
 import { fs, dependencies } from '@kumahq/kuma-http-api/mocks'
 import { defineConfig } from 'vite'
@@ -15,6 +15,7 @@ export const config: UserConfigFn = () => {
         template: './dist/gui/index.html',
       }),
       fakeApi({ dependencies, fs }),
+      playwrightBdd(),
     ],
   }
 }


### PR DESCRIPTION
1. Moves latency mocking into the server
2. For the system-under-test (i.e. the app, not the runner), depends on the in-HTML vars to figure out the `KUMA_API_URL`
3. Adds `bdd` auto-generation to the preview server (we use this to test in CI, and occasionally locally if we want to test a prod build locally.


**Important Note**: (something I forget to mention in the previous PR). We should permanently set `KUMA_MOCK_API_ENABLED=false`. This means MSW is disabled and during development the app will then use the new connect server which uses real HTTP. The only thing now that should be using MSW are PR previews.

I would like to re-think how `KUMA_MOCK_API_ENABLED` functions/is used in the future, but for now just set it to false.