### PR TITLE
fix(services/service-list-tabs-view): with legacy-services all routes always present

### DIFF
--- a/packages/kuma-gui/src/app/legacy-services/components/ServiceListTabsActionGroup.vue
+++ b/packages/kuma-gui/src/app/legacy-services/components/ServiceListTabsActionGroup.vue
@@ -1,0 +1,57 @@
+<template>
+  <XLayout
+    variant="action-group"
+  >
+    <XActionGroup
+      :expanded="true"
+    >
+      <template
+        v-for="{ name } in (!can('use service-insights', props.mesh) ? route.children.filter(({ name }) => !['service-list-view', 'external-service-list-view'].includes(name)) : route.children)"
+        :key="name"
+      >
+        <XAction
+          :class="{
+            'active': route.child()?.name === name,
+          }"
+          :to="{
+            name,
+            params: {
+              mesh: props.mesh.id,
+            },
+          }"
+          :data-testid="`${name}-sub-tab`"
+        >
+          {{ t(`services.routes.items.navigation.${name}.label`) }}
+        </XAction>
+      </template>
+    </XActionGroup>
+  </XLayout>
+</template>
+
+<script setup lang="ts">
+
+import { watch } from 'vue'
+import { useRouter, type RouteRecordRaw } from 'vue-router'
+
+import { useCan, useI18n } from '@/app/application'
+import type { Mesh } from '@/app/meshes/data'
+
+type StringNamedRouteRecordRaw = RouteRecordRaw & {
+  name: string
+}
+
+const { t } = useI18n()
+const can = useCan()
+const router = useRouter()
+
+const props = defineProps<{
+  mesh: Mesh
+  route: { children: StringNamedRouteRecordRaw[], child: () => StringNamedRouteRecordRaw | undefined }
+}>()
+
+watch(() => router.currentRoute.value.name, (val) => {
+  if (val === 'service-list-tabs-view') {
+    can('use service-insights', props.mesh) ? router.replace({ name: 'service-list-view' }) : router.replace({ name: 'mesh-service-list-view' })
+  }
+}, { immediate: true })
+</script>

--- a/packages/kuma-gui/src/app/legacy-services/index.ts
+++ b/packages/kuma-gui/src/app/legacy-services/index.ts
@@ -1,5 +1,6 @@
 import { token } from '@kumahq/container'
 
+import ServiceListTabsActionGroup from './components/ServiceListTabsActionGroup.vue'
 import { features } from './features'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
@@ -68,6 +69,11 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       labels: [
         app.dataPlaneServiceLinks,
       ],
+    }],
+
+    [token<typeof ServiceListTabsActionGroup>('legacy-services.service-list-tabs-action-group'), {
+      service: () => ServiceListTabsActionGroup,
+      decorates: app.serviceListTabsActionGroup,
     }],
   ]
 }

--- a/packages/kuma-gui/src/app/services/components/ServiceListTabsActionGroup.vue
+++ b/packages/kuma-gui/src/app/services/components/ServiceListTabsActionGroup.vue
@@ -1,0 +1,56 @@
+<template>
+  <XLayout
+    variant="action-group"
+  >
+    <XActionGroup
+      :expanded="true"
+    >
+      <template
+        v-for="{ name } in route.children"
+        :key="name"
+      >
+        <XAction
+          :class="{
+            'active': route.child()?.name === name,
+          }"
+          :to="{
+            name,
+            params: {
+              mesh: props.mesh.id,
+            },
+          }"
+          :data-testid="`${name}-sub-tab`"
+        >
+          {{ t(`services.routes.items.navigation.${name}.label`) }}
+        </XAction>
+      </template>
+    </XActionGroup>
+  </XLayout>
+</template>
+
+<script setup lang="ts">
+
+import { watch } from 'vue'
+import { useRouter, type RouteRecordRaw } from 'vue-router'
+
+import { useI18n } from '@/app/application'
+import type { Mesh } from '@/app/meshes/data'
+
+type StringNamedRouteRecordRaw = RouteRecordRaw & {
+  name: string
+}
+
+const { t } = useI18n()
+const router = useRouter()
+
+const props = defineProps<{
+  mesh: Mesh
+  route: { children: StringNamedRouteRecordRaw[], child: () => StringNamedRouteRecordRaw | undefined }
+}>()
+
+watch(() => router.currentRoute.value.name, (val) => {
+  if (val === 'service-list-tabs-view') {
+    router.replace({ name: 'mesh-service-list-view' })
+  }
+}, { immediate: true })
+</script>

--- a/packages/kuma-gui/src/app/services/index.ts
+++ b/packages/kuma-gui/src/app/services/index.ts
@@ -1,5 +1,6 @@
-import { token } from '@kumahq/container'
+import { createInjections, token } from '@kumahq/container'
 
+import ServiceListTabsActionGroup from './components/ServiceListTabsActionGroup.vue'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
@@ -8,6 +9,10 @@ import type { ServiceDefinition } from '@kumahq/container'
 import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
+
+const $ = {
+  serviceListTabsActionGroup: token<typeof ServiceListTabsActionGroup>('services.service-list-tabs-action-group'),
+}
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
@@ -48,5 +53,15 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
     }],
 
+    [$.serviceListTabsActionGroup, {
+      service: () => ServiceListTabsActionGroup,
+    }],
   ]
 }
+
+export const TOKENS = $
+export const [
+  useServiceListTabsActionGroup,
+] = createInjections(
+  $.serviceListTabsActionGroup,
+)

--- a/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
@@ -4,36 +4,13 @@
     :params="{
       mesh: '',
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route }"
   >
     <AppView>
-      <XLayout
-        variant="action-group"
-      >
-        <XActionGroup
-          :expanded="true"
-        >
-          <template
-            v-for="{ name } in route.children"
-            :key="name"
-          >
-            <XAction
-              :class="{
-                'active': route.child()?.name === name,
-              }"
-              :to="{
-                name,
-                params: {
-                  mesh: route.params.mesh,
-                },
-              }"
-              :data-testid="`${name}-sub-tab`"
-            >
-              {{ t(`services.routes.items.navigation.${name}.label`) }}
-            </XAction>
-          </template>
-        </XActionGroup>
-      </XLayout>
+      <ServiceListTabsActionGroup
+        :route="route"
+        :mesh="props.mesh"
+      />
 
       <XI18n
         :path="`services.routes.items.navigation.${route.child()?.name}.description`"
@@ -52,18 +29,10 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
-import { watch } from 'vue'
-import { useRouter } from 'vue-router'
-
+import { useServiceListTabsActionGroup } from '..'
 import type { Mesh } from '@/app/meshes/data'
 const props = defineProps<{
   mesh: Mesh
 }>()
-
-const router = useRouter()
-watch(() => router.currentRoute.value.name, (val) => {
-  if (val === 'service-list-tabs-view') {
-    router.replace({ name: 'mesh-service-list-view' })
-  }
-}, { immediate: true })
+const ServiceListTabsActionGroup = useServiceListTabsActionGroup()
 </script>

--- a/packages/kuma-gui/src/main.ts
+++ b/packages/kuma-gui/src/main.ts
@@ -2,6 +2,7 @@
 import './assets/styles/main.scss'
 
 import { createBuilder } from '@kumahq/container'
+import { nanoEnv } from '@kumahq/settings/env'
 import { createApp } from 'vue'
 
 import { services as application, TOKENS as APPLICATION } from '@/app/application'
@@ -11,6 +12,7 @@ import { services as dataplanes, TOKENS as DATAPLANES } from '@/app/data-planes'
 import { services as gateways } from '@/app/gateways'
 import { services as hostnameGenerators } from '@/app/hostname-generators'
 import { services as kuma, TOKENS as KUMA } from '@/app/kuma'
+import { vars } from '@/app/kuma/env'
 import { services as legacyDataplanes } from '@/app/legacy-data-planes'
 import { services as me } from '@/app/me'
 import { services as meshIdentities } from '@/app/mesh-identities'
@@ -19,7 +21,7 @@ import { services as meshes } from '@/app/meshes'
 import { services as policies } from '@/app/policies'
 import { services as resources } from '@/app/resources'
 import { services as rules } from '@/app/rules'
-import { services as services } from '@/app/services'
+import { services as services, TOKENS as SERVICES } from '@/app/services'
 import { services as vue, TOKENS as VUE } from '@/app/vue'
 import { services as workloads } from '@/app/workloads'
 import { services as zoneEgresses } from '@/app/zone-egresses'
@@ -31,7 +33,10 @@ async function mountVueApplication() {
     ...VUE,
     ...APPLICATION,
     ...KUMA,
+    ...SERVICES,
   }
+  
+  const env = nanoEnv(vars, () => JSON.parse(document.querySelector('#kuma-config')?.textContent || '{}'))
 
   const { build, injectionKey } = createBuilder()
   const get = build(
@@ -58,6 +63,12 @@ async function mountVueApplication() {
     rules($),
     meshIdentities($),
     meshTrusts($),
+
+    // any services depending on env
+    env('KUMA_LEGACY_SERVICES_ENABLED') === 'true' ? await (async () => {
+      const legacyServices = await import('@/app/legacy-services')
+      return legacyServices.services({ ...$, ...DATAPLANES })
+    })() : [],
     //
 
     // any DEV-time only service container configuration
@@ -93,16 +104,6 @@ async function mountVueApplication() {
     await get(msw.TOKENS.msw)
   }
 
-  // The legacy services module is opt-in. It is conditionally lazy loaded and
-  // registered with the container when `KUMA_LEGACY_SERVICES_ENABLED` is enabled
-  // We can only make this decision once the container exists, because `env`, like every other
-  // service, lives in the container. Resolving `$.env` after the initial build.
-  // A second build registers the module into the same container
-  // before routes/sources are resolved at mount time.
-  if (get($.env)('KUMA_LEGACY_SERVICES_ENABLED') === 'true') {
-    const { services: legacyServices } = await import('@/app/legacy-services')
-    build(legacyServices({ ...$, ...DATAPLANES }))
-  }
   const app = createApp((await import('./app/App.vue')).default)
   app.provide(injectionKey, get)
   ;(await get($.app)(app)).mount('#app')

--- a/packages/settings/src/env/index.ts
+++ b/packages/settings/src/env/index.ts
@@ -8,7 +8,7 @@ export type VariableSpec<T extends Record<string, unknown>> = {
   ) => any
 }
 
-export default <T extends Record<string, unknown>>(vars: VariableSpec<T>) => {
+const createEnv = <T extends Record<string, unknown>>(vars: VariableSpec<T>) => {
   const env = (...args: Variables<T>): string => {
     const [str, d = ''] = args
     const getter = vars[str]
@@ -18,4 +18,65 @@ export default <T extends Record<string, unknown>>(vars: VariableSpec<T>) => {
     return String(d)
   }
   return env
+}
+export default createEnv
+
+/* copy/pasta-ble containers */
+declare const typeSymbol: unique symbol
+export type Uri<T = unknown> = { [typeSymbol]: T }
+export type TypeOf<T> = T extends Uri<infer UriType> ? UriType : never
+
+/* nano-container */
+export const nano = (map = new Map<Uri, unknown>()) => {
+  type Service<T> = () => TypeOf<T>
+  const uri = <T>(str: string): Uri<T> => Symbol.for(str) as symbol & Uri<T>
+  const singleton = <T extends Uri>(uri: T, value: Service<T> | undefined) => () => {
+    if (typeof value !== 'undefined' && !map.has(uri)) {
+      map.set(uri, value())
+    }
+    return map.get(uri) as TypeOf<T>
+  }
+  return { singleton, uri }
+}
+export type Container = ReturnType<typeof nano>
+
+/**
+ * More or less the same createBuilder from the other copy/pasteables nano containers,
+ * but adds a getter to immediately retrieve a service for the purpose of exposing a
+ * nanoEnv. Generally this is agnostic and can be copy/pasted.
+ */
+export const createBuilder = (container: Container) => {
+  const { singleton, uri } = container
+  const services = new Map<Uri, () => unknown>()
+  const build = {
+    service: <T>(token: Uri<T>, getter: () => T) => {
+      services.set(token, singleton(token, getter))
+      return build
+    },
+    get: <T extends Uri>(token: T): TypeOf<T> => {
+      const service = services.get(token)
+      if (typeof service === 'undefined') {
+        throw new Error(`Unable to resolve service '${String(token)}'`)
+      }
+      return service() as TypeOf<T>
+    },
+  }
+  return { build, uri }
+}
+
+export function nanoEnv<C, T extends Record<string, unknown>>(
+  vars: (config: C) => VariableSpec<T>,
+  config: () => C,
+) {
+  const { build, uri } = createBuilder(nano())
+  const tokens = {
+    config: uri<C>('env.config'),
+    vars: uri<VariableSpec<T>>('env.vars'),
+    env: uri<(...args: Variables<T>) => string>('env.env'),
+  }
+  return build
+    .service(tokens.config, config)
+    .service(tokens.vars, () => vars(build.get(tokens.config)))
+    .service(tokens.env, () => createEnv(build.get(tokens.vars)))
+    .get(tokens.env)
 }


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/5189 I've accidentally removed a condition that would only render the legacy `internal` and `external` tabs when `can('use service-insights')` would return true, i.e. `meshServices.mode !== 'Exclusive'`. I actually wanted to make this injectable aswell, which I'm doing here now.

Adds injectable `ServiceListTabsActionGroup` in `services` and `legacy-services`.

In order to do this properly I needed to `decorate` the `$.serviceListActionGroup` token with the token in `legacy-services`. The previous injection of `legacy-services` using a second build caused that `decorates` could not act on the already built token. Therefore I went a different approach and created a `nanoEnv` container that we can use to determine `vars` during container build time.
`legacy-services` is now moved back to the one and only `build` of the main container and conditionally becomes part of the main build process.