### PR TITLE
feat(control-planes): disable empty control-plane-action-group

### DIFF
--- a/packages/kuma-gui/src/app/control-planes/index.ts
+++ b/packages/kuma-gui/src/app/control-planes/index.ts
@@ -40,7 +40,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [$.ControlPlaneActionGroup, {
       service: () => {
-        return ControlPlaneActionGroup
+        return undefined
       },
     }],
     [token('control-planes.routes'), {


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/5187 I disabled the injectable `ControlPlaneActionGroup` component, but somehow it sneaked back in, probably after I tested something. We don't need it to be present here anymore but we decorate it elsewhere and probably we will need it here again.