### PR TITLE
fix(kuma-http-api/mocks/meshidentities): wrong shortName

### DIFF
--- a/packages/kuma-http-api/mocks/src/meshes/_/meshidentities.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshidentities.ts
@@ -31,7 +31,7 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
           displayName,
         ] = [
           'kri', // prefix
-          'mtrust', // shortName
+          'mid', // shortName
           String(req.params.mesh), // mesh
           fake.helpers.arrayElement(['', fake.word.noun()]), // zone
           ...([k8s ? fake.word.noun() : '', `${fake.word.noun()}-${id}`]), // nspace, displayName


### PR DESCRIPTION
See title