### PR TITLE
fix: export parseSearch from kuma module

### DIFF
--- a/packages/kuma-gui/src/app/kuma/utils/index.ts
+++ b/packages/kuma-gui/src/app/kuma/utils/index.ts
@@ -17,7 +17,7 @@ type SearchOptions = {
 export const searchRegex = /(\S+:\s*\S*)|(\S+)/
 const kvSeparatorRegex = /:(.*)/
 
-const parseSearch = (query: string, options: SearchOptions = {}) => {
+export const parseSearch = (query: string, options: SearchOptions = {}) => {
   const { defaultKey = 'name' } = options
   const parts = query.trim().split(searchRegex).map((part) => part?.trim().replace(/=/, ':')).filter(Boolean)
 


### PR DESCRIPTION
Follow up for https://github.com/kumahq/kuma-gui/pull/5226

---

Sorry! I totally forgot that parseSearch also needs exporting for usage elsewhere 🤦 and was why it was split up in the first place!