### PR TITLE
chore(kumahq/x): moves XDrawer to use a teleport layer like modals

### DIFF
--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -138,11 +138,15 @@
           </ul>
         </nav>
       </div>
-      <main
-        class="app-main-content"
-      >
+      <main>
+        <div class="drawer">
+          <XTeleportSlot
+            name="drawer-layer"
+          />
+        </div>
         <XLayout
           variant="y-stack"
+          class="app-main-content"
         >
           <div>
             <slot name="default" />
@@ -176,22 +180,30 @@ onMounted(() => {
 </script>
 <style lang="scss" scoped>
 .application-shell {
-  --AppHeaderHeight: 60px;
+  --kuma-app-top: 60px;
+  --x-drawer-offset-top: var(--kuma-app-top);
+
   --AppSidebarWidth: 240px;
   --AppContentPadding: var(--x-space-80);
-  --x-drawer-offset-top: var(--AppHeaderHeight);
 
 }
 .app-content-container {
   display: grid;
-  padding-top: var(--AppHeaderHeight, initial);
+  padding-top: var(--kuma-app-top, initial);
   // Note: `minmax(0, 1fr)` is used because `1fr` implies `minmax(auto, 1fr)` which will allow grid items to grow beyond their container's size.
   grid-template-columns: var(--AppSidebarWidth) minmax(0, 1fr);
 }
+.drawer {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+}
 
+main {
+  min-height: calc(100vh - var(--kuma-app-top));
+}
 .app-main-content {
   padding: var(--AppContentPadding);
-  min-height: calc(100vh - var(--AppHeaderHeight));
 }
 
 header {
@@ -200,7 +212,7 @@ header {
   top: 0;
   left: 0;
   width: 100%;
-  height: var(--AppHeaderHeight);
+  height: var(--kuma-app-top);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -226,7 +238,7 @@ nav {
   padding: 0;
   width: var(--AppSidebarWidth);
   z-index: 10;
-  top: var(--AppHeaderHeight);
+  top: var(--kuma-app-top);
   bottom: 0;
   left: 0;
   overflow-y: auto;

--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -118,7 +118,7 @@ import { sources } from '@/app/policies/sources'
 <style lang="scss" scoped>
 .policy-type-list {
   position: sticky;
-  top: calc(var(--AppHeaderHeight) + var(--x-space-70));
+  top: calc(var(--kuma-app-top) + var(--x-space-70));
   align-self: flex-start;
   max-width: 500px;
 

--- a/packages/x/src/components/x-drawer/XDrawer.vue
+++ b/packages/x/src/components/x-drawer/XDrawer.vue
@@ -1,54 +1,72 @@
 <template>
-  <KSlideout
-    ref="slideOutRef"
-    class="summary-slideout"
-    :close-on-blur="false"
-    :has-overlay="false"
-    visible
-    :max-width="props.width"
-    offset-top="var(--x-drawer-offset-top, 0)"
-    data-testid="summary"
-    @close="emit('close')"
+  <XTeleportTemplate
+    :to="{ name: 'drawer-layer'}"
   >
-    <template #title>
-      <XTeleportSlot :name="id" />
-    </template>
-    <slot />
-  </KSlideout>
+    <KSlideout
+      :id="id"
+      class="summary-slideout"
+      :close-on-blur="false"
+      :has-overlay="false"
+      visible
+      :max-width="props.width"
+      data-testid="summary"
+      @close="emit('close')"
+    >
+      <template #title>
+        <XTeleportSlot :name="id" />
+      </template>
+      <slot />
+    </KSlideout>
+  </XTeleportTemplate>
 </template>
 
 <script lang="ts" setup>
-import { onClickOutside, useThrottleFn } from '@vueuse/core'
-import { ref, provide, useId } from 'vue'
+import { onClickOutside } from '@vueuse/core'
+import { provide, useId, onMounted, nextTick } from 'vue'
 
 const id = useId()
 provide('app-summary-view', id)
 
 // recreates KSlideOuts close on blur, but ignores clicks on any anchors
-const slideOutRef = ref(null)
-onClickOutside(
-  // @ts-ignore CI only ts error
-  slideOutRef,
-  useThrottleFn((event: PointerEvent) => {
-    const $el = event.target as HTMLElement
-    if ((window.getSelection()?.isCollapsed ?? true) && !event.defaultPrevented && event.isTrusted && $el.nodeName.toLowerCase() !== 'a') {
-      emit('close')
-    }
-  }, 1, true, false),
-)
 const props = withDefaults(defineProps<{
   width?: string
+  selector?: string
 }>(), {
   width: '560px',
+  selector: 'main',
 })
 
 const emit = defineEmits<{
   (event: 'close'): void
 }>()
+
+onMounted(async () => {
+  await nextTick()
+  const $el = document.getElementById(id)
+  if($el) {
+    onClickOutside(
+      $el,
+      (event: PointerEvent) => {
+        const $el = event.target as HTMLElement
+        if (
+          (window.getSelection()?.isCollapsed ?? true)
+            && !event.defaultPrevented
+            && event.isTrusted
+            && (!['button', 'a'].includes($el.nodeName.toLowerCase()) || $el.closest(props.selector))
+        ) {
+          emit('close')
+        }
+      },
+    )
+  }
+})
 </script>
 <style lang="scss" scoped>
 .summary-slideout {
-  --app-view-content-top: 0;
+  pointer-events: auto !important;
+}
+:deep(.slideout-backdrop) {
+  pointer-events: none !important;
 }
 :deep(.slideout-header) {
   h1, h2, h4, h5, h6 {
@@ -68,5 +86,7 @@ const emit = defineEmits<{
 }
 :deep(.slideout-container) {
   z-index: auto !important;
+  top: unset !important;
+  height: calc(100vh - var(--x-drawer-offset-top)) !important;
 }
 </style>


### PR DESCRIPTION
Reorganizes XDrawer so it can be relatively positioned.