### PR TITLE
chore(control-planes): move cp notifications under tabs

### DIFF
--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -3,7 +3,9 @@
     :name="props.routeName"
     v-slot="{ can, t, uri, me, route }"
   >
-    <AppView>
+    <AppView
+      :notifications="true"
+    >
       <template #title>
         <h1>
           <RouteTitle


### PR DESCRIPTION
Currently any notifications we add in the control plane detail page appear above the tabs.

We want them to appear below the tabs in the tab panel/content.

Right now this doesn't matter as the place where we add a notification here is feature flagged, but when we remove the flag so the notification shows we want it to be below the tabs not above.