### PR TITLE
chore(x-tabs): sync minimal tabs with KTabs

### DIFF
--- a/packages/x/src/components/x-tabs/XTabs.vue
+++ b/packages/x/src/components/x-tabs/XTabs.vue
@@ -159,6 +159,7 @@ const slots = defineSlots()
 
   &.small {
     ul {
+      align-items: center;
       gap: var(--x-space-70);
       margin-bottom: var(--x-space-50);
     }


### PR DESCRIPTION
When upgrading kongponents here https://github.com/kumahq/kuma-gui/pull/5039 I noticed a slight tweak to the "minimal" styling of KTabs here https://github.com/Kong/kongponents/pull/3244/changes#diff-01f83cc2092a263bfd47c1d0a4ba5e96dea98264d85282662a63f4fa18c44ded

This PR syncs this over to our XTabs

Note: We don't use minimal styling at all currently