### PR TITLE
fix(resources): fetch legacy resources by kri (#5105)

### DIFF
--- a/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
@@ -13,7 +13,7 @@
   >
     <DataCollection
       :predicate="(resourceType) => typeof resourceType !== 'undefined' && resourceType.path === route.params.resourcePath"
-      :items="props.resourceTypes?.resources ?? []"
+      :items="(props.resourceTypes?.resources ?? []).filter((item) => item.shortName.length > 0)"
     >
       <template #empty>
         <XCard>

--- a/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
@@ -69,88 +69,81 @@
                   :errors="[resourcesError, globalInsightError, meshInsightError]"
                   v-slot="{ data: [resources, globalInsight, meshInsight] }"
                 >
-                  <template
-                    v-for="hasLegacyPolicies of [resources.resources.some(resource => !resource.policy?.isTargetRef && (meshInsight.policies[resource.name]?.total ?? 0) > 0)]"
-                    :key="typeof hasLegacyPolicies"
+                  <XLayout
+                    v-for="filtered in [resources.resources.filter((item) =>
+                      (route.params.category === 'all' || item.categories.includes(route.params.category)) && item.shortName.length > 0,
+                    )]"
+                    :key="typeof filtered"
+                    variant="y-stack"
                   >
-                    <XLayout
-                      v-for="filtered in [resources.resources.filter((item) =>
-                        (route.params.category === 'all' || item.categories.includes(route.params.category)) &&
-                        (!item.policy || item.policy?.isTargetRef || hasLegacyPolicies) &&
-                        (item.name !== 'ExternalService' || meshInsight.services.external > 0)),
-                      ]"
-                      :key="typeof filtered"
-                      variant="y-stack"
+                    <template
+                      v-for="([key, group], i) in Object.entries(Object.groupBy(filtered, (resource) => resource.group)).toSorted((a, b) => a[0] > b[0] ? -1 : 1)"
+                      :key="key"
                     >
-                      <template
-                        v-for="([key, group], i) in Object.entries(Object.groupBy(filtered, (resource) => resource.group)).toSorted((a, b) => a[0] > b[0] ? -1 : 1)"
-                        :key="key"
-                      >
-                        <ul v-if="group?.length">
-                          <li>
-                            <XLayout
-                              variant="y-stack"
+                      <ul v-if="group?.length">
+                        <li>
+                          <XLayout
+                            variant="y-stack"
+                          >
+                            <header>
+                              <h3>{{ t(`resources.routes.items.types.${key}.title`) }}</h3>
+                            </header>
+                            <DataCollection
+                              :items="group"
                             >
-                              <header>
-                                <h3>{{ t(`resources.routes.items.types.${key}.title`) }}</h3>
-                              </header>
-                              <DataCollection
-                                :items="group"
-                              >
-                                <template #default="{ items }">
-                                  <ul>
-                                    <li
-                                      v-for="(item, j) in items"
-                                      :key="item.name"
-                                      :class="{
-                                        'active': item.path === route.params.resourcePath,
+                              <template #default="{ items }">
+                                <ul>
+                                  <li
+                                    v-for="(item, j) in items"
+                                    :key="item.name"
+                                    :class="{
+                                      'active': item.path === route.params.resourcePath,
+                                    }"
+                                  >
+                                    <XAction
+                                      :to="{
+                                        name: 'resource-list-view',
+                                        params: {
+                                          mesh: route.params.mesh,
+                                          resourcePath: item.path,
+                                        },
+                                        query: {
+                                          category: route.params.category,
+                                        },
+                                      }"
+                                      :data-testid="`resource-type-link-${item.name}`"
+                                      @vue:mounted="(vNode) => {
+                                        if((route.params.resourcePath.length === 0 || !resources.resources.find((resource) => resource.path === route.params.resourcePath)) && i === 0 && j === 0 && vNode.props?.to) {
+                                          $nextTick(() => {
+                                            route.replace(vNode.props!.to)
+                                          })
+                                        }
                                       }"
                                     >
-                                      <XAction
-                                        :to="{
-                                          name: 'resource-list-view',
-                                          params: {
-                                            mesh: route.params.mesh,
-                                            resourcePath: item.path,
-                                          },
-                                          query: {
-                                            category: route.params.category,
-                                          },
-                                        }"
-                                        :data-testid="`resource-type-link-${item.name}`"
-                                        @vue:mounted="(vNode) => {
-                                          if((route.params.resourcePath.length === 0 || !resources.resources.find((resource) => resource.path === route.params.resourcePath)) && i === 0 && j === 0 && vNode.props?.to) {
-                                            $nextTick(() => {
-                                              route.replace(vNode.props!.to)
-                                            })
-                                          }
-                                        }"
+                                      <XLayout
+                                        variant="x-stack"
+                                        justify="between"
                                       >
-                                        <XLayout
-                                          variant="x-stack"
-                                          justify="between"
-                                        >
-                                          <span>
-                                            {{ item.name }}
-                                          </span>
-                                          <span v-if="item.group === 'global'">
-                                            {{ globalInsight.resources[item.name]?.total ?? 0 }}
-                                          </span>
-                                          <span v-else>
-                                            {{ meshInsight.resources[item.name]?.total ?? 0 }}
-                                          </span>
-                                        </XLayout>
-                                      </XAction>
-                                    </li>
-                                  </ul>
-                                </template>
-                              </DataCollection>
-                            </XLayout>
-                          </li>
-                        </ul>
-                      </template>
-                    </XLayout>
-                  </template>
+                                        <span>
+                                          {{ item.name }}
+                                        </span>
+                                        <span v-if="item.group === 'global'">
+                                          {{ globalInsight.resources[item.name]?.total ?? 0 }}
+                                        </span>
+                                        <span v-else>
+                                          {{ meshInsight.resources[item.name]?.total ?? 0 }}
+                                        </span>
+                                      </XLayout>
+                                    </XAction>
+                                  </li>
+                                </ul>
+                              </template>
+                            </DataCollection>
+                          </XLayout>
+                        </li>
+                      </ul>
+                    </template>
+                  </XLayout>
                 </DataLoader>
               </XCard>
               <div v-if="route.params.resourcePath.length > 0">


### PR DESCRIPTION
Backport of #5105 for 2.14

> We currently try to fetch all resources by their KRI including resources that do not support KRIs, i.e. policies. This fixes the issue by conditionally fetching the "old-style" endpoints.
>
> Closes https://github.com/kumahq/kuma-gui/issues/5086
