### PR TITLE
chore(kumahq/x): update XTabs styles

### DIFF
--- a/packages/x/src/components/x-tabs/XTabs.vue
+++ b/packages/x/src/components/x-tabs/XTabs.vue
@@ -112,11 +112,6 @@ const slots = defineSlots()
 
   /* non-link */
   ul {
-    /* these were removed from .small */
-    /* but I think we should keep them on both variants */
-    overflow-x: auto;
-    overflow-y: hidden;
-
     display: flex;
     gap: var(--x-space-40);
     list-style: none;


### PR DESCRIPTION
I noticed during https://github.com/kumahq/kuma-gui/pull/5196 that KTabs styles were slightly updated (also see https://github.com/Kong/kongponents/pull/3351)

This replicates that change.