### PR TITLE
chore(deps): remove @types/semver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3214,13 +3214,6 @@
       "integrity": "sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==",
       "license": "MIT"
     },
-    "node_modules/@types/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
       "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
@@ -12873,7 +12866,6 @@
         "@kumahq/kuma-http-api": "*",
         "@playwright/test": "^1.62.1",
         "@types/js-yaml": "^4.0.9",
-        "@types/semver": "^7.8.0",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/test-utils": "^2.4.11",
         "jsdom": "^30.0.1",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -38,7 +38,6 @@
     "@kumahq/kuma-http-api": "*",
     "@playwright/test": "^1.62.1",
     "@types/js-yaml": "^4.0.9",
-    "@types/semver": "^7.8.0",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/test-utils": "^2.4.11",
     "jsdom": "^30.0.1",


### PR DESCRIPTION
I found that whilst we depend on `@types/semver` we don't actually depend on `semver` itself. I do remember years back we distinctly removed `semver`, I guess this has been unnecessarily in there since then 🤷 