### PR TITLE
chore(kuma-http-api/eslint): add kuma and generated folders to ignores

### DIFF
--- a/packages/kuma-http-api/eslint.config.js
+++ b/packages/kuma-http-api/eslint.config.js
@@ -5,7 +5,7 @@ import { eslint } from '@kumahq/config'
 const config = [
   ...eslint(),
   {
-    'ignores': ['index.d.ts'],
+    'ignores': ['index.d.ts', 'kuma', 'generated'],
   },
 ]
 


### PR DESCRIPTION
We have both `kuma` and `generated` added to the the local `.gitignore`, but if these folders exists they are not yet excluded from eslint, which can cause issues when trying to check lint issues in this package.