### PR TITLE
fix(data-plane-outbound-summary-overview): invalid rule origin link

### DIFF
--- a/packages/kuma-gui/src/app/rules/data/ResourceRule.ts
+++ b/packages/kuma-gui/src/app/rules/data/ResourceRule.ts
@@ -1,16 +1,26 @@
+import { Origin } from './Origin'
+import type { ResourceTypeDescriptorCollection } from '@/app/resources/data'
 import type { components } from '@kumahq/kuma-http-api'
 type Entity = components['schemas']['ResourceRule']
 type Collection = Entity[]
 
 export const ResourceRule = {
-  fromObject(item: Entity) {
+  fromObject(item: Entity, resources: ResourceTypeDescriptorCollection) {
     const labels = typeof item.resourceMeta.labels !== 'undefined' ? item.resourceMeta.labels : {}
+    const origins = Array.isArray(item.origin) ?
+      item.origin.map((origin) => 
+        ({
+          ...origin,
+          ...(origin.resourceMeta && { resourceMeta: Origin.fromObject(origin.resourceMeta, resources) }),
+        }),
+      ) : []
+
     return {
       ...item,
       type: '',
       raw: item.conf[0] ?? {},
       config: item.conf[0] ?? {},
-      origins: Array.isArray(item.origin) ? item.origin : [],
+      origins,
       labels,
       id: item.resourceMeta.name,
       name: labels['kuma.io/display-name'] ?? item.resourceMeta.name,
@@ -20,8 +30,8 @@ export const ResourceRule = {
     }
   },
 
-  fromCollection(collection: Collection) {
-    const items = Array.isArray(collection) ? collection.map(ResourceRule.fromObject) : []
+  fromCollection(collection: Collection, resources: ResourceTypeDescriptorCollection) {
+    const items = Array.isArray(collection) ? collection.map((item) => ResourceRule.fromObject(item, resources)) : []
     return {
       items,
       total: items.length,

--- a/packages/kuma-gui/src/app/rules/data/Rule.ts
+++ b/packages/kuma-gui/src/app/rules/data/Rule.ts
@@ -105,7 +105,7 @@ export const Rule = {
         const rules = Array.isArray(item.toResourceRules)
           ? item.toResourceRules.map(rule => {
             return {
-              ...ResourceRule.fromObject(rule),
+              ...ResourceRule.fromObject(rule, resources),
               type: item.type,
             }
           })


### PR DESCRIPTION
We missed to pipe `origins` of `toResourceRules` through our `Origin` data-helper (like we do for other rules), which would have backfilled a missing KRI to construct a link to the policy the rule is originated from.