### PR TITLE
fix: make plugins vue app scoped

### DIFF
--- a/packages/data/src/vue/components/data-source/DataSource.spec.ts
+++ b/packages/data/src/vue/components/data-source/DataSource.spec.ts
@@ -2,10 +2,14 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 
 import DataSource from './DataSource.vue'
+import Data from '../../index'
 
 describe('DataSource', () => {
   test("passing an empty uri doesn't fire change", async () => {
     const wrapper = mount(DataSource, {
+      global: {
+        plugins: [Data],
+      },
       props: {
         src: '',
       },
@@ -18,6 +22,9 @@ describe('DataSource', () => {
   test('cached responses and errors work', async () => {
     // change
     const wrapper = mount(DataSource, {
+      global: {
+        plugins: [Data],
+      },
       props: {
         src: 'data:application/json,"one"',
       },

--- a/packages/data/src/vue/index.ts
+++ b/packages/data/src/vue/index.ts
@@ -1,10 +1,12 @@
+import { inject } from 'vue'
+
 import { DataSourcePool, create, destroy } from '../'
 // import {
 //   DataLoader,
 //   DataSink,
 //   DataSource,
 // } from './components'
-import type { Plugin } from 'vue'
+import type { App, Plugin, InjectionKey } from 'vue'
 
 export * from './components'
 
@@ -26,6 +28,7 @@ export * from './components'
 declare const typeSymbol: unique symbol
 type Uri<T = unknown> = { [typeSymbol]: T }
 type TypeOf<T> = T extends Uri<infer UriType> ? UriType : never
+type InjectionHooks<T extends Uri[]> = { [K in keyof T]: T[K] extends Uri ? () => TypeOf<T[K]> : never }
 //
 
 /* nano-container */
@@ -40,8 +43,39 @@ const nano = (map = new Map<Uri, unknown>()) => {
   }
   return { singleton, uri }
 }
+type Container = ReturnType<typeof nano>
 /* */
-const { singleton, uri } = nano()
+
+const createInjections = <T extends Uri[]>(...tokens: T): InjectionHooks<T> => {
+  return tokens.map((token) => {
+    return () => {
+      type Service = TypeOf<typeof token>
+      type Getter = () => Service
+      const service = inject(token as unknown as InjectionKey<Getter>) as () => TypeOf<typeof token>
+      if(typeof service === 'undefined') {
+        throw new Error('Unable to find injection ${token}')
+      }
+      return service()
+    }
+  }) as InjectionHooks<T>
+}
+const createBuilder = (container: Container) => {
+  const { singleton, uri } = container
+  const build = (app: App) => {
+    const builder = {
+      service: <T>(uri: Uri<T>, getter: () => T) => {
+        app.provide(uri as unknown as InjectionKey<typeof getter>, singleton(uri, getter))
+        return builder
+      },
+    }
+    return builder
+  }
+  return { build, uri }
+}
+
+
+const { uri } = nano()
+
 const deps = {
   dataSourcePool: new DataSourcePool({
     'data:application/json,:uri': async (params) => {
@@ -52,10 +86,16 @@ const deps = {
 const tokens = {
   dataSourcePool: uri<typeof deps.dataSourcePool>('data.data-source-pool'),
 }
-export const useDataSourcePool = singleton(tokens.dataSourcePool, () => deps.dataSourcePool)
 const plugin: Plugin = {
   install: (app, options: Partial<typeof deps> = {}) => {
-    Object.assign(deps, options)
+    const services = {
+      ...deps,
+      ...options,
+    }
+
+    const { build } = createBuilder(nano())
+    build(app)
+      .service(tokens.dataSourcePool, () => services.dataSourcePool)
     // components.forEach(([name, item]) => {
     //   app.component(name, item as Component)
     // })
@@ -64,4 +104,8 @@ const plugin: Plugin = {
     // })
   },
 }
+
+export const [ useDataSourcePool ] = createInjections(
+  tokens.dataSourcePool,
+)
 export default plugin

--- a/packages/routing/src/vue/index.ts
+++ b/packages/routing/src/vue/index.ts
@@ -1,10 +1,12 @@
+import { inject } from 'vue'
+
 import type { Dependencies } from '../'
 // import { DataSourcePool, create, destroy } from '../'
 // import {
 //   RouteTitle,
 //   RouteView,
 // } from './components'
-import type { Plugin } from 'vue'
+import type { App, Plugin, InjectionKey } from 'vue'
 
 export * from './components'
 
@@ -24,6 +26,7 @@ export * from './components'
 declare const typeSymbol: unique symbol
 type Uri<T = unknown> = { [typeSymbol]: T }
 type TypeOf<T> = T extends Uri<infer UriType> ? UriType : never
+type InjectionHooks<T extends Uri[]> = { [K in keyof T]: T[K] extends Uri ? () => TypeOf<T[K]> : never }
 //
 
 /* nano-container */
@@ -38,8 +41,37 @@ const nano = (map = new Map<Uri, unknown>()) => {
   }
   return { singleton, uri }
 }
+type Container = ReturnType<typeof nano>
 /* */
-const { singleton, uri } = nano()
+
+const createInjections = <T extends Uri[]>(...tokens: T): InjectionHooks<T> => {
+  return tokens.map((token) => {
+    return () => {
+      type Service = TypeOf<typeof token>
+      type Getter = () => Service
+      const service = inject(token as unknown as InjectionKey<Getter>) as () => TypeOf<typeof token>
+      if(typeof service === 'undefined') {
+        throw new Error('Unable to find injection ${token}')
+      }
+      return service()
+    }
+  }) as InjectionHooks<T>
+}
+const createBuilder = (container: Container) => {
+  const { singleton, uri } = container
+  const build = (app: App) => {
+    const builder = {
+      service: <T>(uri: Uri<T>, getter: () => T) => {
+        app.provide(uri as unknown as InjectionKey<typeof getter>, singleton(uri, getter))
+        return builder
+      },
+    }
+    return builder
+  }
+  return { build, uri }
+}
+
+const { uri } = nano()
 
 const deps: Dependencies = {
   can: () => false,
@@ -53,15 +85,19 @@ const tokens = {
   i18n: uri<Dependencies['i18n']>('routing.i18n'),
   regexp: uri<Dependencies['regexp']>('routing.regexp'),
 }
-export const [ useCan, useI18n, useRegExp, useEnv] = [
-  singleton(tokens.can, () => deps.can),
-  singleton(tokens.i18n, () => deps.i18n),
-  singleton(tokens.regexp, () => deps.regexp),
-  singleton(tokens.env, () => deps.env),
-]
 const plugin: Plugin = {
   install: (app, options: Partial<typeof deps> = {}) => {
-    Object.assign(deps, options)
+    const services = {
+      ...deps,
+      ...options,
+    }
+    const { build } = createBuilder(nano())
+    build(app)
+      .service(tokens.can, () => services.can)
+      .service(tokens.regexp, () => services.regexp)
+      .service(tokens.env, () => services.env)
+      .service(tokens.i18n, () => services.i18n)
+
     // components.forEach(([name, item]) => {
     //   app.component(name, item as Component)
     // })
@@ -70,4 +106,10 @@ const plugin: Plugin = {
     // })
   },
 }
+export const [ useI18n, useCan, useRegExp, useEnv ] = createInjections(
+  tokens.i18n,
+  tokens.can,
+  tokens.regexp,
+  tokens.env,
+)
 export default plugin

--- a/packages/x/src/index.ts
+++ b/packages/x/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@kong/kongponents'
 import { createHighlighterCore } from 'shiki/core'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import { inject } from 'vue'
 
 import {
   XAction,
@@ -50,7 +51,7 @@ import {
   XErrorState,
 } from './components'
 import { vStyle, vIcon }  from './directives/'
-import type { Plugin } from 'vue'
+import type { App, Plugin, InjectionKey } from 'vue'
 
 export * from './components'
 
@@ -161,6 +162,7 @@ declare module 'vue' {
 declare const typeSymbol: unique symbol
 type Uri<T = unknown> = { [typeSymbol]: T }
 type TypeOf<T> = T extends Uri<infer UriType> ? UriType : never
+type InjectionHooks<T extends Uri[]> = { [K in keyof T]: T[K] extends Uri ? () => TypeOf<T[K]> : never }
 //
 
 /* nano-container */
@@ -175,7 +177,38 @@ const nano = (map = new Map<Uri, unknown>()) => {
   }
   return { singleton, uri }
 }
+type Container = ReturnType<typeof nano>
 /* */
+
+const createInjections = <T extends Uri[]>(...tokens: T): InjectionHooks<T> => {
+  return tokens.map((token) => {
+    return () => {
+      type Service = TypeOf<typeof token>
+      type Getter = () => Service
+      const service = inject(token as unknown as InjectionKey<Getter>) as () => TypeOf<typeof token>
+      if(typeof service === 'undefined') {
+        throw new Error('Unable to find injection ${token}')
+      }
+      return service()
+    }
+  }) as InjectionHooks<T>
+}
+const createBuilder = (container: Container) => {
+  const { singleton, uri } = container
+  const build = (app: App) => {
+    const builder = {
+      service: <T>(uri: Uri<T>, getter: () => T) => {
+        app.provide(uri as unknown as InjectionKey<typeof getter>, singleton(uri, getter))
+        return builder
+      },
+    }
+    return builder
+  }
+  return { build, uri }
+}
+
+const { uri } = nano()
+
 const deps = {
   i18n: {
     t: (str: string, _values?: Record<string, string>, _options?: Record<string, unknown>) => str,
@@ -199,23 +232,27 @@ const deps = {
     })
   },
 }
-const { singleton, uri } = nano()
 const tokens = {
   i18n: uri<typeof deps.i18n>('x.i18n'),
   protocolHandler: uri<typeof deps.protocolHandler>('x.action.protocolhandler'),
   syntaxHighlighter: uri<typeof deps.syntaxHighlighter>('x.code-block.syntaxhighlighter'),
 }
-
-export const useI18n = singleton(tokens.i18n, () => deps.i18n)
-export const useProtocolHandler = singleton(tokens.protocolHandler, () => deps.protocolHandler)
-export const useSyntaxHighlighter = singleton(tokens.syntaxHighlighter, () => {
-  const syntax = deps.syntaxHighlighter()
-  return async () => syntax
-})
-
 const plugin: Plugin = {
   install: (app, options: Partial<typeof deps> = {}) => {
-    Object.assign(deps, options)
+    const services = {
+      ...deps,
+      ...options,
+    }
+
+    const { build } = createBuilder(nano())
+    build(app)
+      .service(tokens.syntaxHighlighter, () => {
+        const syntax = deps.syntaxHighlighter()
+        return async () => syntax
+      })
+      .service(tokens.protocolHandler, () => services.protocolHandler)
+      .service(tokens.i18n, () => services.i18n)
+
     components.forEach(([name, item]) => {
       app.component(name, item)
     })
@@ -224,4 +261,9 @@ const plugin: Plugin = {
     })
   },
 }
+export const [ useI18n, useSyntaxHighlighter, useProtocolHandler ] = createInjections(
+  tokens.i18n,
+  tokens.syntaxHighlighter,
+  tokens.protocolHandler,
+)
 export default plugin


### PR DESCRIPTION
Our plugins have lazy-loaded singleton services i.e.

1. Nothing gets executed if they are never "used"
2. Once "used" we reuse the same instance of the service

Previously we instantiated these services in the global scope, therefore if you want to use these plugins several times in the same page (using the same import) but in different applications, then they would share services across applications.

Whilst this is an interesting and potentially useful characteristic, it's not what we want for the moment (we might want this as an _additional_/configurable characteristic)

This PR moves the scoped to be per app instead of having a global scope.

Things to keep in mind:

- I'm still using copy/pasta on purpose, so a lot of the changes here are identical
- I'm temporarily using a little code "borrowed" from `@kumahq/container` (createInjections)
- I've wanted to have the option of a fluent builder (instead of just an almost-YAML one) for a while, this is the beginning of it.
- Side-note: This is getting closer and closer to being able to use this for our main container/builder and thus removing the brandijs dependency.
