### PR TITLE
feat(resources): link to individual detail views

### DIFF
--- a/packages/kuma-gui/features/application/Titles.feature
+++ b/packages/kuma-gui/features/application/Titles.feature
@@ -37,7 +37,7 @@ Feature: application / titles
       | /meshes/default/data-planes                                                                       | Data plane proxies        |
       | /meshes/default/data-planes/kri_dp_default___data-plane-name_/overview                            | data-plane-name           |
       | /meshes/default/policies/circuit-breakers                                                         | Policies                  |
-      | /meshes/default/policies/circuit-breakers/kri_~circuitbreaker_default___program-0_/overview       | program-0                 |
+      | /meshes/default/policies/kri_~circuitbreaker_default___program-0_/overview                        | program-0                 |
       | /meshes/default/resources/mfi                                                                     | Resources                 |
       | /meshes/default/resources/kri_mfi_default_adviser_kuma-system_pension-0-959cb35ab-xtzqf_/overview | pension-0-959cb35ab-xtzqf |
       | /meshes/default/workloads                                                                         | Workloads                 |

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
@@ -102,4 +102,4 @@ Feature: mesh / dataplanes / overview / summary / Inbound
       """
     When I visit the "/meshes/default/data-planes/kri_dp_default_zone-1_kuma-demo_service-less_/overview/inbound/self_inbound_http/overview" URL
     Then I click on the "$inbound-policies-rule table tr:first-of-type td a" element
-    Then the URL contains "/gui/meshes/default/policies/meshfaultinjections/kri_mfi_default_pigsty_jury_the-policy-name_appliance/overview/overview"
+    Then the URL contains "/gui/meshes/default/policies/kri_mfi_default_pigsty_jury_the-policy-name_appliance/overview"

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Outbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Outbound.feature
@@ -75,4 +75,4 @@ Feature: mesh / dataplanes / overview / summary / Outbound
       """
     When I visit the "/meshes/default/data-planes/kri_dp_default_zone-1_kuma-demo_service-less_/overview/outbound/kri_dp_default_numeric_kuma-demo_service-less_httpport/overview" URL
     Then I click on the "$outbound-policies-rule ul:first-of-type li:first-of-type a:first-of-type" element
-    Then the URL contains "/gui/meshes/default/policies/meshfaultinjections/kri_mfi_default_pigsty_jury_the-policy-name_appliance/overview/overview"
+    Then the URL contains "/gui/meshes/default/policies/kri_mfi_default_pigsty_jury_the-policy-name_appliance/overview"

--- a/packages/kuma-gui/features/mesh/policies/Index.feature
+++ b/packages/kuma-gui/features/mesh/policies/Index.feature
@@ -118,7 +118,7 @@ Feature: mesh / policies / index
     Then the "$item:nth-child(1) td:nth-child(2)" element contains "fake-cb-1"
     When I click the "$action-group" element
     And I click the "$view" element
-    Then the URL contains "circuit-breakers/kri_~circuitbreaker_default___fake-cb-1_/overview"
+    Then the URL contains "kri_~circuitbreaker_default___fake-cb-1_/overview"
     And the "$detail-view" element contains "fake-cb-1"
     When I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(3) > a" element
     Then the "$item" element exists 2 times

--- a/packages/kuma-gui/features/mesh/policies/Item.feature
+++ b/packages/kuma-gui/features/mesh/policies/Item.feature
@@ -17,13 +17,13 @@ Feature: mesh / policies / item
       """
 
   Scenario: The about section has the expected content
-    When I visit the "/meshes/default/policies/meshaccesslogs/kri_mal_default_zone-1_kuma-demo_item-1_/overview/overview" URL
+    When I visit the "/meshes/default/policies/kri_mal_default_zone-1_kuma-demo_item-1_/overview" URL
     Then the "$about-section" element exists
     And the "$about-section" element contains "kuma-demo"
     And the "$about-section" element contains "kuma.io/origin:zone"
 
   Scenario: Shows config with format based on environment
-    When I visit the "/meshes/default/policies/meshaccesslogs/kri_mal_default_zone-1_kuma-demo_item-1_/overview/config" URL
+    When I visit the "/meshes/default/policies/kri_mal_default_zone-1_kuma-demo_item-1_/config" URL
     Then the "$config-universal" element exists
     And the URL contains "?environment=universal"
     When I click the "$select-environment" element

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -70,31 +70,29 @@ const protocolHandler = (can: Can, router: Router) => {
         const name = encodedName.replaceAll('~', '_')
         const to = (() => {
           switch (true) {
-            // TODO: Need to find a good workaround for legacy policies and not using policyPath
-            // case shortName === 'mal':
-            // case shortName === 'mcb':
-            // case shortName === 'mfi':
-            // case shortName === 'mhttpr':
-            // case shortName === 'mhc':
-            // case shortName === 'mlbs':
-            // case shortName === 'mm':
-            // case shortName === 'mp':
-            // case shortName === 'mpp':
-            // case shortName === 'mrl':
-            // case shortName === 'mr':
-            // case shortName === 'mtcpr':
-            // case shortName === 'mtls':
-            // case shortName === 'mt':
-            // case shortName === 'mtr':
-            // case shortName === 'mtp':
-            //   return {
-            //     name: 'policy-detail-view',
-            //     params: {
-            //       mesh,
-            //       policyPath: shortName,
-            //       policy: kri,
-            //     },
-            //   }
+            case shortName === 'mal':
+            case shortName === 'mcb':
+            case shortName === 'mfi':
+            case shortName === 'mhttpr':
+            case shortName === 'mhc':
+            case shortName === 'mlbs':
+            case shortName === 'mm':
+            case shortName === 'mp':
+            case shortName === 'mpp':
+            case shortName === 'mrl':
+            case shortName === 'mr':
+            case shortName === 'mtcpr':
+            case shortName === 'mtls':
+            case shortName === 'mt':
+            case shortName === 'mtr':
+            case shortName === 'mtp':
+              return {
+                name: 'policy-detail-view',
+                params: {
+                  mesh,
+                  policy: kri,
+                },
+              }
             case shortName === 'm':
               return {
                 name: 'mesh-detail-view',

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -65,12 +65,36 @@ const protocolHandler = (can: Can, router: Router) => {
     switch (true) {
       case href.startsWith(kriProto): {
         const kri = href.substring(kriProto.length)
-        const { mesh, name: encodedName, zone, namespace, shortName } = Kri.fromString(kri)
+        const { mesh, name: encodedName, shortName } = Kri.fromString(kri)
         // old style names can have _ in them that are replaced with `~`
         const name = encodedName.replaceAll('~', '_')
-        const id = `${name}${namespace !== '' ? `.${namespace}`: '' }`
         const to = (() => {
           switch (true) {
+            // TODO: Need to find a good workaround for legacy policies and not using policyPath
+            // case shortName === 'mal':
+            // case shortName === 'mcb':
+            // case shortName === 'mfi':
+            // case shortName === 'mhttpr':
+            // case shortName === 'mhc':
+            // case shortName === 'mlbs':
+            // case shortName === 'mm':
+            // case shortName === 'mp':
+            // case shortName === 'mpp':
+            // case shortName === 'mrl':
+            // case shortName === 'mr':
+            // case shortName === 'mtcpr':
+            // case shortName === 'mtls':
+            // case shortName === 'mt':
+            // case shortName === 'mtr':
+            // case shortName === 'mtp':
+            //   return {
+            //     name: 'policy-detail-view',
+            //     params: {
+            //       mesh,
+            //       policyPath: shortName,
+            //       policy: kri,
+            //     },
+            //   }
             case shortName === 'm':
               return {
                 name: 'mesh-detail-view',
@@ -92,7 +116,8 @@ const protocolHandler = (can: Can, router: Router) => {
               return {
                 name: 'workload-detail-view',
                 params: {
-                  wl: Kri.toString({ shortName, mesh, zone, namespace, name }),
+                  mesh,
+                  wl: kri,
                 },
               }
             case shortName === '~hostport':
@@ -107,23 +132,23 @@ const protocolHandler = (can: Can, router: Router) => {
                 name: 'mesh-service-detail-view',
                 params: {
                   mesh,
-                  service: id,
+                  kri,
                 },
               }
             case shortName === 'mzsvc':
               return {
                 name: 'mesh-multi-zone-service-detail-view',
                 params: {
-                  mesh: mesh,
-                  service: id,
+                  mesh,
+                  kri,
                 },
               }
             case shortName === 'extsvc':
               return {
                 name: 'mesh-external-service-detail-view',
                 params: {
-                  mesh: mesh,
-                  service: id,
+                  mesh,
+                  kri,
                 },
               }
             case shortName === 'hg':
@@ -133,8 +158,22 @@ const protocolHandler = (can: Can, router: Router) => {
                   kri,
                 },
               }
+            case shortName === 'dp':
+              return {
+                name: 'data-plane-detail-view',
+                params: {
+                  mesh,
+                  proxy: kri,
+                },
+              }
             default:
-              return
+              return {
+                name: 'resource-detail-view',
+                params: {
+                  mesh,
+                  kri,
+                },
+              }
           }
         })()
         if (to) {

--- a/packages/kuma-gui/src/app/policies/routes.ts
+++ b/packages/kuma-gui/src/app/policies/routes.ts
@@ -4,7 +4,7 @@ export const routes = () => {
   const item = (): RouteRecordRaw[] => {
     return [
       {
-        path: 'policies/:policyPath/:policy/overview',
+        path: 'policies/:policy',
         name: 'policy-detail-tabs-view',
         component: () => import('@/app/policies/views/PolicyDetailTabsView.vue'),
         children: [

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailConfigView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailConfigView.vue
@@ -4,7 +4,6 @@
     :params="{
       mesh: '',
       policy: '',
-      policyPath: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -65,7 +64,7 @@
           <template v-else>
             <DataLoader
               :src="uri(sources, '/policy-path/:path/policy/:kri/as/kubernetes', {
-                path: route.params.policyPath,
+                path: policyType?.path ?? '',
                 kri: route.params.policy,
               })"
               v-slot="{ data: [yaml] }"
@@ -91,9 +90,10 @@
 </template>
 
 <script lang="ts" setup>
-import type { Policy } from '../data'
+import type { Policy, PolicyResourceType } from '../data'
 import { sources } from '../sources'
 const props = defineProps<{
   data: Policy | Error | undefined
+  policyType: PolicyResourceType | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
@@ -4,112 +4,126 @@
     :params="{
       mesh: '',
       policy: '',
-      policyPath: '',
     }"
     v-slot="{ route, t, uri }"
   >
-    <DataSource
-      :src="uri(sources, '/policy-path/:path/policy/:kri', {
-        path: route.params.policyPath,
-        kri: route.params.policy,
-      })"
-      v-slot="{ data, result }"
+    <DataLoader
+      :src="uri(sources, '/policy-types', {})"
+      v-slot="{ data: [policyTypesData] }"
     >
-      <AppView
-        :breadcrumbs="[
-          {
-            to: {
-              name: 'mesh-detail-view',
-              params: {
-                mesh: route.params.mesh,
-              },
-            },
-            text: route.params.mesh,
-          },
-          {
-            to: {
-              name: 'policy-list-view',
-              params: {
-                mesh: route.params.mesh,
-                policyPath: route.params.policyPath,
-              },
-            },
-            text: t('policies.routes.item.breadcrumbs'),
-          },
-        ]"
+      <template
+        v-for="policyType in [policyTypesData.policyTypes.find((policyType) => {
+          const { shortName } = Kri.fromString(route.params.policy)
+          return shortName.startsWith('~') ? policyType.name.toLowerCase() === shortName.substring(1) : policyType.shortName === shortName
+        })]"
+        :key="typeof policyType"
       >
-        <template #title>
-          <DataLoader
-            :data="[data]"
-            variant="header"
-            v-slot="{ data: [policy] }"
-          >
-            <h1>
-              <RouteTitle
-                :title="t('policies.routes.item.title', { name: policy.name })"
-              />
-            </h1>
-          </DataLoader>
-        </template>
-        <template
-          #actions
+        <DataSource
+          :src="uri(sources, '/policy-path/:path/policy/:kri', {
+            path: policyType?.path ?? '',
+            kri: route.params.policy,
+          })"
+          v-slot="{ data, result }"
         >
-          <PolicyActionGroup
-            :item="data"
-            :type="{ path: route.params.policyPath }"
-            @change="() => route.replace(
+          <AppView
+            :breadcrumbs="[
               {
-                name: 'policy-list-view',
-                params: {
-                  mesh: route.params.mesh,
-                  policyPath: route.params.policyPath,
+                to: {
+                  name: 'mesh-detail-view',
+                  params: {
+                    mesh: route.params.mesh,
+                  },
                 },
+                text: route.params.mesh,
               },
-            )"
+              {
+                to: {
+                  name: 'policy-list-view',
+                  params: {
+                    mesh: route.params.mesh,
+                    policyPath: policyType?.path,
+                  },
+                },
+                text: t('policies.routes.item.breadcrumbs'),
+              },
+            ]"
           >
-            <template
-              #control
-            >
-              <XAction
-                action="expand"
-                appearance="primary"
+            <template #title>
+              <DataLoader
+                :data="[data]"
+                variant="header"
+                v-slot="{ data: [policy] }"
               >
-                {{ t('policies.action_group.toggle_button') }}
-              </XAction>
+                <h1>
+                  <RouteTitle
+                    :title="t('policies.routes.item.title', { name: policy.name })"
+                  />
+                </h1>
+              </DataLoader>
             </template>
-          </PolicyActionGroup>
-        </template>
-        <XTabs
-          :selected="route.child()?.name"
-        >
-          <template
-            v-for="{ name } in route.children"
-            :key="name"
-            #[`${name}-tab`]
-          >
-            <XAction
-              :to="{ name }"
+            <template
+              #actions
             >
-              {{ t(`policies.routes.item.navigation.${name}`) }}
-            </XAction>
-          </template>
-        </XTabs>
+              <PolicyActionGroup
+                :item="data"
+                :type="{ path: policyType?.path }"
+                @change="() => route.replace(
+                  {
+                    name: 'policy-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                      policyPath: policyType?.path,
+                    },
+                  },
+                )"
+              >
+                <template
+                  #control
+                >
+                  <XAction
+                    action="expand"
+                    appearance="primary"
+                  >
+                    {{ t('policies.action_group.toggle_button') }}
+                  </XAction>
+                </template>
+              </PolicyActionGroup>
+            </template>
+            <XTabs
+              :selected="route.child()?.name"
+            >
+              <template
+                v-for="{ name } in route.children"
+                :key="name"
+                #[`${name}-tab`]
+              >
+                <XAction
+                  :to="{ name }"
+                >
+                  {{ t(`policies.routes.item.navigation.${name}`) }}
+                </XAction>
+              </template>
+            </XTabs>
 
-        <RouterView
-          v-slot="child"
-        >
-          <component
-            :is="child.Component"
-            :data="result"
-          />
-        </RouterView>
-      </AppView>
-    </DataSource>
+            <RouterView
+              v-slot="child"
+            >
+              <component
+                :is="child.Component"
+                :data="result"
+                :policy-type="policyType"
+              />
+            </RouterView>
+          </AppView>
+        </DataSource>
+      </template>
+    </DataLoader>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
 import { usePolicyActionGroup } from '../'
 import { sources } from '../sources'
+import { Kri } from '@/app/kuma'
 const PolicyActionGroup = usePolicyActionGroup()
 </script>

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
@@ -7,7 +7,6 @@
       s: '',
       mesh: '',
       policy: '',
-      policyPath: '',
       proxy: '',
     }"
     v-slot="{ route, t, uri, can, me, r }"
@@ -121,7 +120,7 @@
           <DataLoader
             :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
               mesh: route.params.mesh,
-              path: route.params.policyPath,
+              path: policyType?.path ?? '',
               name: policy.id,
             },{
               page: route.params.page,
@@ -227,12 +226,13 @@
 </template>
 
 <script lang="ts" setup>
-import type { Policy } from '../data'
+import type { Policy, PolicyResourceType } from '../data'
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import { Kri } from '@/app/kuma'
 
 const props = defineProps<{
   data: Policy | Error | undefined
+  policyType: PolicyResourceType | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
@@ -169,12 +169,7 @@
                     <template #actions="{ row }">
                       <XActionGroup>
                         <XAction
-                          :to="{
-                            name: 'resource-detail-view',
-                            params: {
-                              kri: row.kri,
-                            },
-                          }"
+                          :href="`kri://${row.kri}`"
                         >
                           {{ t('common.collection.actions.view') }}
                         </XAction>

--- a/packages/kuma-gui/src/app/resources/views/ResourceSummaryView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceSummaryView.vue
@@ -43,12 +43,7 @@
                   v-icon-start="`policy`"
                 >
                   <XAction
-                    :to="{
-                      name: 'resource-detail-view',
-                      params: {
-                        kri: item.kri,
-                      },
-                    }"
+                    :href="`kri://${item.kri}`"
                   >
                     <RouteTitle
                       :title="t('resources.routes.item.title', { name: item.name })"

--- a/packages/kuma-http-api/mocks/fs.ts
+++ b/packages/kuma-http-api/mocks/fs.ts
@@ -28,6 +28,7 @@ import _16 from './src/meshes/_'
 import _17 from './src/meshes/_/circuit-breakers'
 import _18 from './src/meshes/_/circuit-breakers/_'
 import _125 from './src/meshes/_/circuit-breakers/_/_resources/dataplanes'
+import _234 from './src/meshes/_/dataplanes'
 import _19 from './src/meshes/_/dataplanes/_'
 import _231 from './src/meshes/_/dataplanes/_/_inbounds/_/_policies'
 import _123 from './src/meshes/_/dataplanes/_/_layout'
@@ -178,6 +179,7 @@ export const fs = {
   '/mesh-insights/:mesh': _14,
   '/meshes': _15,
   '/meshes/:name': _16,
+  '/meshes/:mesh/dataplanes': _234,
   '/meshes/:mesh/dataplanes/_overview': _21,
   '/meshes/:mesh/dataplanes/:name': _19,
   '/meshes/:mesh/dataplanes/:name/_overview': _22,

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes.ts
@@ -1,0 +1,127 @@
+import type { Dependencies, ResponseHandler } from '#mocks'
+import type { paths } from '@kumahq/kuma-http-api'
+
+type DataplanesResponse = paths['/meshes/{mesh}/dataplanes']['get']['responses']['200']['content']['application/json']
+
+export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) => {
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+  const query = req.url.searchParams
+
+  const { offset, total, next, pageTotal } = pager(
+    env('KUMA_DATAPLANE_COUNT', `${fake.number.int({ min: 1, max: 100 })}`),
+    req,
+    `/meshes/${req.params.mesh}/dataplanes`,
+  )
+
+  const nameQuery = query.get('name') ?? ''
+  const namespaceQuery = query.get('filter[labels.k8s.kuma.io/namespace]')
+  const zoneQuery = query.get('filter[labels.kuma.io/zone]')
+
+  return {
+    headers: {
+      ...(fake.datatype.boolean() ? { 'Transfer-Encoding': 'chunked' } : {}),
+    },
+    body: {
+      total,
+      next,
+      items: Array.from({ length: pageTotal }, (_, i) => {
+        const multizone = fake.datatype.boolean()
+
+        const inbounds = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
+
+        const type = fake.helpers.arrayElement(['proxy', 'gateway_builtin', 'gateway_delegated'])
+
+        const id = offset + i
+        const [
+          _prefix,
+          shortName,
+          mesh,
+          zone,
+          nspace,
+          displayName,
+        ] = [
+          'kri', // prefix
+          'dp', // shortName
+          String(req.params.mesh), // mesh
+          zoneQuery ?? fake.helpers.arrayElement(['', fake.word.noun()]), // zone
+          ...([k8s ? namespaceQuery ?? fake.word.noun() : '', `${nameQuery || fake.word.noun()}-${id}`]), // nspace, displayName
+        ]
+
+        return {
+          type: 'Dataplane',
+          mesh,
+          name: `${displayName}${k8s ? `.${nspace}` : ''}`,
+          labels: {
+            ...fake.kuma.labels({
+              name: displayName,
+              ...(zoneQuery || multizone ? { zone } : {}),
+              ...(k8s ? { namespace: nspace } : {}),
+            }),
+          },
+          ...fake.kuma.timespan(),
+          kri: fake.kuma.kri({ shortName, mesh, zone: zoneQuery || multizone ? zone : '', namespace: k8s ? nspace : '', displayName, sectionName: '' }),
+          networking: (() => {
+            const address = fake.internet.ipv4()
+            const advertisedAddress = fake.datatype.boolean({ probability: 0.25 }) ? fake.internet.ipv4() : undefined
+            const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
+
+            return {
+              address,
+              ...(advertisedAddress && { advertisedAddress }),
+              ...(type !== 'proxy'
+                ? {
+                  gateway: {
+                    tags: fake.kuma.tags({
+                      service: fake.kuma.serviceName(type),
+                      zone: multizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
+                    }),
+                    ...(dataplaneType && { type: dataplaneType }),
+                  },
+                }
+                : {}),
+              ...(type === 'proxy'
+                ? {
+                  inbound: Array.from({ length: inbounds }).map(() => {
+                    const address = fake.datatype.boolean({ probability: 0.25 }) ? fake.internet.ipv4() : undefined
+                    const port = fake.internet.port()
+                    const hasServiceAddress = fake.datatype.boolean({ probability: 0.25 })
+                    const serviceAddress = hasServiceAddress ? fake.internet.ipv4() : undefined
+                    const servicePort = hasServiceAddress ? fake.internet.port() : undefined
+                    const protocol = fake.kuma.protocol()
+                    const tags = fake.kuma.tags({
+                      protocol,
+                      service: fake.kuma.serviceName(),
+                      zone: multizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
+                    })
+
+                    return {
+                      port,
+                      protocol,
+                      tags,
+                      ...(fake.datatype.boolean()
+                        ? {
+                          health: {
+                            ready: fake.datatype.boolean(),
+                          },
+                        }
+                        : {}),
+                      ...(address && { address }),
+                      ...(serviceAddress && { serviceAddress }),
+                      ...(servicePort && { servicePort }),
+                    }
+                  }),
+                }
+                : {}),
+              outbound: [
+                {
+                  port: fake.internet.port(),
+                  tags: fake.kuma.tags({ service: fake.kuma.serviceName() }),
+                },
+              ],
+            }
+          })(),
+        }
+      }),
+    } satisfies DataplanesResponse,
+  }
+}

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways.ts
@@ -2,7 +2,6 @@ import type { Dependencies, ResponseHandler } from '#mocks'
 import type { MeshGateway } from '@/types/index.d'
 
 export default ({ env, fake, pager }: Dependencies): ResponseHandler => (req) => {
-  const mesh = req.params.mesh as string
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
 
   const { offset, total, next, pageTotal } = pager(
@@ -12,9 +11,9 @@ export default ({ env, fake, pager }: Dependencies): ResponseHandler => (req) =>
   )
   const listenerCount = parseInt(env('KUMA_LISTENER_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
 
-  const queryName = req.url.searchParams.get('name')
-  const queryNamespace = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
-  const queryZone = req.url.searchParams.get('filter[labels.kuma.io/zone]')
+  const nameQuery = req.url.searchParams.get('name')
+  const namespaceQuery = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
+  const zoneQuery = req.url.searchParams.get('filter[labels.kuma.io/zone]')
 
   return {
     headers: {
@@ -25,27 +24,35 @@ export default ({ env, fake, pager }: Dependencies): ResponseHandler => (req) =>
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.word.noun()}-${id}`
 
-        const displayName = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${name}${fake.kuma.dataplaneSuffix(k8s)}`
-        const nspace = queryNamespace ?? fake.k8s.namespace()
-        const zone = queryZone ?? fake.word.noun()
+        const [
+          _prefix,
+          shortName,
+          mesh,
+          zone,
+          nspace,
+          displayName,
+        ] = [
+          'kri', // prefix
+          'mgw', // shortName
+          String(req.params.mesh), // mesh
+          zoneQuery ?? fake.helpers.arrayElement(['', fake.word.noun()]), // zone
+          ...([k8s ? namespaceQuery ?? fake.word.noun() : '', `${nameQuery || fake.word.noun()}-${id}`]), // nspace, displayName
+        ]
+        const name = `${displayName}${k8s ? `.${nspace}` : ''}`
 
         return {
           type: 'MeshGateway',
           mesh,
-          name: `${displayName}${k8s ? `.${nspace}` : ''}`,
-          creationTime: '2022-01-25T13:55:51.798701+01:00',
-          modificationTime: '2022-01-25T13:55:51.798701+01:00',
+          name,
+          ...fake.kuma.timespan(),
+          kri: fake.kuma.kri({ shortName, mesh, zone, namespace: k8s ? nspace : '', displayName, sectionName: '' }),
           labels: {
-            'kuma.io/display-name': displayName,
-            'kuma.io/origin': fake.kuma.origin(),
-            'kuma.io/zone': zone,
-            ...(k8s
-              ? {
-                'k8s.kuma.io/namespace': nspace,
-              }
-              : {}),
+            ...fake.kuma.labels({
+              name: displayName,
+              ...(zone && { zone }),
+              ...(k8s && { namespace: nspace }),
+            }),
           },
           selectors: [
             {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_.ts
@@ -9,7 +9,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const kri = req.params.kri ? `kri_mgw_${req.params.kri}` : undefined
   const [
     _prefix,
-    _shortName,
+    shortName,
     mesh,
     zone,
     nspace,
@@ -38,8 +38,8 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
       type: 'MeshGateway',
       mesh,
       name,
-      creationTime: '2022-01-25T13:55:51.798701+01:00',
-      modificationTime: '2022-01-25T13:55:51.798701+01:00',
+      kri: fake.kuma.kri({ shortName, mesh, zone, namespace: k8s ? nspace : '', displayName, sectionName: '' }),
+      ...fake.kuma.timespan(),
       labels: {
         ...fake.kuma.labels({
           name: displayName,


### PR DESCRIPTION
Uses the KRI protocol handler for links in the resources module and links to the individual detail pages for the respective resources.
In order to link to a policy detail page via the protocol handler, I also had to shorten the URL and remove the `policyPath` path param. This information is redundant because the type of the policy resource is already part of the KRI. But I had to cope with the fact that we still support legacy policies in the policies module, that do not work with KRIs, and also that we need to fetch nested endpoints that require the `:policy-path` path param. This also allows us to remove that weird `/overview/overview` URL structure and go with only `/overview` for a policy detail page. As a (potentially temporary) workaround I added a fetch to the `/policy-types` to be able to map from a KRI to the actual resource and retrieve the `path`.

Closes https://github.com/kumahq/kuma-gui/issues/4824