### PR TITLE
chore(@kumahq/x): add push and href injectable functions

### DIFF
--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -15,7 +15,7 @@ import KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
 import { RestClient } from '@/app/kuma/services/kuma-api/RestClient'
 import type { ServiceDefinition } from '@kumahq/container'
 import type { DataSourcePool } from '@kumahq/data'
-import type { Router } from 'vue-router'
+import type { Router, RouteLocationAsRelative } from 'vue-router'
 
 export * from './utils'
 export { Kri } from './kri'
@@ -27,12 +27,6 @@ declare module 'vue' {
     KumaPort: typeof KumaPort
     KumaTargetRef: typeof KumaTargetRef
   }
-}
-export const TOKENS = {
-  httpClient: token<RestClient>('httpClient'),
-  api: token<KumaApi>('KumaApi'),
-  htmlVars: token('kuma.html.vars'),
-  dataSource: token<<T>(src: string) => Promise<T>>('app.dataSource'),
 }
 function getConfig() {
   const pathConfigNode = document.querySelector('#kuma-config')
@@ -152,18 +146,48 @@ const protocolHandler = (can: Can, router: Router) => {
     }
     return href
   }
+}
 
+const href = (router: Router) => (to: RouteLocationAsRelative) => {
+  try {
+    return router.resolve({
+      params: router.currentRoute.value.params,
+      ...to,
+    }).href
+  } catch(e) {
+    if (e instanceof Error) {
+      e.message = `${e.toString()}: ${JSON.stringify(to)}`
+    }
+    console.error(e)
+  }
+  return ''
+}
+const push = (router: Router) => (href: string) => {
+  const base = router.options.history.base
+  const h = href.startsWith(base) ? href.substring(base.length) : href
+  return router.push(h.length > 0 ? h : '/')
+}
+export const TOKENS = {
+  httpClient: token<RestClient>('httpClient'),
+  api: token<KumaApi>('KumaApi'),
+  htmlVars: token('kuma.html.vars'),
+  dataSource: token<<T>(src: string) => Promise<T>>('app.dataSource'),
+  href: token<ReturnType<typeof href>>('kuma.router.href'),
+  routerPush: token<ReturnType<typeof push>>('kuma.router.push'),
+  routerElement: token<() => HTMLElement | null>('kuma.router.element'),
 }
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('kuma.plugins'), {
-      service: (i18n, can, router) => {
+      service: (i18n, can, router, href, push, routerElement) => {
         return [
           [Kongponents],
           [X, {
             i18n,
             protocolHandler: protocolHandler(can, router),
-            routerElement: () => document.querySelector('.kuma-application'),
+            href,
+            push,
+            routerElement,
           }],
         ]
       },
@@ -171,6 +195,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.i18n,
         app.can,
         app.router,
+        app.href,
+        app.routerPush,
+        app.routerElement,
       ],
       labels: [
         app.plugins,
@@ -178,6 +205,21 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [app.storagePrefix, {
       service: () => 'kumahq.kuma-gui',
+    }],
+    [app.routerElement, {
+      service: () => () => document.querySelector('.kuma-application'),
+    }],
+    [app.href, {
+      service: href,
+      arguments: [
+        app.router,
+      ],
+    }],
+    [app.routerPush, {
+      service: push,
+      arguments: [
+        app.router,
+      ],
     }],
     [app.htmlVars, {
       service: getConfig,
@@ -264,9 +306,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   ]
 }
 export const [
-  useKumaApi,
   useDataSource,
 ] = createInjections(
-  TOKENS.api,
   TOKENS.dataSource,
 )

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -15,7 +15,7 @@ import KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
 import { RestClient } from '@/app/kuma/services/kuma-api/RestClient'
 import type { ServiceDefinition } from '@kumahq/container'
 import type { DataSourcePool } from '@kumahq/data'
-import type { Router } from 'vue-router'
+import type { Router, RouteLocationAsRelative } from 'vue-router'
 
 export * from './utils'
 export { Kri } from './kri'
@@ -27,13 +27,6 @@ declare module 'vue' {
     KumaPort: typeof KumaPort
     KumaTargetRef: typeof KumaTargetRef
   }
-}
-export const TOKENS = {
-  httpClient: token<RestClient>('httpClient'),
-  api: token<KumaApi>('KumaApi'),
-  htmlVars: token('kuma.html.vars'),
-  dataSource: token<<T>(src: string) => Promise<T>>('app.dataSource'),
-  syntaxHighlighter: token('kuma.syntaxHighlighter'),
 }
 function getConfig() {
   const pathConfigNode = document.querySelector('#kuma-config')
@@ -199,19 +192,50 @@ const protocolHandler = (can: Can, router: Router) => {
     }
     return href
   }
+}
 
+const href = (router: Router) => (to: RouteLocationAsRelative) => {
+  try {
+    return router.resolve({
+      params: router.currentRoute.value.params,
+      ...to,
+    }).href
+  } catch(e) {
+    if (e instanceof Error) {
+      e.message = `${e.toString()}: ${JSON.stringify(to)}`
+    }
+    console.error(e)
+  }
+  return ''
+}
+const push = (router: Router) => (href: string) => {
+  const base = router.options.history.base
+  const h = href.startsWith(base) ? href.substring(base.length) : href
+  return router.push(h.length > 0 ? h : '/')
+}
+export const TOKENS = {
+  httpClient: token<RestClient>('httpClient'),
+  api: token<KumaApi>('KumaApi'),
+  htmlVars: token('kuma.html.vars'),
+  dataSource: token<<T>(src: string) => Promise<T>>('app.dataSource'),
+  syntaxHighlighter: token('kuma.syntaxHighlighter'),
+  href: token<ReturnType<typeof href>>('kuma.router.href'),
+  routerPush: token<ReturnType<typeof push>>('kuma.router.push'),
+  routerElement: token<() => HTMLElement | null>('kuma.router.element'),
 }
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [token('kuma.plugins'), {
-      service: (i18n, can, router, syntaxHighlighter) => {
+      service: (i18n, can, router, syntaxHighlighter, href, push, routerElement) => {
         return [
           [Kongponents],
           [X, {
             i18n,
             protocolHandler: protocolHandler(can, router),
-            routerElement: () => document.querySelector('.kuma-application'),
             syntaxHighlighter,
+            href,
+            push,
+            routerElement,
           }],
         ]
       },
@@ -220,6 +244,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.can,
         app.router,
         app.syntaxHighlighter,
+        app.href,
+        app.routerPush,
+        app.routerElement,
       ],
       labels: [
         app.plugins,
@@ -227,6 +254,21 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [app.storagePrefix, {
       service: () => 'kumahq.kuma-gui',
+    }],
+    [app.routerElement, {
+      service: () => () => document.querySelector('.kuma-application'),
+    }],
+    [app.href, {
+      service: href,
+      arguments: [
+        app.router,
+      ],
+    }],
+    [app.routerPush, {
+      service: push,
+      arguments: [
+        app.router,
+      ],
     }],
     [app.htmlVars, {
       service: getConfig,
@@ -317,9 +359,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   ]
 }
 export const [
-  useKumaApi,
   useDataSource,
 ] = createInjections(
-  TOKENS.api,
   TOKENS.dataSource,
 )

--- a/packages/x/src/components/x-action/XAction.vue
+++ b/packages/x/src/components/x-action/XAction.vue
@@ -150,16 +150,15 @@
 <script lang="ts" setup>
 import { KDropdownItem, KButton } from '@kong/kongponents'
 import { computed, inject, provide, useAttrs } from 'vue'
-import { useRouter } from 'vue-router'
 
 
-import { useProtocolHandler } from '../../'
+import { useProtocolHandler, useHref } from '../../'
 import type { ButtonAppearance } from '@kong/kongponents'
 import type { RouteLocationAsRelative } from 'vue-router'
 
 type BooleanLocationQueryValue = string | number | undefined | boolean
 type BooleanLocationQueryRaw = Record<string | number, BooleanLocationQueryValue | BooleanLocationQueryValue[]>
-type RouteLocationRawWithBooleanQuery = Omit<RouteLocationAsRelative, 'query'> & {
+type RouteLocationAsRelativeWithBooleanQuery = Omit<RouteLocationAsRelative, 'query'> & {
   query?: BooleanLocationQueryRaw
 }
 
@@ -174,7 +173,7 @@ const props = withDefaults(defineProps<{
   appearance?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'anchor'
   size?: 'small' | 'medium' | 'large'
   href?: string
-  to?: RouteLocationRawWithBooleanQuery
+  to?: RouteLocationAsRelativeWithBooleanQuery
   for?: string
 }>(), {
   href: '',
@@ -186,14 +185,14 @@ const props = withDefaults(defineProps<{
 })
 
 const attrs = useAttrs()
+const protocolHandler = useProtocolHandler()
+const hrf = useHref()
 
 const group = inject<{
   expanded: boolean
 } | undefined>('x-action-group', undefined)
 
-const router = useRouter()
 
-const protocolHandler = useProtocolHandler()
 
 const query = computed(() => {
   return Object.entries(props.to.query ?? {}).reduce<Record<string, string | number | null | undefined>>((prev, [key, value]) => {
@@ -210,28 +209,16 @@ const query = computed(() => {
     return prev
   }, {})
 })
-const resolve = (to: RouteLocationRawWithBooleanQuery) => {
-  try {
-    return router.resolve({
-      params: router.currentRoute.value.params,
-      ...to,
-      query: query.value,
-    }).href
-  } catch(e) {
-    if (e instanceof Error) {
-      e.message = `${e.toString()}: ${JSON.stringify(props.to)}`
-    }
-    console.error(e)
-  }
-  return ''
-}
 
 const href = computed(() => {
   switch(true) {
     case props.href.includes('://'):
       return protocolHandler(props.href)
     case Object.keys(props.to).length > 0:
-      return resolve(props.to)
+      return hrf({
+        ...props.to,
+        query: query.value,
+      })
     default:
       return props.href
   }

--- a/packages/x/src/components/x-router/XRouter.vue
+++ b/packages/x/src/components/x-router/XRouter.vue
@@ -3,8 +3,14 @@
 </template>
 <script lang="ts">
 
+import { usePush , useRouterElement } from '../../'
 import SharedPool from '../../utilities/SharedPool'
-import type { Router } from 'vue-router'
+
+type Push = ReturnType<typeof usePush>
+type Key = {
+  push: Push
+  element: HTMLElement
+}
 
 const findAnchor = (target: HTMLElement) => {
   // we look for anchors, or any other element that has [data-actionable]
@@ -22,12 +28,7 @@ const findAnchor = (target: HTMLElement) => {
   return null
 }
 
-const push = (href: string, router: Router) => {
-  const base = router.options.history.base
-  const h = href.startsWith(base) ? href.substring(base.length) : href
-  router.push(h.length > 0 ? h : '/')
-}
-const createListener = (router: Router) => {
+const createListener = (push: Push) => {
   return (e: PointerEvent) => {
     // event guards: special click whilst key pressed plus defaultPrevented
     if(
@@ -59,21 +60,17 @@ const createListener = (router: Router) => {
 
       if(href.length > 0) {
         e.preventDefault()
-        return push(href, router)
+        return push(href)
       }
     }
   }
 }
 
-type Key = {
-  router: Router
-  element: HTMLElement
-}
 const keys = new WeakMap<HTMLElement, Key>()
 const pool = new SharedPool<Key, (e: PointerEvent) => void>((state, key, item) => {
   switch (state) {
     case 'creating': {
-      const listener = createListener(key.router)
+      const listener = createListener(key.push)
       key.element.addEventListener('click', listener)
       return listener
     }
@@ -92,19 +89,16 @@ const pool = new SharedPool<Key, (e: PointerEvent) => void>((state, key, item) =
 <script lang="ts" setup>
 // eslint-disable-next-line import/order
 import { onMounted, onBeforeUnmount } from 'vue'
-// eslint-disable-next-line import/order
-import { useRouterElement } from '../../index'
-// eslint-disable-next-line import/order
-import { useRouter } from 'vue-router'
+ 
 
-const router = useRouter()
+const push = usePush()
 
 // keep a track of unique element => router/element pairs
 const key = () => {
   const element = useRouterElement()
   if(element !== null) {
     const key = keys.get(element) ?? {
-      router,
+      push,
       element,
     }
     keys.set(element, key)

--- a/packages/x/src/index.ts
+++ b/packages/x/src/index.ts
@@ -219,6 +219,10 @@ const deps = {
   },
   routerElement: () => document.body,
   protocolHandler: (href: string) => href,
+  href: (_to: unknown) => {
+    return ''
+  },
+  push: (_href: string) => {},
   syntaxHighlighter: async () => {
     return createHighlighterCore({
       langs: [
@@ -238,8 +242,10 @@ const deps = {
 }
 const tokens = {
   i18n: uri<typeof deps.i18n>('x.i18n'),
-  protocolHandler: uri<typeof deps.protocolHandler>('x.action.protocolhandler'),
   syntaxHighlighter: uri<typeof deps.syntaxHighlighter>('x.code-block.syntaxhighlighter'),
+  protocolHandler: uri<typeof deps.protocolHandler>('x.action.protocolhandler'),
+  href: uri<typeof deps.href>('x.action.href'),
+  push: uri<typeof deps.href>('x.router.push'),
   routerElement: uri<HTMLElement>('x.router.routerElement'),
 }
 const plugin: Plugin = {
@@ -256,6 +262,8 @@ const plugin: Plugin = {
         return async () => syntax
       })
       .service(tokens.protocolHandler, () => services.protocolHandler)
+      .service(tokens.href, () => services.href)
+      .service(tokens.push, () => services.push)
       .service(tokens.i18n, () => services.i18n)
       .service(tokens.routerElement, services.routerElement)
 
@@ -271,11 +279,15 @@ export const [
   useI18n,
   useSyntaxHighlighter,
   useProtocolHandler,
+  useHref,
+  usePush,
   useRouterElement,
 ] = createInjections(
   tokens.i18n,
   tokens.syntaxHighlighter,
   tokens.protocolHandler,
+  tokens.href,
+  tokens.push,
   tokens.routerElement,
 )
 export default plugin

--- a/packages/x/src/index.ts
+++ b/packages/x/src/index.ts
@@ -245,11 +245,17 @@ const deps = {
   routerElement: () => document.body,
   protocolHandler: (href: string) => href,
   syntaxHighlighter,
+  href: (_to: unknown) => {
+    return ''
+  },
+  push: (_href: string) => {},
 }
 const tokens = {
   i18n: uri<typeof deps.i18n>('x.i18n'),
-  protocolHandler: uri<typeof deps.protocolHandler>('x.action.protocolhandler'),
   syntaxHighlighter: uri<typeof deps.syntaxHighlighter>('x.code-block.syntaxhighlighter'),
+  protocolHandler: uri<typeof deps.protocolHandler>('x.action.protocolhandler'),
+  href: uri<typeof deps.href>('x.action.href'),
+  push: uri<typeof deps.href>('x.router.push'),
   routerElement: uri<HTMLElement>('x.router.routerElement'),
 }
 const plugin: Plugin = {
@@ -263,6 +269,8 @@ const plugin: Plugin = {
     build(app)
       .service(tokens.syntaxHighlighter, () => services.syntaxHighlighter)
       .service(tokens.protocolHandler, () => services.protocolHandler)
+      .service(tokens.href, () => services.href)
+      .service(tokens.push, () => services.push)
       .service(tokens.i18n, () => services.i18n)
       .service(tokens.routerElement, services.routerElement)
 
@@ -278,11 +286,15 @@ export const [
   useI18n,
   useSyntaxHighlighter,
   useProtocolHandler,
+  useHref,
+  usePush,
   useRouterElement,
 ] = createInjections(
   tokens.i18n,
   tokens.syntaxHighlighter,
   tokens.protocolHandler,
+  tokens.href,
+  tokens.push,
   tokens.routerElement,
 )
 export default plugin


### PR DESCRIPTION
Adds `useHref` and `usePush` and allows you to inject the implementation of these per application.

- `useHref` returns a `href({to: ...})` function (pretty much `router.resolve`)
- `usePush` returns a `push` function (pretty much `router.push`)
