### PR TITLE
refactor(zones): separate zone-ingresses and -egresses modules

### DIFF
--- a/packages/kuma-gui/src/app/zone-egresses/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/index.ts
@@ -1,0 +1,55 @@
+import { token } from '@kumahq/container'
+
+import { routes } from './routes'
+import { sources } from './sources'
+import type { Can } from '@/app/application'
+import egressLocales from '@/app/zone-egresses/locales/en-us/index.yaml'
+import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
+
+type Token = ReturnType<typeof token>
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [token('zones-engresses.routes'), {
+      service: (can: Can) => {
+        return [
+          (item: RouteRecordRaw) => {
+            const _routes = routes()
+            if (item.name === 'zone-cp-detail-tabs-view') {
+              const children = item.children ?? []
+              item.children = [children[0], children[1], ..._routes.items(), ...children.splice(2)].filter((route) => !!route)
+            }
+            if (item.name === 'zone-cp-detail-abstract-view') {
+              item.children = (item.children ?? []).concat(_routes.item())
+            }
+            if(!can('use zones') && item.name === 'control-plane-root-view') {
+              item.children = (item.children ?? []).concat(_routes.items(), _routes.item())
+            }
+          },
+        ]
+      },
+      arguments: [
+        app.can,
+      ],
+      labels: [
+        app.routeWalkers,
+      ],
+    }],
+    [token('zone-egresses.locales'), {
+      service: () => egressLocales,
+      labels: [
+        app.enUs,
+      ],
+    }],
+    [token('zone-egresses.sources'), {
+      service: sources,
+      arguments: [
+        app.api,
+      ],
+      labels: [
+        app.sources,
+      ],
+    }],
+  ]
+}

--- a/packages/kuma-gui/src/app/zone-egresses/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/index.ts
@@ -15,7 +15,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: (can: Can) => {
         return [
           (item: RouteRecordRaw) => {
-            const _routes = routes()
+            const _routes = routes(can)
             if (item.name === 'zone-cp-detail-tabs-view') {
               const children = item.children ?? []
               item.children = [children[0], children[1], ..._routes.items(), ...children.splice(2)].filter((route) => !!route)
@@ -23,8 +23,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
             if (item.name === 'zone-cp-detail-abstract-view') {
               item.children = (item.children ?? []).concat(_routes.item())
             }
+            
             if(!can('use zones') && item.name === 'control-plane-root-view') {
-              item.children = (item.children ?? []).concat(_routes.items(), _routes.item())
+              item.children = (item.children ?? []).concat(_routes.items())
             }
           },
         ]

--- a/packages/kuma-gui/src/app/zone-egresses/routes.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/routes.ts
@@ -1,8 +1,9 @@
+import type { Can } from '@/app/application'
 import { routes as connections, networking } from '@/app/connections/routes'
 import { routes as subscriptions } from '@/app/subscriptions/routes'
 import type { RouteRecordRaw } from 'vue-router'
 
-export const routes = (prefix = 'egresses') => {
+export const routes = (can: Can, prefix = 'egresses') => {
   const item = (): RouteRecordRaw[] => {
     return [
       {
@@ -41,22 +42,37 @@ export const routes = (prefix = 'egresses') => {
     ]
   }
 
+  const items = (): RouteRecordRaw[] => [
+    {
+      path: `${prefix}`,
+      name: 'zone-egress-list-view',
+      component: () => import('@/app/zone-egresses/views/ZoneEgressListView.vue'),
+      children: [
+        {
+          path: ':proxy',
+          name: 'zone-egress-summary-view',
+          component: () => import('@/app/zone-egresses/views/ZoneEgressSummaryView.vue'),
+        },
+      ],
+    },
+  ]
+
   return {
     items: (): RouteRecordRaw[] => {
-      return [
-        {
-          path: `${prefix}`,
-          name: 'zone-egress-list-view',
-          component: () => import('@/app/zone-egresses/views/ZoneEgressListView.vue'),
-          children: [
-            {
-              path: ':proxy',
-              name: 'zone-egress-summary-view',
-              component: () => import('@/app/zone-egresses/views/ZoneEgressSummaryView.vue'),
-            },
-          ],
-        },
-      ]
+      if(!can('use zones')) {
+        return [
+          {
+            path: 'zones',
+            name: 'zone-egress-index-view',
+            redirect: { name: 'zone-egress-list-view '},
+            children: [
+              ...items(),
+              ...item(),
+            ],
+          },
+        ]
+      }
+      return items()
     },
     item,
   }

--- a/packages/kuma-gui/src/app/zone-ingresses/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/index.ts
@@ -1,0 +1,51 @@
+import { token } from '@kumahq/container'
+
+import { routes } from './routes'
+import { sources } from './sources'
+import ingressLocales from '@/app/zone-ingresses/locales/en-us/index.yaml'
+import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
+
+type Token = ReturnType<typeof token>
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [token('zones-ingresses.routes'), {
+      service: () => {
+        return [
+          (item: RouteRecordRaw) => {
+            const _routes = routes()
+            if (item.name === 'zone-cp-detail-tabs-view') {
+              const children = item.children ?? []
+              item.children = [children[0], children[1], ..._routes.items(), ...children.splice(2)].filter((route) => !!route)
+            }
+            if (item.name === 'zone-cp-detail-abstract-view') {
+              item.children = (item.children ?? []).concat(_routes.item())
+            }
+          },
+        ]
+      },
+      arguments: [
+        app.can,
+      ],
+      labels: [
+        app.routeWalkers,
+      ],
+    }],
+    [token('zones-ingresses.locales'), {
+      service: () => ingressLocales,
+      labels: [
+        app.enUs,
+      ],
+    }],
+    [token('zone-ingresses.sources'), {
+      service: sources,
+      arguments: [
+        app.api,
+      ],
+      labels: [
+        app.sources,
+      ],
+    }],
+  ]
+}

--- a/packages/kuma-gui/src/app/zones/index.ts
+++ b/packages/kuma-gui/src/app/zones/index.ts
@@ -6,9 +6,8 @@ import { features } from './features'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
+import type { Can } from '@/app/application'
 import { services as subscriptions } from '@/app/subscriptions'
-import egressLocales from '@/app/zone-egresses/locales/en-us/index.yaml'
-import ingressLocales from '@/app/zone-ingresses/locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@kumahq/container'
 import type { RouteRecordRaw } from 'vue-router'
 
@@ -28,11 +27,11 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: () => ZoneActionGroup,
     }],
     [token('zones.routes'), {
-      service: (can) => {
+      service: (can: Can) => {
         return [
           (item: RouteRecordRaw) => {
-            if (item.name === 'control-plane-root-view') {
-              item.children = (item.children ?? []).concat(routes(can))
+            if (can('use zones') && item.name === 'control-plane-root-view') {
+              item.children = (item.children ?? []).concat(routes())
             }
           },
         ]
@@ -64,18 +63,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('zones.locales'), {
       service: () => locales,
-      labels: [
-        app.enUs,
-      ],
-    }],
-    [token('zone-egresses.locales'), {
-      service: () => egressLocales,
-      labels: [
-        app.enUs,
-      ],
-    }],
-    [token('zones-ingresses.locales'), {
-      service: () => ingressLocales,
       labels: [
         app.enUs,
       ],

--- a/packages/kuma-gui/src/app/zones/routes.ts
+++ b/packages/kuma-gui/src/app/zones/routes.ts
@@ -1,79 +1,55 @@
-import type { Can } from '@/app/application'
 import { routes as subscriptions } from '@/app/subscriptions/routes'
-import { routes as egresses } from '@/app/zone-egresses/routes'
-import { routes as ingresses } from '@/app/zone-ingresses/routes'
 import type { RouteRecordRaw } from 'vue-router'
 
-export const routes = (
-  can: Can,
-): RouteRecordRaw[] => {
+export const routes = (): RouteRecordRaw[] => {
   const prefix = 'zones'
   return [
-    ...(can('use zones')
-      ? [
+    {
+      path: `${prefix}`,
+      name: 'zone-index-view',
+      redirect: { name: 'zone-cp-list-view' },
+      children: [
         {
-          path: `${prefix}`,
-          name: 'zone-index-view',
-          redirect: { name: 'zone-cp-list-view' },
+          path: '',
+          name: 'zone-cp-list-view',
+          component: () => import('@/app/zones/views/ZoneListView.vue'),
+        },
+        {
+          path: ':zone',
+          name: 'zone-cp-detail-abstract-view',
           children: [
             {
               path: '',
-              name: 'zone-cp-list-view',
-              component: () => import('@/app/zones/views/ZoneListView.vue'),
-            },
-            {
-              path: ':zone',
-              name: 'zone-cp-detail-abstract-view',
+              name: 'zone-cp-detail-tabs-view',
+              component: () => import('@/app/zones/views/ZoneDetailTabsView.vue'),
+              redirect: { name: 'zone-cp-detail-view' },
               children: [
                 {
-                  path: '',
-                  name: 'zone-cp-detail-tabs-view',
-                  component: () => import('@/app/zones/views/ZoneDetailTabsView.vue'),
-                  redirect: { name: 'zone-cp-detail-view' },
-                  children: [
-                    {
-                      path: 'overview',
-                      name: 'zone-cp-detail-view',
-                      component: () => import('@/app/zones/views/ZoneDetailView.vue'),
-                      children: subscriptions('zone-cp'),
-                    },
-                    {
-                      path: 'config',
-                      name: 'zone-cp-config-view',
-                      component: () => import('@/app/zones/views/ZoneConfigView.vue'),
-                    },
-                    ...ingresses().items(),
-                    ...egresses().items(),
-                    {
-                      path: 'subscriptions',
-                      name: 'zone-cp-subscriptions-list-view',
-                      props: {
-                        i18nPrefix: 'zone-cps',
-                        routePrefix: 'zone-cp',
-                      },
-                      component: () => import('@/app/subscriptions/views/SubscriptionsListView.vue'),
-                      children: [...subscriptions('zone-cp')],
-                    },
-                  ],
+                  path: 'overview',
+                  name: 'zone-cp-detail-view',
+                  component: () => import('@/app/zones/views/ZoneDetailView.vue'),
+                  children: subscriptions('zone-cp'),
                 },
-                ...ingresses().item(),
-                ...egresses().item(),
+                {
+                  path: 'config',
+                  name: 'zone-cp-config-view',
+                  component: () => import('@/app/zones/views/ZoneConfigView.vue'),
+                },
+                {
+                  path: 'subscriptions',
+                  name: 'zone-cp-subscriptions-list-view',
+                  props: {
+                    i18nPrefix: 'zone-cps',
+                    routePrefix: 'zone-cp',
+                  },
+                  component: () => import('@/app/subscriptions/views/SubscriptionsListView.vue'),
+                  children: [...subscriptions('zone-cp')],
+                },
               ],
             },
           ],
         },
-
-      ]
-      : [
-        {
-          path: `${prefix}`,
-          name: 'zone-egress-index-view',
-          redirect: { name: 'zone-egress-list-view' },
-          children: [
-            ...egresses().items(),
-            ...egresses().item(),
-          ],
-        },
-      ]),
+      ],
+    },
   ]
 }

--- a/packages/kuma-gui/src/app/zones/sources.ts
+++ b/packages/kuma-gui/src/app/zones/sources.ts
@@ -5,16 +5,12 @@ import { Kri } from '../kuma'
 import type { DataSourceResponse } from '@/app/application'
 import { defineSources } from '@/app/application'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
-import { sources as zoneEgresses } from '@/app/zone-egresses/sources'
-import { sources as zoneIngresses } from '@/app/zone-ingresses/sources'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 export type { ZoneOverview } from './data'
 import type {
   ZoneOverview as PartialZoneOverview,
 } from '@/types/index.d'
 import type { paths } from '@kumahq/kuma-http-api'
-
-
 
 export type ZoneOverviewCollection = CollectionResponse<ZoneOverview>
 export type ZoneOverviewSource = DataSourceResponse<ZoneOverview>
@@ -28,9 +24,6 @@ export const sources = (api: KumaApi) => {
     fetch: api.client.fetch,
   })
   return defineSources({
-    ...zoneIngresses(api),
-    ...zoneEgresses(api),
-
     '/zone-cps': async (params) => {
       const { size } = params
       const offset = size * (params.page - 1)

--- a/packages/kuma-gui/src/main.ts
+++ b/packages/kuma-gui/src/main.ts
@@ -23,6 +23,8 @@ import { services as rules } from '@/app/rules'
 import { services as services } from '@/app/services'
 import { services as vue, TOKENS as VUE } from '@/app/vue'
 import { services as workloads } from '@/app/workloads'
+import { services as zoneEgresses } from '@/app/zone-egresses'
+import { services as zoneIngresses } from '@/app/zone-ingresses'
 import { services as zones } from '@/app/zones'
 
 async function mountVueApplication() {
@@ -43,6 +45,8 @@ async function mountVueApplication() {
     configuration($),
     controlPlanes($),
     zones($),
+    zoneEgresses($),
+    zoneIngresses($),
     meshes($),
     hostnameGenerators($),
     services($),


### PR DESCRIPTION
Separates the `zone-ingresses` and `zone-egresses` module to be able to conditionally include them.

Part of https://github.com/kumahq/kuma-gui/issues/5041