### PR TITLE
feat(resources): add top-level control plane resources tab

### DIFF
--- a/packages/kuma-gui/features/application/MainNavigation.feature
+++ b/packages/kuma-gui/features/application/MainNavigation.feature
@@ -2,13 +2,14 @@ Feature: application / MainNavigation
 
   Background:
     Given the CSS selectors
-      | Alias              | Selector                                   |
-      | main-nav           | .app-sidebar                               |
-      | control-planes-nav | [data-testid='control-planes-navigator'] a |
-      | meshes-nav         | [data-testid='meshes-navigator'] a         |
-      | zones-nav          | [data-testid='zones-navigator'] a          |
-      | zone-egresses-nav  | [data-testid='zone-egresses-navigator'] a  |
-      | configuration-nav  | [data-testid='configuration-navigator'] a  |
+      | Alias              | Selector                                            |
+      | main-nav           | .app-sidebar                                        |
+      | control-planes-nav | [data-testid='control-planes-navigator'] a          |
+      | meshes-nav         | [data-testid='meshes-navigator'] a                  |
+      | zones-nav          | [data-testid='zones-navigator'] a                   |
+      | zone-egresses-nav  | [data-testid='zone-egresses-navigator'] a           |
+      | resources-nav      | [data-testid='control-plane-resources-navigator'] a |
+      | configuration-nav  | [data-testid='configuration-navigator'] a           |
 
   Scenario Outline: The navigation shows <Element> exists for <Mode>
     Given the environment
@@ -22,6 +23,8 @@ Feature: application / MainNavigation
       | Element            | Mode   |
       | $zones-nav         | global |
       | $zone-egresses-nav | zone   |
+      | $resources-nav     | global |
+      | $resources-nav     | zone   |
 
   Scenario Outline: The navigation shows <Element> doesn't exist for <Mode>
     Given the environment
@@ -54,6 +57,7 @@ Feature: application / MainNavigation
       | Selector            | Title               |
       | $control-planes-nav | Overview            |
       | $zones-nav          | Zone control planes |
+      | $resources-nav      | Resources           |
       | $configuration-nav  | Configuration       |
 
   Scenario: Pagination deeplinking

--- a/packages/kuma-gui/features/application/Titles.feature
+++ b/packages/kuma-gui/features/application/Titles.feature
@@ -44,6 +44,8 @@ Feature: application / titles
       | /meshes/default/workloads/kri_wl_default_z1_ns1_workload-1_/overview                              | workload-1                |
       | /hostname-generators                                                                              | HostnameGenerators        |
       | /hostname-generators/kri_hg____hg-name_/overview                                                  | hg-name                   |
+      | /resources/hg                                                                                     | Resources                 |
+      | /resources/kri_hg____hg-name_/overview                                                            | hg-name                   |
 
   Scenario Outline: Visiting the "<Title>" page in "zone" Mode
     Given the environment

--- a/packages/kuma-gui/features/control-planes/resources/Index.feature
+++ b/packages/kuma-gui/features/control-planes/resources/Index.feature
@@ -1,0 +1,156 @@
+Feature: control-planes / resources / index
+
+  Background:
+    Given the CSS selectors
+      | Alias                   | Selector                                                                                 |
+      | resources-nav           | [data-testid='control-plane-resources-navigator'] a                                      |
+      | type-hostname-generator | [data-testid='resource-type-link-HostnameGenerator']                                     |
+      | type-mesh               | [data-testid='resource-type-link-Mesh']                                                  |
+      | type-zone               | [data-testid='resource-type-link-Zone']                                                  |
+      | type-mesh-access-log    | [data-testid='resource-type-link-MeshAccessLog']                                         |
+      | items                   | [data-testid='control-plane-resource-list-view']                                         |
+      | items-header            | $items th                                                                                |
+      | item                    | $items tbody tr                                                                          |
+      | action                  | $item:first-child [data-action]                                                          |
+      | action-group            | $item:first-child [data-testid='x-action-group-control']                                 |
+      | view                    | $item:first-child [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | button-docs             | [data-testid='policy-documentation-link']                                                |
+      | input-search            | [data-testid='filter-bar-filter-input']                                                  |
+      | summary                 | [data-testid='summary']                                                                  |
+      | summary-title           | $summary [data-testid='slideout-title']                                                  |
+      | state-empty             | [data-testid='empty-block']                                                              |
+      | state-error             | [data-testid='x-error-state']                                                            |
+    And the environment
+      """
+      KUMA_MODE: global
+      """
+    And the URL "/hostnamegenerators" responds with
+      """
+      body:
+        items:
+          - name: resource-1.kuma-system
+            kri: kri_hg__zone-1_kuma-system_resource-1_
+            labels:
+              kuma.io/display-name: resource-1
+              k8s.kuma.io/namespace: kuma-system
+              kuma.io/origin: zone
+              kuma.io/zone: zone-1
+          - name: resource-2.kuma-system
+            kri: kri_hg__zone-2_kuma-system_resource-2_
+            labels:
+              kuma.io/display-name: resource-2
+              k8s.kuma.io/namespace: kuma-system
+              kuma.io/origin: zone
+              kuma.io/zone: zone-2
+      """
+
+  Scenario: Clicking the sidebar tab opens the resources listing
+    When I visit the "/" URL
+    And I click the "$resources-nav" element
+    Then the page title contains "Resources"
+    And the "$type-hostname-generator" element exists
+
+  Scenario: The tab lists global-scoped resource types
+    When I visit the "/resources" URL
+    Then the "$type-hostname-generator" element exists
+    And the "$type-mesh" element exists
+    And the "$type-zone" element exists
+
+  Scenario: Mesh-scoped resource types are not listed in the tab
+    When I visit the "/resources" URL
+    Then the "$type-hostname-generator" element exists but the "$type-mesh-access-log" element doesn't exist
+
+  Scenario: The first resource type is selected when none is given
+    When I visit the "/resources" URL
+    Then the URL contains "/resources/hg"
+    And the "$items" element exists
+
+  Scenario: Listing has expected content
+    When I visit the "/resources/hg" URL
+    Then the "$button-docs" element exists
+    And the "$items-header" element exists 4 times
+    And the "$item:nth-child(1)" element contains
+      | Value       |
+      | resource-1  |
+      | kuma-system |
+      | zone-1      |
+    And the "$item:nth-child(2)" element contains
+      | Value       |
+      | resource-2  |
+      | kuma-system |
+      | zone-2      |
+
+  Scenario: Selecting a different resource type lists that type
+    Given the environment
+      """
+      KUMA_MESH_COUNT: 2
+      """
+    And the URL "/meshes" responds with
+      """
+      body:
+        items:
+          - name: mesh-1
+            kri: kri_m____mesh-1_
+          - name: mesh-2
+            kri: kri_m____mesh-2_
+      """
+    When I visit the "/resources" URL
+    And I click the "$type-mesh" element
+    Then the URL contains "/resources/m"
+    And the "$item" element exists 2 times
+    And the "$item:nth-child(1)" element contains "mesh-1"
+    And the "$item:nth-child(2)" element contains "mesh-2"
+
+  Scenario: Clicking the item name opens the summary
+    When I visit the "/resources/hg" URL
+    And I click the "$action" element
+    Then the URL contains "/resources/hg/kri_hg__zone-1_kuma-system_resource-1_"
+    And the "$summary" element exists
+    And the "$summary-title" element contains "resource-1"
+
+  Scenario: Clicking the view action navigates to the detail page
+    When I visit the "/resources/hg" URL
+    And I click the "$action-group" element
+    And I click the "$view" element
+    Then the URL contains "kri_hg__zone-1_kuma-system_resource-1_/overview"
+    And the URL doesn't contain "/resources/hg/kri_hg__zone-1_kuma-system_resource-1_"
+
+  Scenario: Sending filters to the API
+    When I visit the "/resources/hg" URL
+    Then the "$input-search" element exists
+    When I "type" "my-resource namespace:kuma-demo zone:zone-1" into the "$input-search" element
+    And I "type" "{enter}" into the "$input-search" element
+    Then the URL "/hostnamegenerators" was requested with
+      """
+      searchParams:
+        name: my-resource
+        filter[labels.k8s.kuma.io/namespace]: kuma-demo
+        filter[labels.kuma.io/zone]: zone-1
+        offset: 0
+        size: 50
+      """
+
+  Scenario: Having no resources of a type shows the empty state
+    Given the URL "/hostnamegenerators" responds with
+      """
+      body:
+        total: 0
+        items: !!js/undefined
+        next: !!js/undefined
+      """
+    When I visit the "/resources/hg" URL
+    Then the "$state-empty" element exists
+
+  Scenario: Erroring shows an error state
+    Given the URL "/hostnamegenerators" responds with
+      """
+      headers:
+        Status-Code: '500'
+      """
+    When I visit the "/resources/hg" URL
+    Then the "$state-error" element exists
+
+  Scenario: An unknown resource type falls back to the first resource type
+    When I visit the "/resources/not-a-short-name" URL
+    Then the URL contains "/resources/hg"
+    And the "$item:nth-child(1)" element contains "resource-1"

--- a/packages/kuma-gui/features/control-planes/resources/Item.feature
+++ b/packages/kuma-gui/features/control-planes/resources/Item.feature
@@ -1,0 +1,43 @@
+Feature: control-planes / resources / item
+
+  Background:
+    Given the CSS selectors
+      | Alias       | Selector                                 |
+      | breadcrumbs | .k-breadcrumbs                           |
+      | about       | [data-testid='about-resource']           |
+      | config      | [data-testid='codeblock-yaml-universal'] |
+      | config-k8s  | [data-testid='codeblock-yaml-k8s']       |
+    And the environment
+      """
+      KUMA_MODE: global
+      """
+    And the URL "/_kri/kri_hg__zone-1_kuma-system_resource-1_" responds with
+      """
+      body:
+        name: resource-1
+        labels:
+          kuma.io/display-name: resource-1
+          k8s.kuma.io/namespace: kuma-system
+          kuma.io/origin: zone
+          kuma.io/zone: zone-1
+      """
+
+  Scenario: Shows expected content
+    When I visit the "/resources/kri_hg__zone-1_kuma-system_resource-1_/overview" URL
+    Then the page title contains "resource-1"
+    And the "$about" element exists
+    And the "$about" element contains
+      | Value       |
+      | zone-1      |
+      | kuma-system |
+    And the "$config" element exists
+
+  Scenario: The breadcrumb links back to the resource type listing
+    When I visit the "/resources/kri_hg__zone-1_kuma-system_resource-1_/overview" URL
+    Then the "$breadcrumbs" element contains "Resources"
+    When I click the "$breadcrumbs a" element
+    Then the URL contains "/resources/hg"
+
+  Scenario: Deeplinking the kubernetes format shows the kubernetes configuration
+    When I visit the "/resources/kri_hg__zone-1_kuma-system_resource-1_/overview?environment=k8s" URL
+    Then the "$config-k8s" element exists but the "$config" element doesn't exist

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -67,6 +67,20 @@
                 name: 'mesh-index-view',
               }"
             />
+            <AppNavigator
+              v-icon-start="`policy`"
+              data-testid="control-plane-resources-navigator"
+              :active="
+                [
+                  'control-plane-resource-type-list-view',
+                  'control-plane-resource-detail-view',
+                  'hostname-generator-root-view',
+                ].includes(child.name)"
+              label="Resources"
+              :to="{
+                name: 'control-plane-resource-type-list-view',
+              }"
+            />
           </template>
 
           <template #bottomNavigation>

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneActionGroup.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneActionGroup.vue
@@ -8,9 +8,6 @@
         {{ t("main-overview.action_menu.toggle_button") }}
       </XAction>
     </template>
-    <XAction :to="{ name: 'hostname-generator-root-view' }">
-      {{ t("main-overview.action_menu.items.hostname_generators") }}
-    </XAction>
 
     <slot name="actions" />
   </XActionGroup>

--- a/packages/kuma-gui/src/app/control-planes/index.ts
+++ b/packages/kuma-gui/src/app/control-planes/index.ts
@@ -2,11 +2,12 @@ import { token, createInjections } from '@kumahq/container'
 
 import { features } from './features'
 import locales from './locales/en-us/index.yaml'
-import { routes } from './routes'
+import { controlPlaneResourcesRoutes, routes } from './routes'
 import { sources } from './sources'
 import ControlPlaneActionGroup from '@/app/control-planes/components/ControlPlaneActionGroup.vue'
 import ControlPlaneStatus from '@/app/control-planes/components/ControlPlaneStatus.vue'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -46,6 +47,20 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: routes,
       labels: [
         app.routes,
+      ],
+    }],
+    [token('control-planes.routes.walkers'), {
+      service: () => {
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'control-plane-root-view') {
+              item.children = (item.children ?? []).concat(controlPlaneResourcesRoutes())
+            }
+          },
+        ]
+      },
+      labels: [
+        app.routeWalkers,
       ],
     }],
     [token('control-planes.features'), {

--- a/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
@@ -26,5 +26,3 @@ main-overview:
       title: 'Meshes'
   action_menu:
     toggle_button: 'Actions'
-    items:
-      hostname_generators: HostnameGenerators

--- a/packages/kuma-gui/src/app/control-planes/routes.ts
+++ b/packages/kuma-gui/src/app/control-planes/routes.ts
@@ -1,4 +1,6 @@
+import { routes as resourcesRoutes } from '@/app/resources/routes'
 import type { RouteRecordRaw } from 'vue-router'
+
 export const routes = (): RouteRecordRaw[] => {
   return [
     {
@@ -14,5 +16,18 @@ export const routes = (): RouteRecordRaw[] => {
         },
       ],
     },
+  ]
+}
+
+export const controlPlaneResourcesRoutes = () => {
+  const cpResourcesRoutes = resourcesRoutes('control-plane')
+  return [
+    {
+      name: 'control-plane-resource-type-list-view',
+      path: 'resources',
+      component: () => import('@/app/control-planes/views/ControlPlaneResourceTypeListView.vue'),
+      children: cpResourcesRoutes.items()[0].children,
+    },
+    ...cpResourcesRoutes.item(),
   ]
 }

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -11,6 +11,7 @@
           />
         </h1>
       </template>
+
       <template #actions>
         <ControlPlaneActionGroup />
       </template>

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneResourceTypeListView.vue
@@ -1,0 +1,139 @@
+<template>
+  <RouteView
+    name="control-plane-resource-type-list-view"
+    :params="{
+      shortName: '',
+    }"
+    v-slot="{ uri, route, t }"
+  >
+    <AppView>
+      <template #title>
+        <h1>
+          <RouteTitle
+            :title="t('resources.routes.items.title')"
+          />
+        </h1>
+      </template>
+      <DataSource
+        :src="uri(sources, '/resource-type-descriptors', {})"
+        v-slot="{ data: sourceResources, error: resourcesError }"
+      >
+        <DataSource
+          :src="uri(controlPlanesSources, '/global-insight', {})"
+          v-slot="{ data: sourceGlobalInsight, error: globalInsightError }"
+        >
+          <XLayout
+            variant="x-stack"
+            size="large"
+          >
+            <XCard class="resource-type-collection">
+              <DataLoader
+                :data="[sourceResources, sourceGlobalInsight]"
+                :errors="[resourcesError, globalInsightError]"
+                v-slot="{ data: [resources, globalInsight] }"
+              >
+                <XLayout
+                  v-for="filtered in [resources.resources.filter((item) =>
+                    item.group === 'global' && item.shortName.length > 0,
+                  )]"
+                  :key="typeof filtered"
+                  variant="y-stack"
+                >
+                  <DataCollection
+                    :items="filtered"
+                  >
+                    <template #default="{ items }">
+                      <ul>
+                        <li
+                          v-for="(item, j) in items"
+                          :key="item.name"
+                          :class="{
+                            'active': item.shortName === route.params.shortName,
+                          }"
+                        >
+                          <XAction
+                            :to="{
+                              name: 'control-plane-resource-list-view',
+                              params: {
+                                shortName: item.shortName,
+                              },
+                            }"
+                            :data-testid="`resource-type-link-${item.name}`"
+                            @vue:mounted="(vNode) => {
+                              if((route.params.shortName.length === 0 || !resources.resources.find((resource) => resource.shortName === route.params.shortName)) && j === 0 && vNode.props?.to) {
+                                $nextTick(() => {
+                                  route.replace(vNode.props!.to)
+                                })
+                              }
+                            }"
+                          >
+                            <XLayout
+                              variant="x-stack"
+                              justify="between"
+                            >
+                              <span>
+                                {{ item.name }}
+                              </span>
+                              <span>
+                                {{ get(globalInsight, item.insightPath)?.total ?? 0 }}
+                              </span>
+                            </XLayout>
+                          </XAction>
+                        </li>
+                      </ul>
+                    </template>
+                  </DataCollection>
+                </XLayout>
+              </DataLoader>
+            </XCard>
+            <div v-if="route.params.shortName.length > 0">
+              <RouterView v-slot="{ Component }">
+                <component
+                  :is="Component"
+                  :resource-types="sourceResources"
+                />
+              </RouterView>
+            </div>
+          </XLayout>
+        </DataSource>
+      </DataSource>
+    </AppView>
+  </RouteView>
+</template>
+
+<script setup lang="ts">
+import { get } from '@/app/application'
+import { sources as controlPlanesSources } from '@/app/control-planes/sources'
+import { sources } from '@/app/resources/sources'
+</script>
+<style lang="scss" scoped>
+.resource-type-collection {
+  max-width: 500px;
+  align-self: flex-start;
+
+  & + * {
+    flex: 1;
+  }
+}
+
+ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+li :deep(a) {
+  display: block;
+  color: var(--x-color-text-neutral);
+  padding: var(--x-space-40) var(--x-space-60);
+  text-decoration: none;
+  :hover, :focus {
+    span:first-of-type {
+      text-decoration: underline;
+    }
+  }
+}
+li.active :deep(a) {
+  background-color: var(--x-color-background-primary-weakest);
+  color: currentColor;
+}
+</style>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -89,6 +89,15 @@
                   </XCopyButton>
                 </template>
 
+                <template #zone="{ row: item }">
+                  <XAction
+                    v-if="item.zone.length > 0"
+                    :href="`kri://${Kri.toString({ shortName: 'z', name: item.zone })}`"
+                  >
+                    {{ item.zone }}
+                  </XAction>
+                </template>
+
                 <template #actions="{ row: item }">
                   <XActionGroup>
                     <XAction
@@ -133,4 +142,5 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
+import { Kri } from '@/app/kuma'
 </script>

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -166,13 +166,22 @@ const protocolHandler = (can: Can, router: Router) => {
                 },
               }
             default:
-              return {
-                name: 'resource-detail-view',
-                params: {
-                  mesh,
-                  kri,
-                },
-              }
+              // mesh-scoped resources live under a mesh, global-scoped
+              // resources are reachable via the top-level resources tab
+              return mesh.length > 0
+                ? {
+                  name: 'mesh-resource-detail-view',
+                  params: {
+                    mesh,
+                    kri,
+                  },
+                }
+                : {
+                  name: 'control-plane-resource-detail-view',
+                  params: {
+                    kri,
+                  },
+                }
           }
         })()
         if (to) {

--- a/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
@@ -55,7 +55,7 @@ meshes:
         data-plane-list-view: Data plane proxies
         policy-list-index-view: Policies
         workload-list-view: Workloads
-        resource-type-list-view: Resources
+        mesh-resource-type-list-view: Resources
       overview: 'Overview'
       about:
         title: About this mesh

--- a/packages/kuma-gui/src/app/resources/index.ts
+++ b/packages/kuma-gui/src/app/resources/index.ts
@@ -22,7 +22,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('resources.routes'), {
       service: () => {
-        const _routes = routes()
+        const _routes = routes('mesh')
         return [
           (item: RouteRecordRaw) => {
             if (item.name === 'mesh-detail-tabs-view') {

--- a/packages/kuma-gui/src/app/resources/routes.ts
+++ b/packages/kuma-gui/src/app/resources/routes.ts
@@ -1,10 +1,10 @@
 import type { RouteRecordRaw } from 'vue-router'
 
-export const routes = () => {
+export const routes = (prefix: string) => {
   const summary = (): RouteRecordRaw[] => {
     return [
       {
-        name: 'resource-summary-view',
+        name: `${prefix}-resource-summary-view`,
         path: ':kri',
         component: () => import('@/app/resources/views/ResourceSummaryView.vue'),
       },
@@ -14,8 +14,11 @@ export const routes = () => {
   const item = (): RouteRecordRaw[] => {
     return [
       {
-        name: 'resource-detail-view',
+        name: `${prefix}-resource-detail-view`,
         path: 'resources/:kri/overview',
+        props: {
+          routePrefix: prefix,
+        },
         component: () => import('@/app/resources/views/ResourceDetailView.vue'),
       },
     ]
@@ -25,13 +28,19 @@ export const routes = () => {
     items: (): RouteRecordRaw[] => {
       return [
         {
-          name: 'resource-type-list-view',
+          name: `${prefix}-resource-type-list-view`,
           path: 'resources',
+          props: {
+            routePrefix: prefix,
+          },
           component: () => import('@/app/resources/views/ResourceTypeListView.vue'),
           children: [
             {
-              name: 'resource-list-view',
+              name: `${prefix}-resource-list-view`,
               path: ':shortName',
+              props: {
+                routePrefix: prefix,
+              },
               component: () => import('@/app/resources/views/ResourceListView.vue'),
               children: [
                 ...summary(),

--- a/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="resource-detail-view"
+    :name="props.routeName"
     :params="{
       mesh: '',
       kri: '',
@@ -30,7 +30,7 @@
           ] : []),
           {
             to: {
-              name: 'resource-list-view',
+              name: `${props.routePrefix}-resource-list-view`,
               params: {
                 mesh: route.params.mesh,
                 shortName: Kri.fromString(route.params.kri).shortName,
@@ -199,4 +199,8 @@
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
 import { Kri } from '@/app/kuma'
+const props = defineProps<{
+  routeName: string
+  routePrefix: string
+}>()
 </script>

--- a/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceListView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="resource-list-view"
+    :name="props.routeName"
     :params="{
       page: 1,
       size: Number,
@@ -143,7 +143,7 @@
                       <XAction
                         data-action
                         :to="{
-                          name: 'resource-summary-view',
+                          name: `${props.routePrefix}-resource-summary-view`,
                           params: {
                             kri: row.kri,
                           },
@@ -184,7 +184,7 @@
               >
                 <XDrawer
                   @close="route.replace({
-                    name: 'resource-list-view',
+                    name: props.routeName,
                     params: {
                       mesh: route.params.mesh,
                       shortName: route.params.shortName,
@@ -219,6 +219,8 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import { Kri } from '@/app/kuma'
 const DataEmptyState = useDataEmptyState()
 const props = defineProps<{
+  routeName: string
+  routePrefix: string
   resourceTypes?: ResourceTypeDescriptorCollection
 }>()
 </script>

--- a/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
+++ b/packages/kuma-gui/src/app/resources/views/ResourceTypeListView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="resource-type-list-view"
+    :name="props.routeName"
     :params="{
       mesh: '',
       shortName: '',
@@ -102,7 +102,7 @@
                                   >
                                     <XAction
                                       :to="{
-                                        name: 'resource-list-view',
+                                        name: `${props.routePrefix}-resource-list-view`,
                                         params: {
                                           mesh: route.params.mesh,
                                           shortName: item.shortName,
@@ -164,6 +164,10 @@ import { get } from '@/app/application'
 import { sources as controlPlanesSources } from '@/app/control-planes/sources'
 import { sources as meshesSources } from '@/app/meshes/sources'
 import { sources } from '@/app/resources/sources'
+const props = defineProps<{
+  routeName: string
+  routePrefix: string
+}>()
 </script>
 <style lang="scss" scoped>
 .resource-type-collection {

--- a/packages/kuma-http-api/mocks/FakeKuma.ts
+++ b/packages/kuma-http-api/mocks/FakeKuma.ts
@@ -519,6 +519,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       'MeshMultiZoneService',
       'MeshService',
       'Secret',
+      'HostnameGenerator',
     ] as const
     const items = [...resources, ...this.policyNames({ min: Number.MAX_SAFE_INTEGER })]
 
@@ -555,6 +556,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       ['Workload', 'wl'],
       ['ZoneEgress', 'ze'],
       ['ZoneIngress', 'zi'],
+      ['Zone', 'z'],
     ])
     return resourceNames.get(resourceName ?? this.faker.helpers.arrayElement([...resourceNames.keys()])) ?? ''
   }

--- a/packages/kuma-http-api/mocks/src/_resources.ts
+++ b/packages/kuma-http-api/mocks/src/_resources.ts
@@ -679,7 +679,7 @@ function getResources(): Resources['resources'] {
       'pluralDisplayName': 'Zones',
       'readOnly': false,
       'scope': 'Global',
-      'shortName': '',
+      'shortName': 'z',
       'singularDisplayName': 'Zone',
     },
     {

--- a/packages/kuma-http-api/mocks/src/meshes.ts
+++ b/packages/kuma-http-api/mocks/src/meshes.ts
@@ -18,6 +18,7 @@ export default ({ fake, env, pager }: Dependencies): ResponseHandler => (req) =>
           type: 'Mesh',
           creationTime: '2020-06-19T12:18:02.097986-04:00',
           modificationTime: '2020-06-19T12:18:02.097986-04:00',
+          kri: fake.kuma.kri({ resourceName: 'Mesh', zone: '', mesh: '', namespace: '', name, sectionName: '' }),
           ...(fake.datatype.boolean() && {
             mtls: {
               enabledBackend: 'ca-1',


### PR DESCRIPTION
Add a top-level "Resources" tab that lists global-scoped resources (Hostname Generators, Meshes, Zones, Ingresses/Egresses). It is an extra, mostly duplicated view `ControlPlaneResourceTypeListView` rendered at the root under `'control-plane-root-view'` and for the other views references the views of the resources module. The mesh-scoped resource views and routes are left unchanged. The tab shows only global resources and has no page/group header since it is already scoped to the global level.
The `protocolHandler` has been modified at the default case to check wether there is a `mesh` in the KRI and depending on that param being present either routes to the generic `ResourceDetailView` on the global or mesh level.

The `HostnameGenerators` link is removed from the control plane overview action menu. `HostnameGenerators` are now reachable via the new tab.

Closes #5101

---

Partially generated via LLM
