### PR TITLE
fix: remove double line headers (statuses)

### DIFF
--- a/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/workloads/views/WorkloadDetailTabsView.vue
@@ -52,11 +52,6 @@
                   :title="workload.name"
                 />
               </h1>
-              <XBadge
-                :appearance="t(`common.status.appearance.${workload.status.state}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${workload.status.state}`) }}
-              </XBadge>
             </XLayout>
           </DataLoader>
         </template>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -59,11 +59,6 @@
                   :title="t('zone-ingresses.routes.item.title', { name: zoneIngress.name })"
                 />
               </h1>
-              <XBadge
-                :appearance="t(`common.status.appearance.${zoneIngress.state}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${zoneIngress.state}`) }}
-              </XBadge>
             </XLayout>
           </DataLoader>
         </template>

--- a/packages/x/src/components/x-progress/XProgress.vue
+++ b/packages/x/src/components/x-progress/XProgress.vue
@@ -42,9 +42,6 @@
       width="10"
       height="2"
     />
-    <KSkeletonBox
-      width="5"
-    />
   </XLayout>
 </template>
 <script lang="ts" setup>


### PR DESCRIPTION
A little while back we removed the majority of the places where we'd show a status underneath the title on detail pages.

I noticed a couple that I missed, plus I figured I'd remove the double line loader for the `variant='header'`, which as of this PR now only has a single line.