### PR TITLE
[Backport 2.14] fix(subscriptions): fix nacks typo and don't i18n resource names (#5063)

### DIFF
--- a/packages/kuma-gui/src/app/subscriptions/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/subscriptions/locales/en-us/index.yaml
@@ -21,7 +21,7 @@ subscriptions:
         data-plane-subscription-summary-config-view: YAML
       headers:
         config: Config
-        responses: Total responses (sent/ack'ed)
+        responses: Total responses (sent/ACK'ed)
         type: Type
-        stat: Responses (sent/ack'ed)
-        nacked: Responses rejected / NACK'ed
+        stat: Responses (sent/ACK'ed)
+        nacked: Responses rejected (NACK'ed)

--- a/packages/kuma-gui/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/packages/kuma-gui/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -128,7 +128,7 @@
                                   {{ t('subscriptions.routes.item.headers.type') }}
                                 </th>
                                 <th>
-                                  {{ t('subscriptions.routes.item.headers.stat') }}
+                                  {{ t('subscriptions.routes.item.headers.nacked') }}
                                 </th>
                               </tr>
                             </thead>
@@ -140,7 +140,7 @@
                                 <th
                                   scope="row"
                                 >
-                                  {{ t(`http.api.property.${key}`) }}
+                                  {{ key }}
                                 </th>
                                 <td>
                                   {{ value.responsesRejected }}
@@ -170,7 +170,7 @@
                                 <th
                                   scope="row"
                                 >
-                                  {{ t(`http.api.property.${key}`) }}
+                                  {{ key }}
                                 </th>
                                 <td>
                                   {{ value.responsesSent }}/{{ value.responsesAcknowledged }}


### PR DESCRIPTION
Note: This PR should be backported to 2.14

### Before

<img width="656" height="293" alt="Screenshot 2026-06-25 at 11 16 15" src="https://github.com/user-attachments/assets/c86cd9c5-3394-49c5-a8b5-5b7fc0fdc8e1" />

### After

<img width="657" height="301" alt="Screenshot 2026-06-25 at 11 15 37" src="https://github.com/user-attachments/assets/522270d1-7934-4351-b436-c387a71ff054" />

---------

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
