### PR TITLE
fix(kongponents): override default links styles for table actions

### DIFF
--- a/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
@@ -142,9 +142,12 @@ onMounted(rewrite)
 /* this used to use `> *` but thats too eager for x-badges so for now we are using span */
 .app-collection :deep(td [data-action]:is(a, button)) {
   &, > span {
-    color: inherit;
+    /* override default kongponent styling because we use links for navigating /*
+    /* using table rows instead of divs/onclicks */
+    color: inherit !important;
+    text-decoration: none !important;
+    /* end override */
     font-weight: var(--x-font-weight-semibold);
-    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
We use accessible links for our click/navigation functionality for table rows.

From what I can see, others generally use non-accessible dev/onclick handlers for the rows.

This difference means we get the "secondary link" styling on our "primary links" for table rows.

I'd rather keep using accessible links instead of re-inventing wheels with onclick handlers instead of native links, so for the moment at least I've overridden the default link styling that was added recently. This makes everything look the same as elsewhere.

If elsewhere changes their look again soon then we can just revert this again, but I have a feeling that won't happen.