### PR TITLE
fix(services): add label links to service detail pages (#5116)

### DIFF
--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       environment: String,
     }"
-    v-slot="{ route, can, t, uri, me }"
+    v-slot="{ route, can, t, uri, me, r }"
   >
     <AppView>
       <XLayout variant="y-stack">
@@ -90,33 +90,31 @@
                 </dd>
               </div>
 
-              <template
-                v-for="labels in [Object.entries(service.labels)]"
-                :key="typeof labels"
-              >
-                <div v-if="labels.length > 0">
-                  <dt>{{ t('services.routes.item.labels') }}</dt>
-                  <dd>
-                    <XLayout
-                      variant="separated"
-                      truncate
+              <div v-if="Object.keys(service.labels).length > 0">
+                <dt>Labels</dt>
+                <dd>
+                  <XLayout
+                    variant="separated"
+                  >
+                    <XAction
+                      v-for="(value, key) in service.labels"
+                      :key="key"
+                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                        mesh: service.mesh,
+                        zone: service.zone,
+                        namespace: service.namespace,
+                        name: value,
+                      }, { defaultMessage: '' })"
                     >
-                      <template
-                        v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                        :key="typeof kumaRe"
+                      <XBadge
+                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                       >
-                        <XBadge
-                          v-for="[key, value] in labels"
-                          :key="key"
-                          :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                        >
-                          {{ key }}:{{ value }}
-                        </XBadge>
-                      </template>
-                    </XLayout>
-                  </dd>
-                </div>
-              </template>
+                        {{ key }}:<strong>{{ value }}</strong>
+                      </XBadge>
+                    </XAction>
+                  </XLayout>
+                </dd>
+              </div>
             </XDl>
           </DataLoader>
         </XCard>

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailView.vue
@@ -9,7 +9,7 @@
       codeRegExp: false,
       environment: String,
     }"
-    v-slot="{ route, t, uri, me }"
+    v-slot="{ route, t, uri, me, r }"
   >
     <AppView>
       <XLayout variant="y-stack">
@@ -77,34 +77,32 @@
                   </template>
                 </dd>
               </div>
-        
-              <template
-                v-for="labels in [Object.entries(service.labels)]"
-                :key="typeof labels"
-              >
-                <div v-if="labels.length > 0">
-                  <dt>{{ t('services.routes.item.labels') }}</dt>
-                  <dd>
-                    <XLayout
-                      variant="separated"
-                      truncate
+
+              <div v-if="Object.keys(service.labels).length > 0">
+                <dt>Labels</dt>
+                <dd>
+                  <XLayout
+                    variant="separated"
+                  >
+                    <XAction
+                      v-for="(value, key) in service.labels"
+                      :key="key"
+                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                        mesh: service.mesh,
+                        zone: '',
+                        namespace: service.namespace,
+                        name: value,
+                      }, { defaultMessage: '' })"
                     >
-                      <template
-                        v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                        :key="typeof kumaRe"
+                      <XBadge
+                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                       >
-                        <XBadge
-                          v-for="[key, value] in labels"
-                          :key="key"
-                          :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                        >
-                          {{ key }}:{{ value }}
-                        </XBadge>
-                      </template>
-                    </XLayout>
-                  </dd>
-                </div>
-              </template>
+                        {{ key }}:<strong>{{ value }}</strong>
+                      </XBadge>
+                    </XAction>
+                  </XLayout>
+                </dd>
+              </div>
             </XDl>
           </DataLoader>
         </XCard>

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -12,7 +12,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ can, route, t, uri, me }"
+    v-slot="{ can, route, t, uri, me, r }"
   >
     <AppView>
       <XLayout variant="y-stack">
@@ -125,33 +125,31 @@
                   </template>
                 </dd>
               </div>
-              <template
-                v-for="labels in [Object.entries(service.labels)]"
-                :key="typeof labels"
-              >
-                <div v-if="labels.length > 0">
-                  <dt>{{ t('services.routes.item.labels') }}</dt>
-                  <dd>
-                    <XLayout
-                      variant="separated"
-                      truncate
+              <div v-if="Object.keys(service.labels).length > 0">
+                <dt>Labels</dt>
+                <dd>
+                  <XLayout
+                    variant="separated"
+                  >
+                    <XAction
+                      v-for="(value, key) in service.labels"
+                      :key="key"
+                      :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                        mesh: service.mesh,
+                        zone: service.zone,
+                        namespace: service.namespace,
+                        name: value,
+                      }, { defaultMessage: '' })"
                     >
-                      <template
-                        v-for="kumaRe in [/^(.+\.)?kuma\.io\//]"
-                        :key="typeof kumaRe"
+                      <XBadge
+                        :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
                       >
-                        <XBadge
-                          v-for="[key, value] in labels"
-                          :key="key"
-                          :appearance="kumaRe.test(key) ? 'info' : 'decorative'"
-                        >
-                          {{ key }}:{{ value }}
-                        </XBadge>
-                      </template>
-                    </XLayout>
-                  </dd>
-                </div>
-              </template>
+                        {{ key }}:<strong>{{ value }}</strong>
+                      </XBadge>
+                    </XAction>
+                  </XLayout>
+                </dd>
+              </div>
             </XDl>
           </DataLoader>
         </XCard>


### PR DESCRIPTION
Adds linked labels to the Mesh*Service detail pages.