### PR TITLE
chore(mk/install): add min-release-age-exclude for @kong scoped packages

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -15,6 +15,7 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 					--ignore-scripts \
 					--allow-git none \
 					--min-release-age 12 \
+					--min-release-age-exclude=@kong*/* \
 		&& touch $(NPM_WORKSPACE_ROOT)/node_modules
 #
 .PHONY: .sync

--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -15,7 +15,9 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 					--ignore-scripts \
 					--allow-git none \
 					--min-release-age 12 \
-					--min-release-age-exclude=@kong*/* \
+					--min-release-age-exclude=@kong/* \
+					--min-release-age-exclude=@kong-ui/* \
+					--min-release-age-exclude=@kong-ui-public/* \
 		&& touch $(NPM_WORKSPACE_ROOT)/node_modules
 #
 .PHONY: .sync
@@ -26,7 +28,10 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 					--prefer-dedupe \
 					--ignore-scripts \
 					--allow-git none \
-					--min-release-age 12
+					--min-release-age 12 \
+					--min-release-age-exclude=@kong/* \
+					--min-release-age-exclude=@kong-ui/* \
+					--min-release-age-exclude=@kong-ui-public/*
 
 .PHONY: .clean
 .clean:

--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -15,9 +15,7 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 					--ignore-scripts \
 					--allow-git none \
 					--min-release-age 12 \
-					--min-release-age-exclude=@kong/* \
-					--min-release-age-exclude=@kong-ui/* \
-					--min-release-age-exclude=@kong-ui-public/* \
+					--min-release-age-exclude=@kong{,-ui,-ui-public}/* \
 		&& touch $(NPM_WORKSPACE_ROOT)/node_modules
 #
 .PHONY: .sync
@@ -29,9 +27,7 @@ $(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lo
 					--ignore-scripts \
 					--allow-git none \
 					--min-release-age 12 \
-					--min-release-age-exclude=@kong/* \
-					--min-release-age-exclude=@kong-ui/* \
-					--min-release-age-exclude=@kong-ui-public/*
+					--min-release-age-exclude=@kong{,-ui,-ui-public}/*
 
 .PHONY: .clean
 .clean:


### PR DESCRIPTION
Now with `npm@11.17.0` we are able to set the `min-release-age-exclude` for `@kong` packages 🎉 