### PR TITLE
fix(zone-proxies): parsing response of clusters stats tarball

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -160,7 +160,7 @@
                               show-icon
                             >
                               <XI18n
-                                t="data-planes.routes.item.download.error"
+                                path="data-planes.routes.item.download.error"
                               />
                             </XAlert>
                           </template>

--- a/packages/kuma-gui/src/app/zone-egresses/sources.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/sources.ts
@@ -101,7 +101,6 @@ export const sources = (api: KumaApi) => {
           case 'xds':
             prev.push(async () => {
               const res = await http.GET('/zoneegresses/{name}/xds', {
-                parseAs: 'text',
                 params: {
                   path: {
                     name,

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -171,7 +171,7 @@
                                 show-icon
                               >
                                 <XI18n
-                                  t="zone-egresses.routes.item.download.error"
+                                  path="zone-egresses.routes.item.download.error"
                                 />
                               </XAlert>
                             </template>

--- a/packages/kuma-gui/src/app/zone-ingresses/sources.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/sources.ts
@@ -102,7 +102,6 @@ export const sources = (api: KumaApi) => {
       }).reduce((prev, [key]) => {
         switch (key) {
           case 'proxy':
-
             prev.push(async () => {
               const res = await http.GET('/zone-ingresses/{name}', {
                 params: {
@@ -154,6 +153,7 @@ export const sources = (api: KumaApi) => {
           case 'clusters':
             prev.push(async () => {
               const res = await http.GET('/zoneingresses/{name}/clusters', {
+                parseAs: 'text',
                 params: {
                   path: {
                     name,

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -168,7 +168,7 @@
                                 show-icon
                               >
                                 <XI18n
-                                  t="zone-ingresses.routes.item.download.error"
+                                  path="zone-ingresses.routes.item.download.error"
                                 />
                               </XAlert>
                             </template>


### PR DESCRIPTION
Two things here, while the most important one is that incorrect parsing of clusters response when trying to download the tarball of stats.

1. When using `openapi-fetch`, keeping the default parsing strategy `parseAs: 'json'` and the response is streamed (no `Content-Length`), the response is being parsed as text, but then fed into `JSON.parse` to create a JSON object. If the `Content-Type` of the response is actually `text/plain` this causes an error. Therefore we've added `parseAs: 'text'` to the places where we expect plain text as a response, but we've missed that one case for `/clusters` stats
2. I've noticed that we don't show an error text when this happens and realized that the prop on `XI18n` was incorrect `t` and should be `path`

Generally I've aligned all the `/<type>/:name/as/tarball/:spec` sources as there also one case in `zone-egresses` that had `parseAs: 'text'` on `xds`, which returns JSON.