### PR TITLE
feat(hostname-generator): support kri links

### DIFF
--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -92,12 +92,7 @@
                 <template #actions="{ row: item }">
                   <XActionGroup>
                     <XAction
-                      :to="{
-                        name: 'hostname-generator-detail-view',
-                        params: {
-                          kri: item.kri,
-                        },
-                      }"
+                      :href="`kri://${item.kri}`"
                     >
                       {{ t('common.collection.actions.view') }}
                     </XAction>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
@@ -21,13 +21,7 @@
           <template #title>
             <h2>
               <XAction
-                :to="{
-                  name: 'hostname-generator-detail-view',
-                  params: {
-                    name: route.params.kri,
-                  },
-
-                }"
+                :href="`kri://${item.kri}`"
               >
                 <RouteTitle
                   :title="t('hostname-generators.routes.item.title', { name: item.name })"

--- a/packages/kuma-gui/src/app/service-mesh/index.ts
+++ b/packages/kuma-gui/src/app/service-mesh/index.ts
@@ -17,7 +17,8 @@ const protocolHandler = (can: Can) => {
     const kriProto = 'kri://'
     switch (true) {
       case href.startsWith(kriProto): {
-        const { mesh, name: encodedName, zone, namespace, shortName } = Kri.fromString(href.substring(kriProto.length))
+        const kri = href.substring(kriProto.length)
+        const { mesh, name: encodedName, zone, namespace, shortName } = Kri.fromString(kri)
         // old style names can have _ in them that are replaced with `~`
         const name = encodedName.replaceAll('~', '_')
         const id = `${name}${namespace !== '' ? `.${namespace}`: '' }`
@@ -76,6 +77,13 @@ const protocolHandler = (can: Can) => {
                 params: {
                   mesh: mesh,
                   service: id,
+                },
+              }
+            case shortName === 'hg':
+              return {
+                name: 'hostname-generator-detail-view',
+                params: {
+                  kri,
                 },
               }
             default:

--- a/packages/x/src/components/x-action/XAction.vue
+++ b/packages/x/src/components/x-action/XAction.vue
@@ -82,6 +82,7 @@
         name="default"
       />
     </KButton>
+
     <a
       v-else
       data-testid="x-action"
@@ -180,7 +181,7 @@
 // eslint-disable-next-line import/order
 import SharedPool from '../../utilities/SharedPool'
 // eslint-disable-next-line import/order
-import type { Router , RouteLocationNamedRaw } from 'vue-router'
+import type { Router, RouteLocationAsRelative } from 'vue-router'
 
 const findAnchor = (target: HTMLElement) => {
   // we look for anchors, or any other element that has [data-actionable]
@@ -256,7 +257,7 @@ import type { ButtonAppearance } from '@kong/kongponents'
 
 type BooleanLocationQueryValue = string | number | undefined | boolean
 type BooleanLocationQueryRaw = Record<string | number, BooleanLocationQueryValue | BooleanLocationQueryValue[]>
-type RouteLocationRawWithBooleanQuery = Omit<RouteLocationNamedRaw, 'query'> & {
+type RouteLocationRawWithBooleanQuery = Omit<RouteLocationAsRelative, 'query'> & {
   query?: BooleanLocationQueryRaw
 }
 


### PR DESCRIPTION
Use KRI to link from the `hostname-generator-list-view` to the `hostname-generator-detail-view`.

---

The linking from generic resource summary and list-view to a specific detail view will probably the last iteration on linking from KRIs, so it's not covered here. For now I'm thinking that within the protocolHandler and the default case of the big switch statement could be the link to the generic detail page.