### PR TITLE
feat(workloads): use kri for linking, typesafe data-loading

### DIFF
--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -92,8 +92,7 @@ const protocolHandler = (can: Can, router: Router) => {
               return {
                 name: 'workload-detail-view',
                 params: {
-                  // @TODO: passthrough kri
-                  wl: Kri.toString({ shortName, mesh, zone, namespace, name }),
+                  wl: kri,
                 },
               }
             case shortName === '~hostport':

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -92,6 +92,7 @@ const protocolHandler = (can: Can, router: Router) => {
               return {
                 name: 'workload-detail-view',
                 params: {
+                  // @TODO: passthrough kri
                   wl: Kri.toString({ shortName, mesh, zone, namespace, name }),
                 },
               }

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -65,7 +65,7 @@ const protocolHandler = (can: Can, router: Router) => {
     switch (true) {
       case href.startsWith(kriProto): {
         const kri = href.substring(kriProto.length)
-        const { mesh, name: encodedName, zone, namespace, shortName } = Kri.fromString(kri)
+        const { mesh, name: encodedName, namespace, shortName } = Kri.fromString(kri)
         // old style names can have _ in them that are replaced with `~`
         const name = encodedName.replaceAll('~', '_')
         const id = `${name}${namespace !== '' ? `.${namespace}`: '' }`

--- a/packages/kuma-gui/src/app/workloads/routes.ts
+++ b/packages/kuma-gui/src/app/workloads/routes.ts
@@ -6,7 +6,7 @@ export const routes = () => {
     return [
       {
         name: 'workload-detail-tabs-view',
-        path: 'workloads/:wl',
+        path: 'workloads/:kri',
         component: () => import('@/app/workloads/views/WorkloadDetailTabsView.vue'),
         children: [
           {
@@ -34,7 +34,7 @@ export const routes = () => {
           component: () => import('@/app/workloads/views/WorkloadListView.vue'),
           children: [
             {
-              path: ':wl',
+              path: ':kri',
               name: 'workload-summary-view',
               component: () => import('@/app/workloads/views/WorkloadSummaryView.vue'),
             },

--- a/packages/kuma-gui/src/app/workloads/routes.ts
+++ b/packages/kuma-gui/src/app/workloads/routes.ts
@@ -6,7 +6,7 @@ export const routes = () => {
     return [
       {
         name: 'workload-detail-tabs-view',
-        path: 'workloads/:kri',
+        path: 'workloads/:wl',
         component: () => import('@/app/workloads/views/WorkloadDetailTabsView.vue'),
         children: [
           {
@@ -34,7 +34,7 @@ export const routes = () => {
           component: () => import('@/app/workloads/views/WorkloadListView.vue'),
           children: [
             {
-              path: ':kri',
+              path: ':wl',
               name: 'workload-summary-view',
               component: () => import('@/app/workloads/views/WorkloadSummaryView.vue'),
             },

--- a/packages/kuma-gui/src/app/workloads/sources.ts
+++ b/packages/kuma-gui/src/app/workloads/sources.ts
@@ -32,23 +32,23 @@ export const sources = (api: KumaApi) => {
       return Workload.fromCollection(res.data!)
     },
 
-    '/workloads/:wl': async (params) => {
-      const { wl } = params
+    '/workloads/:kri': async (params) => {
+      const { kri } = params
 
       const res = await http.GET('/_kri/{kri}', {
-        params: { path: { kri: wl } },
+        params: { path: { kri } },
       })
 
       return Workload.fromObject(res.data as KumaWorkloadItem)
     },
 
-    '/workloads/:wl/as/kubernetes': async (params) => {
-      const { wl } = params
+    '/workloads/:kri/as/kubernetes': async (params) => {
+      const { kri } = params
 
       const res = await http.GET('/_kri/{kri}', {
         params: {
           path: {
-            kri: wl,
+            kri,
           },
           // @ts-expect-error -- query type is not defined in openapi spec --
           query: {
@@ -57,7 +57,7 @@ export const sources = (api: KumaApi) => {
         },
       })
 
-      return res.data
+      return res.data!
     },
   })
 }

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadConfigView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadConfigView.vue
@@ -3,7 +3,7 @@
     name="workload-config-view"
     :params="{
       mesh: '',
-      kri: '',
+      wl: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -66,7 +66,7 @@
           <template v-else>
             <DataLoader
               :src="uri(sources, '/workloads/:kri/as/kubernetes', {
-                kri: route.params.kri,
+                kri: route.params.wl,
               })"
               v-slot="{ data: [k8sConfig] }"
             >

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadConfigView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadConfigView.vue
@@ -3,7 +3,7 @@
     name="workload-config-view"
     :params="{
       mesh: '',
-      wl: '',
+      kri: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -47,27 +47,26 @@
           <template v-if="route.params.environment === 'universal'">
             <DataLoader
               :data="[props.data]"
+              v-slot="{ data: [workload] }"
             >
-              <template v-if="typeof props.data !== 'undefined' && !(props.data instanceof Error)">
-                <XCodeBlock
-                  data-testid="codeblock-yaml-universal"
-                  language="yaml"
-                  :code="YAML.stringify(props.data.$raw)"
-                  is-searchable
-                  :query="route.params.codeSearch"
-                  :is-filter-mode="route.params.codeFilter"
-                  :is-reg-exp-mode="route.params.codeRegExp"
-                  @query-change="route.update({ codeSearch: $event })"
-                  @filter-mode-change="route.update({ codeFilter: $event })"
-                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-                />
-              </template>
+              <XCodeBlock
+                data-testid="codeblock-yaml-universal"
+                language="yaml"
+                :code="YAML.stringify(workload.$raw)"
+                is-searchable
+                :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter"
+                :is-reg-exp-mode="route.params.codeRegExp"
+                @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+              />
             </DataLoader>
           </template>
           <template v-else>
             <DataLoader
-              :src="uri(sources, '/workloads/:wl/as/kubernetes', {
-                wl: route.params.wl,
+              :src="uri(sources, '/workloads/:kri/as/kubernetes', {
+                kri: route.params.kri,
               })"
               v-slot="{ data: [k8sConfig] }"
             >

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
@@ -3,13 +3,13 @@
     name="workload-detail-tabs-view"
     :params="{
       mesh: '',
-      kri: '',
+      wl: '',
     }"
     v-slot="{ route, t, uri }"
   >
     <DataSource
       :src="uri(sources, '/workloads/:kri', {
-        kri: route.params.kri,
+        kri: route.params.wl,
       })"
       v-slot="{ data, result }"
     >

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
@@ -3,13 +3,13 @@
     name="workload-detail-tabs-view"
     :params="{
       mesh: '',
-      wl: '',
+      kri: '',
     }"
     v-slot="{ route, t, uri }"
   >
     <DataSource
-      :src="uri(sources, '/workloads/:wl', {
-        wl: route.params.wl,
+      :src="uri(sources, '/workloads/:kri', {
+        kri: route.params.kri,
       })"
       v-slot="{ data, result }"
     >

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailView.vue
@@ -19,75 +19,74 @@
       <XCard
         data-testid="about-workload"
       >
-        <XTimespan
-          :start="typeof props.data !== 'undefined' && !(props.data instanceof Error) ? props.data.creationTime : undefined"
-          :end="typeof props.data !== 'undefined' && !(props.data instanceof Error) ? props.data.modificationTime : undefined"
-        />
         <template #title>
           {{ t('workloads.routes.item.about.title') }}
         </template>
         <DataLoader
           :data="[props.data]"
+          v-slot="{ data: [workload] }"
         >
-          <template v-if="typeof props.data !== 'undefined' && !(props.data instanceof Error)">
-            <XDl>
-              <div>
-                <dt>{{ t('http.api.property.status') }}</dt>
-                <dd>
-                  <XBadge
-                    :appearance="t(`common.status.appearance.${props.data.status.state}`, undefined, { defaultMessage: 'neutral' })"
-                  >
-                    {{ t(`http.api.value.${props.data.status.state}`) }}
-                  </XBadge>
-                </dd>
-              </div>
+          <XTimespan
+            :start="workload.creationTime"
+            :end="workload.modificationTime"
+          />
+          <XDl>
+            <div>
+              <dt>{{ t('http.api.property.status') }}</dt>
+              <dd>
+                <XBadge
+                  :appearance="t(`common.status.appearance.${workload.status.state}`, undefined, { defaultMessage: 'neutral' })"
+                >
+                  {{ t(`http.api.value.${workload.status.state}`) }}
+                </XBadge>
+              </dd>
+            </div>
 
-              <div v-if="can('use zones') && props.data.zone.length">
-                <dt>{{ t('http.api.property.zone') }}</dt>
-                <dd>
+            <div v-if="can('use zones') && workload.zone.length">
+              <dt>{{ t('http.api.property.zone') }}</dt>
+              <dd>
+                <XAction
+                  v-if="workload.zone"
+                  :href="`kri://${Kri.toString({ shortName: 'z', name: workload.zone })}`"
+                >
+                  <XBadge>{{ workload.zone }}</XBadge>
+                </XAction>
+              </dd>
+            </div>
+
+            <div v-if="workload.namespace.length">
+              <dt>{{ t('http.api.property.namespace') }}</dt>
+              <dd>
+                <XBadge>{{ workload.namespace }}</XBadge>
+              </dd>
+            </div>
+
+            <div v-if="Object.keys(workload.labels).length > 0">
+              <dt>{{ t('workloads.routes.item.about.labels') }}</dt>
+              <dd>
+                <XLayout
+                  variant="separated"
+                >
                   <XAction
-                    v-if="props.data.zone"
-                    :href="`kri://${Kri.toString({ shortName: 'z', name: props.data.zone })}`"
+                    v-for="(value, key) in workload.labels"
+                    :key="key"
+                    :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                      mesh: workload.mesh,
+                      zone: workload.zone,
+                      namespace: workload.namespace,
+                      name: value,
+                    }, { defaultMessage: '' })"
                   >
-                    <XBadge>{{ props.data.zone }}</XBadge>
-                  </XAction>
-                </dd>
-              </div>
-
-              <div v-if="props.data.namespace.length">
-                <dt>{{ t('http.api.property.namespace') }}</dt>
-                <dd>
-                  <XBadge>{{ props.data.namespace }}</XBadge>
-                </dd>
-              </div>
-
-              <div v-if="Object.keys(props.data.labels).length > 0">
-                <dt>{{ t('workloads.routes.item.about.labels') }}</dt>
-                <dd>
-                  <XLayout
-                    variant="separated"
-                  >
-                    <XAction
-                      v-for="(value, key) in props.data.labels"
-                      :key="key"
-                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
-                        mesh: props.data.mesh,
-                        zone: props.data.zone,
-                        namespace: props.data.namespace,
-                        name: value,
-                      }, { defaultMessage: '' })"
+                    <XBadge
+                      :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                     >
-                      <XBadge
-                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
-                      >
-                        {{ key }}:<strong>{{ value }}</strong>
-                      </XBadge>
-                    </XAction>
-                  </XLayout>
-                </dd>
-              </div>
-            </XDl>
-          </template>
+                      {{ key }}:<strong>{{ value }}</strong>
+                    </XBadge>
+                  </XAction>
+                </XLayout>
+              </dd>
+            </div>
+          </XDl>
         </DataLoader>
       </XCard>
 

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
@@ -77,7 +77,7 @@
                       :to="{
                         name: 'workload-summary-view',
                         params: {
-                          kri: item.kri,
+                          wl: item.kri,
                         },
                         query: {
                           page: route.params.page,

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadListView.vue
@@ -49,17 +49,17 @@
               :data="[data]"
               :errors="[error]"
               variant="list"
+              v-slot="{ data: [workloads] }"
             >
               <DataCollection
-                v-if="typeof data !== 'undefined'"
-                :items="data.items"
-                :total="data.total"
+                :items="workloads.items"
+                :total="workloads.total"
                 :page="route.params.page"
                 :page-size="route.params.size"
                 @change="route.update"
               >
                 <AppCollection
-                  :items="data.items"
+                  :items="workloads.items"
                   type="workload" 
                   :headers="[
                     { ...me.get('headers.name'), label: t('workloads.routes.items.headers.name'), key: 'name' },
@@ -77,7 +77,7 @@
                       :to="{
                         name: 'workload-summary-view',
                         params: {
-                          wl: item.kri,
+                          kri: item.kri,
                         },
                         query: {
                           page: route.params.page,
@@ -110,12 +110,7 @@
                   <template #actions="{ row: item }">
                     <XActionGroup>
                       <XAction
-                        :to="{
-                          name: 'workload-detail-view',
-                          params: {
-                            wl: item.kri,
-                          },
-                        }"
+                        :href="`kri://${item.kri}`"
                       >
                         {{ t('common.collection.actions.view') }}
                       </XAction>

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadSummaryView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadSummaryView.vue
@@ -3,14 +3,14 @@
     name="workload-summary-view"
     :params="{
       mesh: '',
-      wl: '',
+      kri: '',
       environment: String,
     }"
     v-slot="{ route, t, uri }"
   >
     <DataCollection
       :items="props.items"
-      :predicate="item => item.kri === route.params.wl"
+      :predicate="item => item.kri === route.params.kri"
     >
       <template #empty>
         <XEmptyState>
@@ -35,13 +35,7 @@
                 v-icon-start="'workload'"
               >
                 <XAction
-                  :to="{
-                    name: 'workload-detail-view',
-                    params: {
-                      mesh: route.params.mesh,
-                      wl: route.params.wl,
-                    },
-                  }"
+                  :href="`kri://${route.params.kri}`"
                 >
                   <RouteTitle
                     :title="t('workloads.routes.item.title', { name: data.name })"
@@ -83,8 +77,8 @@
             </template>
             <template v-else>
               <DataLoader
-                :src="uri(sources, '/workloads/:wl/as/kubernetes', {
-                  wl: route.params.wl,
+                :src="uri(sources, '/workloads/:kri/as/kubernetes', {
+                  kri: route.params.kri,
                 })"
                 v-slot="{ data: [k8sYaml] }"
               >

--- a/packages/kuma-gui/src/app/workloads/views/WorkloadSummaryView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadSummaryView.vue
@@ -3,14 +3,14 @@
     name="workload-summary-view"
     :params="{
       mesh: '',
-      kri: '',
+      wl: '',
       environment: String,
     }"
     v-slot="{ route, t, uri }"
   >
     <DataCollection
       :items="props.items"
-      :predicate="item => item.kri === route.params.kri"
+      :predicate="item => item.kri === route.params.wl"
     >
       <template #empty>
         <XEmptyState>
@@ -35,7 +35,7 @@
                 v-icon-start="'workload'"
               >
                 <XAction
-                  :href="`kri://${route.params.kri}`"
+                  :href="`kri://${route.params.wl}`"
                 >
                   <RouteTitle
                     :title="t('workloads.routes.item.title', { name: data.name })"
@@ -78,7 +78,7 @@
             <template v-else>
               <DataLoader
                 :src="uri(sources, '/workloads/:kri/as/kubernetes', {
-                  kri: route.params.kri,
+                  kri: route.params.wl,
                 })"
                 v-slot="{ data: [k8sYaml] }"
               >


### PR DESCRIPTION
The main thing here was to do align the route params by using `kri` instead of `wl` and use the kri protocol to route to the detail-view.
While I was here I did some more changes to the data-loading, which was still using the old-style `DataLoader` approach.