### PR TITLE
chore(x-code-block): change syntax highlighting theme to latte

### DIFF
--- a/packages/x/src/index.ts
+++ b/packages/x/src/index.ts
@@ -216,8 +216,8 @@ const { uri } = nano()
 export const syntaxHighlighter = {
   options: {
     themes: {
-      dark: 'catppuccin-mocha',
-      light: 'catppuccin-mocha',
+      dark: 'catppuccin-latte',
+      light: 'catppuccin-latte',
     },
     structure: 'inline',
   } satisfies Partial<CodeToHastOptions>,
@@ -229,8 +229,8 @@ export const syntaxHighlighter = {
     ],
     themes: [
       {
-        name: 'catppuccin-mocha',
-        default: (await import('shiki/themes/catppuccin-mocha.mjs')).default,
+        name: 'catppuccin-latte',
+        default: (await import('shiki/themes/catppuccin-latte.mjs')).default,
       },
     ],
     engine: createJavaScriptRegexEngine(),


### PR DESCRIPTION
Changes XCodeBlock syntax highlighting to use `latte` to make the code a little more readable

## Before

<img width="553" height="681" alt="Screenshot 2026-08-17 at 14 03 56" src="https://github.com/user-attachments/assets/9a4237dc-d66a-4c5b-b9d1-034a25c4f320" />

## After

<img width="566" height="571" alt="Screenshot 2026-08-17 at 14 03 42" src="https://github.com/user-attachments/assets/3e868b54-f4b2-4f40-ad8a-7718816ef216" />

