### PR TITLE
fix(data-planes): fetch layout when mesh-service non-exclusive (#5066)

### DIFF
--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -20,11 +20,11 @@
       v-slot="{ data: traffic, error, refresh }"
     >
       <DataSource
-        :src="uri(sources, '/meshes/:mesh/dataplanes/:name/layout', {
+        :src="props.mesh.meshServices.mode === 'Exclusive' ? uri(sources, '/meshes/:mesh/dataplanes/:name/layout', {
           mesh: route.params.mesh,
           name: route.params.proxy,
-        })"
-        v-slot="{ data: sourceDataplaneLayout }"
+        }) : ''"
+        v-slot="{ data: sourceDataplaneLayout }: DataSourceResponse<DataplaneNetworkingLayout>"
       >
         <AppView
           :notifications="true"
@@ -412,6 +412,7 @@
                             </XLayout>
                           </dd>
                         </div>
+
                         <div
                           v-if="typeof sourceDataplaneLayout !== 'undefined' && sourceDataplaneLayout?.spiffeId?.length > 0"
                         >
@@ -882,11 +883,12 @@ import ConnectionCard from '@/app/connections/components/connection-traffic/Conn
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'
 import { sources as connectionSources } from '@/app/connections/sources'
-import type { DataplaneOverview, DataplaneInbound } from '@/app/data-planes/data'
+import type { DataplaneOverview, DataplaneInbound, DataplaneNetworkingLayout } from '@/app/data-planes/data'
 import { sources } from '@/app/data-planes/sources'
 import { Kri } from '@/app/kuma'
 import type { Mesh } from '@/app/meshes/data'
 import { useRoute } from '@/app/vue'
+import type { DataSourceResponse } from '@kumahq/data'
 
 const _route = useRoute()
 

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
@@ -43,8 +43,28 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   }))
   const zone = fake.word.noun()
 
+  const meshServiceMode = env('KUMA_MESHSERVICE_MODE', 'Everywhere')
+
+  if(meshServiceMode !== 'Exclusive') {
+    return {
+      headers: {
+        'Status-Code': '400',
+      },
+      body: {
+        'type': '/std-errors',
+        'status': 400,
+        'title': 'Bad Request',
+        'detail': 'bad request: can\'t use _layout endpoint without meshService enabled',
+        'details': 'bad request: can\'t use _layout endpoint without meshService enabled',
+      },
+    }
+  }
+
   return {
-    headers: {},
+    headers: {
+      'Status-Code': '200',
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
     body: {
       kri: fake.kuma.kri({
         resourceName: 'Dataplane',


### PR DESCRIPTION
Backport for 2.14 (https://github.com/kumahq/kuma-gui/pull/5066)

> If `mesh.meshServices.mode` is not `Exclusive`, fetching the `_layout` endpoint causes an error. I've left the data-source in the same place, even though it means that we have to use a ternary for the `:src` and have to add the types. This means that the data-source can stay in the same place when we need to add a `DataLoader` somewhere deeper.
>
> Closes https://github.com/kumahq/kuma-gui/issues/5035
