### PR TITLE
feat(resources): shorten URLs

### DIFF
--- a/packages/kuma-gui/features/application/Titles.feature
+++ b/packages/kuma-gui/features/application/Titles.feature
@@ -9,41 +9,41 @@ Feature: application / titles
     Then the page title contains "<Title>"
 
     Examples:
-      | URL                                                                                                                   | Title                     |
-      | /                                                                                                                     | Overview                  |
-      | /configuration                                                                                                        | Configuration             |
-      | /zones                                                                                                                | Zone control planes       |
-      | /zones/kri_z____zone-cp-name_/overview                                                                                | zone-cp-name              |
-      | /zones/kri_z____zone-cp-name_/ingresses                                                                               | Ingresses                 |
-      | /zones/kri_z____zone-cp-name_/ingresses/kri_zi__zone-cp-name__zone-ingress-name_/overview                             | zone-ingress-name         |
-      | /zones/kri_z____zone-cp-name_/egresses                                                                                | Egresses                  |
-      | /zones/kri_z____zone-cp-name_/egresses/kri_ze__zone-cp-name__zone-egress-name_/overview                               | zone-egress-name          |
-      | /meshes                                                                                                               | Meshes                    |
-      | /meshes/default/overview                                                                                              | Mesh overview             |
-      | /meshes/default/services/internal                                                                                     | Services                  |
-      | /meshes/default/services/internal/service-name/overview                                                               | service-name              |
-      | /meshes/default/services/external                                                                                     | ExternalServices          |
-      | /meshes/default/services/external/service-name/overview                                                               | service-name              |
-      | /meshes/default/gateways/builtin                                                                                      | Built-in gateways         |
-      | /meshes/default/gateways/builtin/gateway.namespace/overview                                                           | gateway                   |
-      | /meshes/default/gateways/delegated                                                                                    | Delegated gateways        |
-      | /meshes/default/gateways/delegated/gateway/overview                                                                   | gateway                   |
-      | /meshes/default/services/mesh-services                                                                                | MeshServices              |
-      | /meshes/default/services/mesh-services/kri_msvc____service-name_/overview                                             | service-name              |
-      | /meshes/default/services/mesh-multi-zone-services                                                                     | MeshMultiZoneServices     |
-      | /meshes/default/services/mesh-multi-zone-services/kri_mzsvc____service-name_/overview                                 | service-name              |
-      | /meshes/default/services/mesh-external-services                                                                       | MeshExternalServices      |
-      | /meshes/default/services/mesh-external-services/kri_extsvc____service-name_/overview                                  | service-name              |
-      | /meshes/default/data-planes                                                                                           | Data plane proxies        |
-      | /meshes/default/data-planes/kri_dp_default___data-plane-name_/overview                                                | data-plane-name           |
-      | /meshes/default/policies/circuit-breakers                                                                             | Policies                  |
-      | /meshes/default/policies/circuit-breakers/kri_~circuitbreaker_default___program-0_/overview                           | program-0                 |
-      | /meshes/default/resources/meshfaultinjections                                                                         | Resources                 |
-      | /meshes/default/resources/meshfaultinjections/kri_mfi_default_adviser_kuma-system_pension-0-959cb35ab-xtzqf_/overview | pension-0-959cb35ab-xtzqf |
-      | /meshes/default/workloads                                                                                             | Workloads                 |
-      | /meshes/default/workloads/kri_wl_default_z1_ns1_workload-1_/overview                                                  | workload-1                |
-      | /hostname-generators                                                                                                  | HostnameGenerators        |
-      | /hostname-generators/kri_hg____hg-name_/overview                                                                      | hg-name                   |
+      | URL                                                                                               | Title                     |
+      | /                                                                                                 | Overview                  |
+      | /configuration                                                                                    | Configuration             |
+      | /zones                                                                                            | Zone control planes       |
+      | /zones/kri_z____zone-cp-name_/overview                                                            | zone-cp-name              |
+      | /zones/kri_z____zone-cp-name_/ingresses                                                           | Ingresses                 |
+      | /zones/kri_z____zone-cp-name_/ingresses/kri_zi__zone-cp-name__zone-ingress-name_/overview         | zone-ingress-name         |
+      | /zones/kri_z____zone-cp-name_/egresses                                                            | Egresses                  |
+      | /zones/kri_z____zone-cp-name_/egresses/kri_ze__zone-cp-name__zone-egress-name_/overview           | zone-egress-name          |
+      | /meshes                                                                                           | Meshes                    |
+      | /meshes/default/overview                                                                          | Mesh overview             |
+      | /meshes/default/services/internal                                                                 | Services                  |
+      | /meshes/default/services/internal/service-name/overview                                           | service-name              |
+      | /meshes/default/services/external                                                                 | ExternalServices          |
+      | /meshes/default/services/external/service-name/overview                                           | service-name              |
+      | /meshes/default/gateways/builtin                                                                  | Built-in gateways         |
+      | /meshes/default/gateways/builtin/gateway.namespace/overview                                       | gateway                   |
+      | /meshes/default/gateways/delegated                                                                | Delegated gateways        |
+      | /meshes/default/gateways/delegated/gateway/overview                                               | gateway                   |
+      | /meshes/default/services/mesh-services                                                            | MeshServices              |
+      | /meshes/default/services/mesh-services/kri_msvc____service-name_/overview                         | service-name              |
+      | /meshes/default/services/mesh-multi-zone-services                                                 | MeshMultiZoneServices     |
+      | /meshes/default/services/mesh-multi-zone-services/kri_mzsvc____service-name_/overview             | service-name              |
+      | /meshes/default/services/mesh-external-services                                                   | MeshExternalServices      |
+      | /meshes/default/services/mesh-external-services/kri_extsvc____service-name_/overview              | service-name              |
+      | /meshes/default/data-planes                                                                       | Data plane proxies        |
+      | /meshes/default/data-planes/kri_dp_default___data-plane-name_/overview                            | data-plane-name           |
+      | /meshes/default/policies/circuit-breakers                                                         | Policies                  |
+      | /meshes/default/policies/circuit-breakers/kri_~circuitbreaker_default___program-0_/overview       | program-0                 |
+      | /meshes/default/resources/mfi                                                                     | Resources                 |
+      | /meshes/default/resources/kri_mfi_default_adviser_kuma-system_pension-0-959cb35ab-xtzqf_/overview | pension-0-959cb35ab-xtzqf |
+      | /meshes/default/workloads                                                                         | Workloads                 |
+      | /meshes/default/workloads/kri_wl_default_z1_ns1_workload-1_/overview                              | workload-1                |
+      | /hostname-generators                                                                              | HostnameGenerators        |
+      | /hostname-generators/kri_hg____hg-name_/overview                                                  | hg-name                   |
 
   Scenario Outline: Visiting the "<Title>" page in "zone" Mode
     Given the environment

--- a/packages/kuma-gui/features/mesh/resources/Index.feature
+++ b/packages/kuma-gui/features/mesh/resources/Index.feature
@@ -37,7 +37,7 @@ Feature: mesh / resources / index
       """
 
   Scenario: Listing has expected content
-    When I visit the "/meshes/default/resources/meshaccesslogs" URL
+    When I visit the "/meshes/default/resources/mal" URL
     Then the "$button-docs" element exists
     Then the "$items-header" element exists 4 times
     And the "$item" element exists 2 times
@@ -53,18 +53,19 @@ Feature: mesh / resources / index
       | zone-2      |
 
   Scenario: Clicking the item name opens the summary
-    When I visit the "/meshes/default/resources/meshaccesslogs" URL
+    When I visit the "/meshes/default/resources/mal" URL
     And I click the "$action" element
-    Then the URL contains "meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_"
+    Then the URL contains "mal/kri_mal_default_zone-1_kuma-system_resource-1_"
 
   Scenario: Clicking the view action navigates to the detail page
-    When I visit the "/meshes/default/resources/meshaccesslogs" URL
+    When I visit the "/meshes/default/resources/mal" URL
     And I click the "$action-group" element
     And I click the "$view" element
-    Then the URL contains "meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview"
+    Then the URL contains "kri_mal_default_zone-1_kuma-system_resource-1_/overview"
+    And the URL doesn't contain "mal/kri_mal_default_zone-1_kuma-system_resource-1_/overview"
 
   Scenario: Sending filters
-    When I visit the "/meshes/default/resources/meshaccesslogs" URL
+    When I visit the "/meshes/default/resources/mal" URL
     Then the "$input-search" element exists
     When I "type" "my-resource namespace:kuma-demo" into the "$input-search" element
     And I "type" "{enter}" into the "$input-search" element

--- a/packages/kuma-gui/features/mesh/resources/Item.feature
+++ b/packages/kuma-gui/features/mesh/resources/Item.feature
@@ -21,7 +21,7 @@ Feature: mesh / resources / item
           kuma.io/origin: zone
           foo: bar
       """
-    When I visit the "/meshes/default/resources/meshaccesslogs/<Kri>/overview" URL
+    When I visit the "/meshes/default/resources/<Kri>/overview" URL
     Then the "$about-section" element exists
     And the "$about-section" element <Contains> "kuma-system"
     And the "$about-section" element contains "zone-1"
@@ -36,19 +36,19 @@ Feature: mesh / resources / item
   Rule: Offering different view formats
 
     Scenario: Universal config is shown by default
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview" URL
+      When I visit the "/meshes/default/resources/kri_mal_default_zone-1_kuma-system_resource-1_/overview" URL
       Then the "$config-universal" element exists
 
     Scenario: Visiting with environment=universal shows the universal codeblock
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview?environment=universal" URL
+      When I visit the "/meshes/default/resources/kri_mal_default_zone-1_kuma-system_resource-1_/overview?environment=universal" URL
       Then the "$config-universal" element exists
 
     Scenario: Visiting with environment=k8s shows the k8s codeblock
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview?environment=k8s" URL
+      When I visit the "/meshes/default/resources/kri_mal_default_zone-1_kuma-system_resource-1_/overview?environment=k8s" URL
       Then the "$config-k8s" element exists
 
     Scenario: Switching to k8s environment shows the k8s codeblock
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_/overview" URL
+      When I visit the "/meshes/default/resources/kri_mal_default_zone-1_kuma-system_resource-1_/overview" URL
       Then the "$config-universal" element exists
       Then I click the "$select-environment" element
       Then I click the "[data-testid='select-item-k8s'] button" element

--- a/packages/kuma-gui/features/mesh/resources/Summary.feature
+++ b/packages/kuma-gui/features/mesh/resources/Summary.feature
@@ -27,7 +27,7 @@ Feature: mesh / resources / summary
       """
 
   Scenario: Clicking a row opens the summary
-    When I visit the "/meshes/default/resources/meshaccesslogs" URL
+    When I visit the "/meshes/default/resources/mal" URL
     And I click the "$action" element
     Then the "$summary" element exists
     And the "$summary" element contains "resource-1"
@@ -40,18 +40,18 @@ Feature: mesh / resources / summary
     Then the "$item" element exists but the "$summary" element doesn't exist
 
   Scenario: Opening a summary URL directly shows the summary
-    When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_" URL
+    When I visit the "/meshes/default/resources/mal/kri_mal_default_zone-1_kuma-system_resource-1_" URL
     Then the "$summary" element exists
     And the "$summary" element contains "resource-1"
 
   Rule: Offering different view formats
 
     Scenario: The universal format is shown by default
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_" URL
+      When I visit the "/meshes/default/resources/mal/kri_mal_default_zone-1_kuma-system_resource-1_" URL
       Then the "$summary [data-testid='codeblock-yaml-universal']" element exists
 
     Scenario: Switching to k8s format shows the k8s codeblock
-      When I visit the "/meshes/default/resources/meshaccesslogs/kri_mal_default_zone-1_kuma-system_resource-1_" URL
+      When I visit the "/meshes/default/resources/mal/kri_mal_default_zone-1_kuma-system_resource-1_" URL
       And I click the "$select-preference" element
       And I click the "[data-testid='select-item-k8s'] button" element
       Then the URL contains "environment=k8s"

--- a/packages/kuma-gui/src/app/resources/routes.ts
+++ b/packages/kuma-gui/src/app/resources/routes.ts
@@ -15,7 +15,7 @@ export const routes = () => {
     return [
       {
         name: 'resource-detail-view',
-        path: 'resources/:resourcePath/:kri/overview',
+        path: 'resources/:kri/overview',
         component: () => import('@/app/resources/views/ResourceDetailView.vue'),
       },
     ]
@@ -31,7 +31,7 @@ export const routes = () => {
           children: [
             {
               name: 'resource-list-view',
-              path: ':resourcePath',
+              path: ':shortName',
               component: () => import('@/app/resources/views/ResourceListView.vue'),
               children: [
                 ...summary(),

--- a/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
@@ -4,7 +4,6 @@
     :params="{
       mesh: '',
       kri: '',
-      resourcePath: '',
       environment: String,
       codeSearch: '',
       codeFilter: false,
@@ -34,7 +33,7 @@
               name: 'resource-list-view',
               params: {
                 mesh: route.params.mesh,
-                resourcePath: route.params.resourcePath,
+                shortName: Kri.fromString(route.params.kri).shortName,
               },
             },
             text: 'Resources',

--- a/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
@@ -5,14 +5,14 @@
       page: 1,
       size: Number,
       mesh: '',
-      resourcePath: '',
+      shortName: '',
       kri: '',
       s: '',
     }"
     v-slot="{ route, t, can, uri, me }"
   >
     <DataCollection
-      :predicate="(resourceType) => typeof resourceType !== 'undefined' && resourceType.path === route.params.resourcePath"
+      :predicate="(resourceType) => typeof resourceType !== 'undefined' && resourceType.shortName === route.params.shortName"
       :items="(props.resourceTypes?.resources ?? []).filter((item) => item.shortName.length > 0)"
     >
       <template #empty>
@@ -74,13 +74,13 @@
             </search>
             <DataLoader
               :src="type.group === 'global' ? uri(sources, '/resources/:path', {
-                path: route.params.resourcePath,
+                path: type.path,
               }, {
                 page: route.params.page,
                 size: route.params.size,
                 search: route.params.s,
               }) : uri(sources, '/resources/:path/for/:mesh', {
-                path: route.params.resourcePath,
+                path: type.path,
                 mesh: route.params.mesh,
               }, {
                 page: route.params.page,
@@ -192,7 +192,7 @@
                     name: 'resource-list-view',
                     params: {
                       mesh: route.params.mesh,
-                      policyPath: route.params.resourcePath,
+                      shortName: route.params.shortName,
                     },
                     query: {
                       page: route.params.page,

--- a/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
@@ -3,7 +3,7 @@
     name="resource-type-list-view"
     :params="{
       mesh: '',
-      resourcePath: '',
+      shortName: '',
       category: String,
     }"
     v-slot="{ uri, route, t }"
@@ -97,7 +97,7 @@
                                     v-for="(item, j) in items"
                                     :key="item.name"
                                     :class="{
-                                      'active': item.path === route.params.resourcePath,
+                                      'active': item.shortName === route.params.shortName,
                                     }"
                                   >
                                     <XAction
@@ -105,7 +105,7 @@
                                         name: 'resource-list-view',
                                         params: {
                                           mesh: route.params.mesh,
-                                          resourcePath: item.path,
+                                          shortName: item.shortName,
                                         },
                                         query: {
                                           category: route.params.category,
@@ -113,7 +113,7 @@
                                       }"
                                       :data-testid="`resource-type-link-${item.name}`"
                                       @vue:mounted="(vNode) => {
-                                        if((route.params.resourcePath.length === 0 || !resources.resources.find((resource) => resource.path === route.params.resourcePath)) && i === 0 && j === 0 && vNode.props?.to) {
+                                        if((route.params.shortName.length === 0 || !resources.resources.find((resource) => resource.shortName === route.params.shortName)) && i === 0 && j === 0 && vNode.props?.to) {
                                           $nextTick(() => {
                                             route.replace(vNode.props!.to)
                                           })
@@ -146,7 +146,7 @@
                   </XLayout>
                 </DataLoader>
               </XCard>
-              <div v-if="route.params.resourcePath.length > 0">
+              <div v-if="route.params.shortName.length > 0">
                 <RouterView v-slot="{ Component }">
                   <component
                     :is="Component"

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes.ts
@@ -4,6 +4,7 @@ import type { MeshHTTPRoute } from '@/types/index.d'
 export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) => {
   const mesh = req.params.mesh as string
 
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const { offset, total, next, pageTotal } = pager(
     env('KUMA_MESHHTTPROUTES_COUNT', `${fake.number.int({ min: 1, max: 1000 })}`),
     req,
@@ -23,24 +24,35 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${id}`
-        const zone = zoneQuery ?? fake.word.noun()
+        const [
+          _prefix,
+          shortName,
+          mesh,
+          zone,
+          nspace,
+          displayName,
+        ] = [
+          'kri', // prefix
+          'mhttpr', // shortName
+          String(req.params.mesh), // mesh
+          zoneQuery ?? fake.helpers.arrayElement(['', fake.word.noun()]), // zone
+          ...([k8s ? namespaceQuery ?? fake.helpers.arrayElement(['kuma-system', fake.word.noun()]) : '', `${nameQuery || fake.word.noun()}-${id}`]), // nspace, displayName
+        ]
 
         return {
           type: 'MeshHTTPRoute',
           mesh,
-          name,
+          name: `${displayName}${nspace.length > 0 ? `.${nspace}` : ''}`,
           creationTime: '2024-03-01T09:20:28Z',
           modificationTime: '2024-03-01T09:20:28Z',
-          ...((namespaceQuery || fake.datatype.boolean()) && {
-            labels: {
-              'k8s.kuma.io/namespace': namespaceQuery ?? 'kuma-system',
-              'kuma.io/display-name': name,
-              'kuma.io/mesh': 'default',
-              'kuma.io/origin': 'zone',
-              'kuma.io/zone': zone,
-            },
-          }),
+          kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, name: displayName, sectionName: '' }),
+          labels: {
+            ...fake.kuma.labels({
+              name: displayName,
+              ...(zone ? { zone } : {}),
+              ...(k8s ? { namespace: nspace } : {}),
+            }),
+          },
           spec: {
             targetRef: {
               kind: 'MeshGateway',

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshhttproutes/_.ts
@@ -9,7 +9,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const kri = req.params.kri ? `kri_mhttpr_${req.params.kri}` : undefined
   const [
     _prefix,
-    _shortName,
+    shortName,
     mesh,
     zone,
     nspace,
@@ -38,8 +38,8 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
       type: 'MeshHTTPRoute',
       mesh,
       name,
-      creationTime: '2024-03-01T09:20:28Z',
-      modificationTime: '2024-03-01T09:20:28Z',
+      ...fake.kuma.timespan(),
+      kri: fake.kuma.kri({ shortName, mesh, zone, namespace: nspace, name: displayName, sectionName: '' }),
       labels: {
         ...fake.kuma.labels({
           name: displayName,


### PR DESCRIPTION
Partial duplicate of https://github.com/kumahq/kuma-gui/pull/5123.

This does the minimum to have `shortName`s instead of resource paths in the resources module to shorten the URLs. 
In https://github.com/kumahq/kuma-gui/pull/5123 we do a little more to also cover legacy resources that don't have a `kri` and no `shortName`, but I think for now we don't need this because we don't support legacy resources in the resources module.