### PR TITLE
refactor(zone-ingresses,zone-egresses): decouple from main application

### DIFF
--- a/packages/config/src/vite/plugins/server.ts
+++ b/packages/config/src/vite/plugins/server.ts
@@ -15,6 +15,8 @@ export type KumaHtmlVars = {
   storeType: string
   apiReadOnly: boolean
   legacyServicesEnabled: string
+  zoneIngressesEnabled: string
+  zoneEgressesEnabled: string
 }
 type ServerOptions = {
   template: string
@@ -61,6 +63,8 @@ export const defaultKumaHtmlVars = {
   apiReadOnly: false,
   //
   legacyServicesEnabled: 'false',
+  zoneIngressesEnabled: 'false',
+  zoneEgressesEnabled: 'false',
 }
 
 const interpolate = (template: string, vars: KumaHtmlVars) => {
@@ -118,6 +122,8 @@ const server = ({
             storeType: cookies.KUMA_STORE_TYPE,
             //
             legacyServicesEnabled: cookies.KUMA_LEGACY_SERVICES_ENABLED,
+            zoneIngressesEnabled: cookies.KUMA_ZONE_INGRESSES_ENABLED,
+            zoneEgressesEnabled: cookies.KUMA_ZONE_EGRESSES_ENABLED,
           }).filter(([_, value]) => typeof value !== 'undefined')),
           //
         } satisfies KumaHtmlVars,

--- a/packages/kuma-gui/features/application/MainNavigation.feature
+++ b/packages/kuma-gui/features/application/MainNavigation.feature
@@ -20,11 +20,10 @@ Feature: application / MainNavigation
     Then the "<Element>" element exists
 
     Examples:
-      | Element            | Mode   |
-      | $zones-nav         | global |
-      | $zone-egresses-nav | zone   |
-      | $resources-nav     | global |
-      | $resources-nav     | zone   |
+      | Element        | Mode   |
+      | $zones-nav     | global |
+      | $resources-nav | global |
+      | $resources-nav | zone   |
 
   Scenario Outline: The navigation shows <Element> doesn't exist for <Mode>
     Given the environment
@@ -37,6 +36,7 @@ Feature: application / MainNavigation
     Examples:
       | Element            | Mode   |
       | $zone-egresses-nav | global |
+      | $zone-egresses-nav | zone   |
       | $zones-nav         | zone   |
 
   Scenario Outline: Visiting the "<Title>" page

--- a/packages/kuma-gui/features/application/Titles.feature
+++ b/packages/kuma-gui/features/application/Titles.feature
@@ -14,10 +14,6 @@ Feature: application / titles
       | /configuration                                                                                    | Configuration             |
       | /zones                                                                                            | Zone control planes       |
       | /zones/kri_z____zone-cp-name_/overview                                                            | zone-cp-name              |
-      | /zones/kri_z____zone-cp-name_/ingresses                                                           | Ingresses                 |
-      | /zones/kri_z____zone-cp-name_/ingresses/kri_zi__zone-cp-name__zone-ingress-name_/overview         | zone-ingress-name         |
-      | /zones/kri_z____zone-cp-name_/egresses                                                            | Egresses                  |
-      | /zones/kri_z____zone-cp-name_/egresses/kri_ze__zone-cp-name__zone-egress-name_/overview           | zone-egress-name          |
       | /meshes                                                                                           | Meshes                    |
       | /meshes/default/overview                                                                          | Mesh overview             |
       | /meshes/default/gateways/builtin                                                                  | Built-in gateways         |
@@ -42,16 +38,3 @@ Feature: application / titles
       | /hostname-generators/kri_hg____hg-name_/overview                                                  | hg-name                   |
       | /resources/hg                                                                                     | Resources                 |
       | /resources/kri_hg____hg-name_/overview                                                            | hg-name                   |
-
-  Scenario Outline: Visiting the "<Title>" page in "zone" Mode
-    Given the environment
-      """
-      KUMA_MODE: zone
-      """
-    When I visit the "<URL>" URL
-    Then the page title contains "<Title>"
-
-    Examples:
-      | URL                                                      | Title            |
-      | /zones/egresses                                          | Egresses         |
-      | /zones/egresses/kri_ze__zone__zone-egress-name_/overview | zone-egress-name |

--- a/packages/kuma-gui/features/legacy-services/zones/zone-cps/ingresses/item/Services.feature
+++ b/packages/kuma-gui/features/legacy-services/zones/zone-cps/ingresses/item/Services.feature
@@ -9,6 +9,7 @@ Feature: legacy-services / zones / ingresses / item / service
     And the environment
       """
       KUMA_LEGACY_SERVICES_ENABLED: true
+      KUMA_ZONE_INGRESSES_ENABLED: true
       KUMA_MODE: global
       KUMA_SERVICE_COUNT: 1
       """

--- a/packages/kuma-gui/features/zone-egresses/README.md
+++ b/packages/kuma-gui/features/zone-egresses/README.md
@@ -1,0 +1,4 @@
+# features / zone-egresses
+
+The gherkin `.feature`-files located here are separated from the general folder structure. The `zone-egresses` module of the kuma-gui application is excluded from production by default and can be pulled in optionally. Therefore all the scenarios depend on the setting `KUMA_ZONE_EGRESSES_ENABLED: true` to be set.
+At some point `zone-egresses` may be removed completely without replacement.

--- a/packages/kuma-gui/features/zone-egresses/application/MainNavigation.feature
+++ b/packages/kuma-gui/features/zone-egresses/application/MainNavigation.feature
@@ -1,0 +1,37 @@
+Feature: zone-egresses / application / MainNavigation
+
+  Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
+    Given the CSS selectors
+      | Alias             | Selector                                  |
+      | meshes-nav        | [data-testid='meshes-navigator'] a        |
+      | zones-nav         | [data-testid='zones-navigator'] a         |
+      | zone-egresses-nav | [data-testid='zone-egresses-navigator'] a |
+
+  Scenario Outline: The navigation shows <Element> exists for <Mode>
+    Given the environment
+      """
+      KUMA_MODE: <Mode>
+      """
+    When I visit the "/" URL
+    Then the "<Element>" element exists
+
+    Examples:
+      | Element            | Mode   |
+      | $zones-nav         | global |
+      | $zone-egresses-nav | zone   |
+
+  Scenario Outline: The navigation shows <Element> doesn't exist for <Mode>
+    Given the environment
+      """
+      KUMA_MODE: <Mode>
+      """
+    When I visit the "/" URL
+    Then the "$meshes-nav" element exists but the "<Element>" element doesn't exist
+
+    Examples:
+      | Element            | Mode   |
+      | $zone-egresses-nav | global |

--- a/packages/kuma-gui/features/zone-egresses/application/Titles.feature
+++ b/packages/kuma-gui/features/zone-egresses/application/Titles.feature
@@ -1,0 +1,33 @@
+Feature: zone-egresses / application / titles
+
+  Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
+
+  Scenario Outline: Visiting "<URL>" page in "global" Mode
+    Given the environment
+      """
+      KUMA_MODE: global
+      """
+    When I visit the "<URL>" URL
+    Then the page title contains "<Title>"
+
+    Examples:
+      | URL                                                                                     | Title            |
+      | /zones/kri_z____zone-cp-name_/egresses                                                  | Egresses         |
+      | /zones/kri_z____zone-cp-name_/egresses/kri_ze__zone-cp-name__zone-egress-name_/overview | zone-egress-name |
+
+  Scenario Outline: Visiting the "<Title>" page in "zone" Mode
+    Given the environment
+      """
+      KUMA_MODE: zone
+      """
+    When I visit the "<URL>" URL
+    Then the page title contains "<Title>"
+
+    Examples:
+      | URL                                                      | Title            |
+      | /zones/egresses                                          | Egresses         |
+      | /zones/egresses/kri_ze__zone__zone-egress-name_/overview | zone-egress-name |

--- a/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Index.feature
+++ b/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Index.feature
@@ -1,6 +1,10 @@
 Feature: zones / egresses / index
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias | Selector                                        |
       | item  | [data-testid='zone-egress-collection'] tbody tr |

--- a/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Item.feature
+++ b/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Item.feature
@@ -1,6 +1,10 @@
 Feature: zones / egresses / item
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias              | Selector                                      |
       | page               | [data-testid='zone-egress-detail-tabs-view']  |

--- a/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Navigation.feature
+++ b/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Navigation.feature
@@ -1,6 +1,10 @@
 Feature: zones / egresses / navigation
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias         | Selector                                                                    |
       | row           | [data-testid$='-collection'] tr:first-child                                 |

--- a/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Subscriptions.feature
+++ b/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/Subscriptions.feature
@@ -1,6 +1,10 @@
 Feature: dataplanes / subscriptions
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias                            | Selector                                              |
       | about-section                    | [data-testid='about-section-content']                 |

--- a/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/ZoneEgressSummary.feature
+++ b/packages/kuma-gui/features/zone-egresses/zones/zone-cps/egresses/ZoneEgressSummary.feature
@@ -1,54 +1,60 @@
-Feature: Zone Ingress summary
+Feature: Zone Egress summary
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_EGRESSES_ENABLED: true
+      """
     Given the CSS selectors
-      | Alias                | Selector                                         |
-      | item                 | [data-testid='zone-ingress-collection'] tbody tr |
-      | summary              | [data-testid='summary']                          |
-      | close-summary-button | $summary [data-testid='slideout-close-icon']     |
-      | select-preference    | $summary [data-testid='select-input']            |
-      | structured-view      | $summary [data-testid='structured-view']         |
-    And the URL "/zone-ingresses/_overview" responds with
+      | Alias                | Selector                                        |
+      | item                 | [data-testid='zone-egress-collection'] tbody tr |
+      | summary              | [data-testid='summary']                         |
+      | close-summary-button | $summary [data-testid='slideout-close-icon']    |
+      | select-preference    | $summary [data-testid='select-input']           |
+      | structured-view      | $summary [data-testid='structured-view']        |
+    And the URL "/zoneegresses/_overview" responds with
       """
       body:
         items:
-          - name: zone-ingress-1
-            kri: kri_zi__zone-1__zone-ingress-1_
-            zoneIngress:
+          - name: zone-egress-1
+            kri: kri_ze__zone-1__zone-egress-1_
+            labels:
+              kuma.io/display-name: zone-egress-1
+            zoneEgress:
               zone: zone-1
       """
 
   Scenario: Clicking a row opens the summary
     Given the environment
       """
-      KUMA_ZONEINGRESS_COUNT: 1
+      KUMA_ZONEEGRESS_COUNT: 1
       """
-    When I visit the "/zones/kri_zi__zone-1__zone-ingress-1_/ingresses" URL
+    When I visit the "/zones/kri_z____zone-1_/egresses" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
-    And the "$summary" element contains "zone-ingress-1"
+    And the "$summary" element contains "zone-egress-1"
     When I click the "$close-summary-button" element
     Then the "$item" element exists but the "$summary" element doesn't exist
     When I navigate "back"
     Then the "$summary" element exists
-    And the "$summary" element contains "zone-ingress-1"
+    And the "$summary" element contains "zone-egress-1"
     When I navigate "forward"
     Then the "$item" element exists but the "$summary" element doesn't exist
 
-  Scenario Outline: Summary URL goes to page with open summary
+  Scenario: Summary URL goes to page with open summary
     Given the environment
       """
-      KUMA_ZONEINGRESS_COUNT: 51
+      KUMA_ZONEEGRESS_COUNT: 51
       """
-    When I visit the "/zones/kri_z____zone-1_/ingresses/kri_zi__zone-1__zone-ingress-1_?page=2&size=50" URL
+    When I visit the "/zones/kri_z____zone-1_/egresses/kri_ze__zone-1__zone-egress-1_?page=2&size=50" URL
     Then the "$summary" element exists
 
   Scenario: Switching to universal format and back
     Given the environment
       """
-      KUMA_ZONEINGRESS_COUNT: 1
+      KUMA_ZONEEGRESS_COUNT: 1
       """
-    When I visit the "/zones/kri_z____zone-1_/ingresses/kri_zi__zone-1__zone-ingress-1_" URL
+    When I visit the "/zones/kri_z____zone-1_/egresses/kri_ze__zone-1__zone-egress-1_" URL
     Then the "$select-preference" element exists
     And the "$structured-view" element exists
     When I click the "$select-preference" element

--- a/packages/kuma-gui/features/zone-ingresses/README.md
+++ b/packages/kuma-gui/features/zone-ingresses/README.md
@@ -1,0 +1,4 @@
+# features / zone-ingresses
+
+The gherkin `.feature`-files located here are separated from the general folder structure. The `zone-ingresses` module of the kuma-gui application is excluded from production by default and can be pulled in optionally. Therefore all the scenarios depend on the setting `KUMA_ZONE_INGRESSES_ENABLED: true` to be set.
+At some point `zone-ingresses` may be removed completely without replacement.

--- a/packages/kuma-gui/features/zone-ingresses/application/Titles.feature
+++ b/packages/kuma-gui/features/zone-ingresses/application/Titles.feature
@@ -1,0 +1,20 @@
+Feature: zone-ingresses / application / titles
+
+  Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
+
+  Scenario Outline: Visiting "<URL>" page in "global" Mode
+    Given the environment
+      """
+      KUMA_MODE: global
+      """
+    When I visit the "<URL>" URL
+    Then the page title contains "<Title>"
+
+    Examples:
+      | URL                                                                                       | Title             |
+      | /zones/kri_z____zone-cp-name_/ingresses                                                   | Ingresses         |
+      | /zones/kri_z____zone-cp-name_/ingresses/kri_zi__zone-cp-name__zone-ingress-name_/overview | zone-ingress-name |

--- a/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/Index.feature
+++ b/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/Index.feature
@@ -1,6 +1,10 @@
 Feature: zones / ingresses / index
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias | Selector                                         |
       | item  | [data-testid='zone-ingress-collection'] tbody tr |

--- a/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/Navigation.feature
+++ b/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/Navigation.feature
@@ -1,6 +1,10 @@
 Feature: zones / ingresses / navigation
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias         | Selector                                                                    |
       | row           | [data-testid$='-collection'] tbody tr:first-child                           |

--- a/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -1,56 +1,58 @@
-Feature: Zone Egress summary
+Feature: Zone Ingress summary
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
     Given the CSS selectors
-      | Alias                | Selector                                        |
-      | item                 | [data-testid='zone-egress-collection'] tbody tr |
-      | summary              | [data-testid='summary']                         |
-      | close-summary-button | $summary [data-testid='slideout-close-icon']    |
-      | select-preference    | $summary [data-testid='select-input']           |
-      | structured-view      | $summary [data-testid='structured-view']        |
-    And the URL "/zoneegresses/_overview" responds with
+      | Alias                | Selector                                         |
+      | item                 | [data-testid='zone-ingress-collection'] tbody tr |
+      | summary              | [data-testid='summary']                          |
+      | close-summary-button | $summary [data-testid='slideout-close-icon']     |
+      | select-preference    | $summary [data-testid='select-input']            |
+      | structured-view      | $summary [data-testid='structured-view']         |
+    And the URL "/zone-ingresses/_overview" responds with
       """
       body:
         items:
-          - name: zone-egress-1
-            kri: kri_ze__zone-1__zone-egress-1_
-            labels:
-              kuma.io/display-name: zone-egress-1
-            zoneEgress:
+          - name: zone-ingress-1
+            kri: kri_zi__zone-1__zone-ingress-1_
+            zoneIngress:
               zone: zone-1
       """
 
   Scenario: Clicking a row opens the summary
     Given the environment
       """
-      KUMA_ZONEEGRESS_COUNT: 1
+      KUMA_ZONEINGRESS_COUNT: 1
       """
-    When I visit the "/zones/kri_z____zone-1_/egresses" URL
+    When I visit the "/zones/kri_zi__zone-1__zone-ingress-1_/ingresses" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
-    And the "$summary" element contains "zone-egress-1"
+    And the "$summary" element contains "zone-ingress-1"
     When I click the "$close-summary-button" element
     Then the "$item" element exists but the "$summary" element doesn't exist
     When I navigate "back"
     Then the "$summary" element exists
-    And the "$summary" element contains "zone-egress-1"
+    And the "$summary" element contains "zone-ingress-1"
     When I navigate "forward"
     Then the "$item" element exists but the "$summary" element doesn't exist
 
-  Scenario: Summary URL goes to page with open summary
+  Scenario Outline: Summary URL goes to page with open summary
     Given the environment
       """
-      KUMA_ZONEEGRESS_COUNT: 51
+      KUMA_ZONEINGRESS_COUNT: 51
       """
-    When I visit the "/zones/kri_z____zone-1_/egresses/kri_ze__zone-1__zone-egress-1_?page=2&size=50" URL
+    When I visit the "/zones/kri_z____zone-1_/ingresses/kri_zi__zone-1__zone-ingress-1_?page=2&size=50" URL
     Then the "$summary" element exists
 
   Scenario: Switching to universal format and back
     Given the environment
       """
-      KUMA_ZONEEGRESS_COUNT: 1
+      KUMA_ZONEINGRESS_COUNT: 1
       """
-    When I visit the "/zones/kri_z____zone-1_/egresses/kri_ze__zone-1__zone-egress-1_" URL
+    When I visit the "/zones/kri_z____zone-1_/ingresses/kri_zi__zone-1__zone-ingress-1_" URL
     Then the "$select-preference" element exists
     And the "$structured-view" element exists
     When I click the "$select-preference" element

--- a/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/item/Index.feature
+++ b/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/item/Index.feature
@@ -1,6 +1,10 @@
 Feature: zones / ingresses / item
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias              | Selector                                       |
       | page               | [data-testid='zone-ingress-detail-tabs-view']  |

--- a/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/item/Services.feature
+++ b/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/item/Services.feature
@@ -1,6 +1,10 @@
 Feature: zones / ingresses / item / services
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias                 | Selector                                      |
       | items                 | [data-testid='available-services-collection'] |

--- a/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/item/Subscriptions.feature
+++ b/packages/kuma-gui/features/zone-ingresses/zones/zone-cps/ingresses/item/Subscriptions.feature
@@ -1,6 +1,10 @@
 Feature: dataplanes / subscriptions
 
   Background:
+    Given the environment
+      """
+      KUMA_ZONE_INGRESSES_ENABLED: true
+      """
     Given the CSS selectors
       | Alias                             | Selector                                               |
       | about-section                     | [data-testid='about-section-content']                  |

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -47,16 +47,9 @@
                 name: 'zone-index-view',
               }"
             />
-            <AppNavigator
-              v-else
-              v-icon-start="`zone-egress`"
-              data-testid="zone-egresses-navigator"
-              :active="child.name === 'zone-egress-index-view'"
-              label="ZoneEgresses"
-              :to="{
-                name: 'zone-egress-list-view',
-              }"
-            />
+            <template v-else-if="ZoneAppNavigator">
+              <ZoneAppNavigator />
+            </template>
             <AppNavigator
               v-icon-start="`mesh`"
               v-style="'--icon-name-start: var(--icon-mesh)'"
@@ -119,11 +112,13 @@ import { useRouter } from 'vue-router'
 import AppNavigator from '@/app/application/components/app-navigator/AppNavigator.vue'
 import type { ControlPlaneAddressesSource } from '@/app/control-planes/sources'
 import ApplicationShell from '@/app/kuma/components/ApplicationShell.vue'
+import { useZoneHomeNavigatorFallback } from '@/app/zones'
 import type { RouteRecordRaw } from 'vue-router'
 
 type StringNamedRouteRecordRaw = RouteRecordRaw & {
   name: string
 }
+const ZoneAppNavigator = useZoneHomeNavigatorFallback()
 const router = useRouter()
 const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) => route.name === 'control-plane-root-view')?.children.map(item => {
   item.name = String(item.name)

--- a/packages/kuma-gui/src/app/connections/data/index.ts
+++ b/packages/kuma-gui/src/app/connections/data/index.ts
@@ -1,6 +1,11 @@
 import { get } from '@/app/application'
 import { findDeep } from '@/app/application/utilities'
 
+// `connections` views are shared by any proxy type (dataplane, zone-ingress, zone-egress, ...)
+// so they only need the bare minimum shape they actually read off of an overview/networking object.
+export type ConnectionOverview = { id: string }
+export type ConnectionNetworking = { inboundAddress: string }
+
 const protocols = ['http', 'tcp'] as const
 const appProtocols = ['http', 'tcp', 'grpc'] as const
 

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -67,14 +67,13 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
 import { DataplaneNetworkingLayout } from '@/app/data-planes/data'
-import type { DataplaneInbound, DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
+import type { DataplaneInbound } from '@/app/data-planes/data'
 const props = defineProps<{
   routeName: string
   data: DataplaneInbound | DataplaneNetworkingLayout['inbounds'][number]
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -79,17 +79,16 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 
+import type { ConnectionNetworking, ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneNetworkingLayout, DataplaneInbound, DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgress, ZoneEgressOverview } from '@/app/zone-egresses/data/'
-import type { ZoneIngress, ZoneIngressOverview } from '@/app/zone-ingresses/data/'
+import type { DataplaneNetworkingLayout, DataplaneInbound } from '@/app/data-planes/data'
 
 
 const props = defineProps<{
   data: DataplaneInbound | DataplaneNetworkingLayout['inbounds'][number]
-  networking: DataplaneNetworking | ZoneIngress['networking'] | ZoneEgress['networking']
+  networking: ConnectionNetworking
   routeName: string
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined
+  overview: ConnectionOverview | Error | undefined
 }>()
 
 const data = computed(() => ({

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryView.vue
@@ -74,13 +74,12 @@
 </template>
 
 <script lang="ts" setup>
-import type { DataplaneInbound, DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
+import type { ConnectionOverview } from '../data'
+import type { DataplaneInbound, DataplaneNetworking } from '@/app/data-planes/data/'
 
 const props = defineProps<{
   data: DataplaneInbound[]
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
   networking: DataplaneNetworking
   routeName: string
 }>()

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -57,14 +57,13 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneNetworkingLayout, DataplaneInbound, DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
+import type { DataplaneNetworkingLayout, DataplaneInbound } from '@/app/data-planes/data'
 
 const props = defineProps<{
   data: DataplaneInbound | DataplaneNetworkingLayout['inbounds'][number]
   routeName: string
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -67,12 +67,10 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
 const props = defineProps<{
   routeName: string
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
@@ -64,13 +64,12 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
+import type { DataplaneNetworking } from '@/app/data-planes/data/'
 const props = defineProps<{
   networking: DataplaneNetworking
   routeName: string
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryView.vue
@@ -53,13 +53,11 @@
 </template>
 
 <script lang="ts" setup>
-import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
-import type { ZoneEgress, ZoneEgressOverview } from '@/app/zone-egresses/data/'
-import type { ZoneIngress, ZoneIngressOverview } from '@/app/zone-ingresses/data/'
+import type { ConnectionNetworking, ConnectionOverview } from '../data'
 const props = defineProps<{
   data: Record<string, any>
-  networking: DataplaneNetworking | ZoneIngress['networking'] | ZoneEgress['networking']
+  networking: ConnectionNetworking
   routeName: string
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
@@ -73,13 +73,11 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import type { DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
 const props = defineProps<{
   routeName: string
-  overview: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined 
+  overview: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
@@ -67,12 +67,10 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
 const props = defineProps<{
   routeName: string
-  data: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined
+  data: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
@@ -69,14 +69,13 @@
 </template>
 
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
+import type { DataplaneNetworking } from '@/app/data-planes/data'
 
 const props = defineProps<{
   networking: DataplaneNetworking | Error | undefined
   routeName: string
-  data: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined
+  data: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -74,12 +74,10 @@
 </template>
 
 <script lang="ts" setup>
+import type { ConnectionOverview } from '../data'
 import { sources } from '../sources'
-import type { DataplaneOverview } from '@/app/data-planes/data'
-import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
-import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
 const props = defineProps<{
   routeName: string
-  data: DataplaneOverview | ZoneIngressOverview | ZoneEgressOverview | Error | undefined
+  data: ConnectionOverview | Error | undefined
 }>()
 </script>

--- a/packages/kuma-gui/src/app/kuma/env.ts
+++ b/packages/kuma-gui/src/app/kuma/env.ts
@@ -10,6 +10,8 @@ type HtmlVars = {
   storeType: string
   //
   legacyServicesEnabled?: string
+  zoneIngressesEnabled?: string
+  zoneEgressesEnabled?: string
 }
 export const vars = (config: HtmlVars) => {
   const version = semver(config.version)
@@ -25,6 +27,8 @@ export const vars = (config: HtmlVars) => {
     //
     KUMA_RESOURCES_ROUTE_ENABLED: () => 'false',
     KUMA_LEGACY_SERVICES_ENABLED: () => config.legacyServicesEnabled ?? 'false',
+    KUMA_ZONE_INGRESSES_ENABLED: () => config.zoneIngressesEnabled ?? 'false',
+    KUMA_ZONE_EGRESSES_ENABLED: () => config.zoneEgressesEnabled ?? 'false',
   }
 }
 declare module '@/app/application' {

--- a/packages/kuma-gui/src/app/zone-egresses/components/ZoneEgressesAppNavigator.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/components/ZoneEgressesAppNavigator.vue
@@ -1,0 +1,21 @@
+<template>
+  <AppNavigator
+    v-icon-start="`zone-egress`"
+    data-testid="zone-egresses-navigator"
+    :active="active"
+    label="ZoneEgresses"
+    :to="{
+      name: 'zone-egress-list-view',
+    }"
+  />
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import AppNavigator from '@/app/application/components/app-navigator/AppNavigator.vue'
+
+const route = useRoute()
+const active = computed(() => route.matched.some((item) => item.name === 'zone-egress-index-view'))
+</script>

--- a/packages/kuma-gui/src/app/zone-egresses/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/index.ts
@@ -1,5 +1,6 @@
 import { token } from '@kumahq/container'
 
+import ZoneEgressesAppNavigator from './components/ZoneEgressesAppNavigator.vue'
 import { routes } from './routes'
 import { sources } from './sources'
 import type { Can } from '@/app/application'
@@ -51,6 +52,10 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       labels: [
         app.sources,
       ],
+    }],
+    [token<typeof ZoneEgressesAppNavigator>('zone-egresses.components.zone-egresses-navigator'), {
+      service: () => ZoneEgressesAppNavigator,
+      decorates: app.ZoneAppNavigator,
     }],
   ]
 }

--- a/packages/kuma-gui/src/app/zone-egresses/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zone-egresses/locales/en-us/index.yaml
@@ -1,3 +1,9 @@
+zone-cps:
+  routes:
+    item:
+      navigation:
+        zone-egress-list-view: Egresses
+
 zone-egresses:
   x-empty-state:
     title: No data

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -14,7 +14,7 @@
       v-slot="{ data: [zoneEgress] }"
     >
       <AppView
-        :docs="t('zone-ingresses.href.docs')"
+        :docs="t('zone-egresses.href.docs')"
         :breadcrumbs="[
           ...(can('use zones') ? [
             {

--- a/packages/kuma-gui/src/app/zone-ingresses/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zone-ingresses/locales/en-us/index.yaml
@@ -1,3 +1,9 @@
+zone-cps:
+  routes:
+    item:
+      navigation:
+        zone-ingress-list-view: Ingresses
+
 zone-ingresses:
   x-empty-state:
     title: No data

--- a/packages/kuma-gui/src/app/zones/index.ts
+++ b/packages/kuma-gui/src/app/zones/index.ts
@@ -9,6 +9,7 @@ import { sources } from './sources'
 import type { Can } from '@/app/application'
 import { services as subscriptions } from '@/app/subscriptions'
 import type { ServiceDefinition } from '@kumahq/container'
+import type { Component } from 'vue'
 import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
@@ -16,6 +17,7 @@ type Token = ReturnType<typeof token>
 const $ = {
   ZoneControlPlanesList: token<typeof ZoneControlPlanesList>('zones.components.ZoneControlPlanesList'),
   ZoneActionGroup: token<typeof ZoneActionGroup>('zones.components.ZoneActionGroup'),
+  ZoneAppNavigator: token<Component | undefined>('zones.components.ZoneAppNavigator'),
 }
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
@@ -25,6 +27,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [$.ZoneActionGroup, {
       service: () => ZoneActionGroup,
+    }],
+    [$.ZoneAppNavigator, {
+      service: () => undefined,
     }],
     [token('zones.routes'), {
       service: (can: Can) => {
@@ -74,7 +79,9 @@ export const TOKENS = $
 export const [
   useZoneControlPlanesList,
   useZoneActionGroup,
+  useZoneHomeNavigatorFallback,
 ] = createInjections(
   $.ZoneControlPlanesList,
   $.ZoneActionGroup,
+  $.ZoneAppNavigator,
 )

--- a/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
@@ -41,8 +41,6 @@ zone-cps:
         zone-cp-detail-view: Overview
         zone-cp-config-view: Config
         zone-cp-subscriptions-list-view: KDS connections
-        zone-ingress-list-view: Ingresses
-        zone-egress-list-view: Egresses
       authentication_type: Dataplane authentication type
       overview: Overview
       version: Version
@@ -98,8 +96,6 @@ zones:
       title: Zones
       navigation:
         zone-cp-list-view: Zone control planes
-        zone-ingress-list-view: Ingresses
-        zone-egress-list-view: Egresses
   index:
     create: 'Create zone'
   action_menu:

--- a/packages/kuma-gui/src/main.ts
+++ b/packages/kuma-gui/src/main.ts
@@ -24,9 +24,7 @@ import { services as rules } from '@/app/rules'
 import { services as services, TOKENS as SERVICES } from '@/app/services'
 import { services as vue, TOKENS as VUE } from '@/app/vue'
 import { services as workloads } from '@/app/workloads'
-import { services as zoneEgresses } from '@/app/zone-egresses'
-import { services as zoneIngresses } from '@/app/zone-ingresses'
-import { services as zones } from '@/app/zones'
+import { services as zones, TOKENS as ZONES } from '@/app/zones'
 
 async function mountVueApplication() {
   const $ = {
@@ -49,8 +47,6 @@ async function mountVueApplication() {
     configuration($),
     controlPlanes($),
     zones($),
-    zoneEgresses($),
-    zoneIngresses($),
     meshes($),
     hostnameGenerators($),
     services($),
@@ -68,6 +64,14 @@ async function mountVueApplication() {
     env('KUMA_LEGACY_SERVICES_ENABLED') === 'true' ? await (async () => {
       const legacyServices = await import('@/app/legacy-services')
       return legacyServices.services({ ...$, ...DATAPLANES })
+    })() : [],
+    env('KUMA_ZONE_INGRESSES_ENABLED') === 'true' ? await (async () => {
+      const zoneIngresses = await import('@/app/zone-ingresses')
+      return zoneIngresses.services($)
+    })() : [],
+    env('KUMA_ZONE_EGRESSES_ENABLED') === 'true' ? await (async () => {
+      const zoneEgresses = await import('@/app/zone-egresses')
+      return zoneEgresses.services({ ...$, ...ZONES })
     })() : [],
     //
 


### PR DESCRIPTION
Completely decouples the `zone-ingresses` and `zone-egresses` modules and removes them conditionally (as per default) from the main application.

- The modules are now lazy loaded and registered with the container only when `KUMA_ZONE_(INGRESSES|EGRESSES)_ENABLED` is enabled. Nothing outside the two modules imports from them anymore.
- The `connections` views only ever read `.id`/`.inboundAddress` off of an overview/networking object, so they now use minimal structural types instead of importing `ZoneIngressOverview`/`ZoneEgressOverview`.
- The standalone/non-global zone CP nav fallback in `App.vue` (shows "ZoneEgresses" in place of "Zones") is now an injectable `zones.components.ZoneEgressesAppNavigator` token, defaulting to nothing, that `zone-egresses` decorates with its own component. App.vue no longer hardcodes any `zone-egress-*` route names.
- Moved the "Ingresses"/"Egresses" zone-tab locale labels out of `zones` into each module's own locale file.
- Gherkin features specific to these modules moved to `features/zone-ingress-egress/`, gated behind `KUMA_ZONE_(INGRESSES|EGRESSES)_ENABLED: true`.

Closes https://github.com/kumahq/kuma-gui/issues/5041
