### PR TITLE
chore(services): move MeshService to use dataplaneLabels w/fallback

### DIFF
--- a/packages/kuma-gui/src/app/services/data/MeshService.ts
+++ b/packages/kuma-gui/src/app/services/data/MeshService.ts
@@ -33,8 +33,15 @@ export const MeshService = {
           ...item,
           ports: Array.isArray(item.ports) ? item.ports : [],
           selector: ((item = {}) => {
+            const labels = item.dataplaneLabels ?? {}
             return {
-              dataplaneTags: Object.keys(item.dataplaneTags ?? {}).length > 0 ? item.dataplaneTags! : {},
+              dataplaneLabels: {
+                ...labels,
+                matchLabels: Object.keys(labels.matchLabels ?? {}).length > 0 ?
+                  labels.matchLabels ?? {} :
+                  // @ts-ignore (types) temporary support of old dataplaneTags
+                  Object.keys(item.dataplaneTags ?? {}).length > 0 ? item.dataplaneTags ?? {} : {},
+              },
             }
           })(item.selector),
           identities: Array.isArray(item.identities) ? item.identities : [],

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -78,7 +78,6 @@
                   <template v-if="service.spec.ports.length">
                     <XLayout
                       variant="separated"
-                      truncate
                     >
                       <KumaPort
                         v-for="connection in service.spec.ports"
@@ -100,18 +99,26 @@
                   {{ t('http.api.property.selector') }}
                 </dt>
                 <dd>
-                  <template v-if="Object.keys(service.spec.selector.dataplaneTags).length">
+                  <template v-if="Object.keys(service.spec.selector.dataplaneLabels.matchLabels).length">
                     <XLayout
                       variant="separated"
-                      truncate
                     >
-                      <XBadge
-                        v-for="(value, key) in service.spec.selector.dataplaneTags"
-                        :key="`${key}:${value}`"
-                        appearance="info"
+                      <XAction
+                        v-for="(value, key) in service.spec.selector.dataplaneLabels.matchLabels"
+                        :key="key"
+                        :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                          mesh: service.mesh,
+                          zone: service.zone,
+                          namespace: service.namespace,
+                          name: value,
+                        }, { defaultMessage: '' })"
                       >
-                        {{ key }}:{{ value }}
-                      </XBadge>
+                        <XBadge
+                          :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                        >
+                          {{ key }}:<strong>{{ value }}</strong>
+                        </XBadge>
+                      </XAction>
                     </XLayout>
                   </template>
                   <template v-else>
@@ -313,7 +320,7 @@
                 :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
                   mesh: route.params.mesh,
                   tags: JSON.stringify({
-                    ...service.spec.selector.dataplaneTags,
+                    ...service.spec.selector.dataplaneLabels.matchLabels,
                   }),
                 }, {
                   page: route.params.page,

--- a/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
@@ -143,17 +143,31 @@
                     Selector
                   </th>
                   <td>
-                    <XLayout
-                      variant="separated"
-                    >
-                      <XBadge
-                        v-for="(value, key) in item.spec.selector.dataplaneTags"
-                        :key="`${key}:${value}`"
-                        appearance="info"
+                    <template v-if="Object.keys(item.spec.selector.dataplaneLabels.matchLabels).length">
+                      <XLayout
+                        variant="separated"
                       >
-                        {{ key }}:{{ value }}
-                      </XBadge>
-                    </XLayout>
+                        <XAction
+                          v-for="(value, key) in item.spec.selector.dataplaneLabels.matchLabels"
+                          :key="key"
+                          :href="t(`common.label.href.${key.replaceAll('.', '~')}`, {
+                            mesh: item.mesh,
+                            zone: item.zone,
+                            namespace: item.namespace,
+                            name: value,
+                          }, { defaultMessage: '' })"
+                        >
+                          <XBadge
+                            :variant="r('kuma.label').test(key) ? 'reserved-kv' : 'kv'"
+                          >
+                            {{ key }}:<strong>{{ value }}</strong>
+                          </XBadge>
+                        </XAction>
+                      </XLayout>
+                    </template>
+                    <template v-else>
+                      {{ t('common.detail.none') }}
+                    </template>
                   </td>
                 </tr>
                 <tr

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshservices.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshservices.ts
@@ -63,9 +63,14 @@ export default ({ fake, pager, env }: Dependencies): ResponseHandler => (req) =>
                 appProtocol: fake.kuma.protocol(),
               }
             )),
-            selector: {
+            selector: fake.helpers.arrayElement([{
+              dataplaneLabels: {
+                matchLabels: fake.kuma.labels({ zone: fake.word.noun() }),
+              },
+            }, {
+              // @TODO(types): legacy v2
               dataplaneTags: fake.kuma.tags({}),
-            },
+            }]),
             state: fake.helpers.arrayElement(['Available', 'Unavailable']),
           },
           status: {

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshservices/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshservices/_.ts
@@ -57,15 +57,19 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
             appProtocol: fake.kuma.protocol(),
           }
         )),
-        selector: {
+        selector: fake.helpers.arrayElement([{
+          dataplaneLabels: {
+            matchLabels: fake.kuma.labels({ zone: fake.word.noun() }),
+          },
+        }, {
+          // @TODO(types): legacy v2
           dataplaneTags: fake.kuma.tags({}),
-        },
+        }]),
         state: fake.helpers.arrayElement(['Available', 'Unavailable']),
-        identities: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map((_, index) => {
-          const type = fake.helpers.arrayElement(['ServiceTag', 'SpiffeID'])
+        identities: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => {
           return {
-            type,
-            value: type === 'ServiceTag' ? `${fake.word.noun()}-${index + 1}` : fake.kuma.spiffeId({ mesh, namespace: nspace, sa: name }),
+            type: 'SpiffeID',
+            value: fake.kuma.spiffeId({ mesh, namespace: nspace, sa: name }),
           }
         }),
       },


### PR DESCRIPTION
Moves `MeshService` to use `dataplaneLabels.matchLabels` instead of `dataplaneTags`.

For the moment, perhaps temporarily, we fallback to the old `dataplaneTags`.

---

I also noticed that these can contain things like `kima.io/mesh` so I made them conditionally link depending on that, just like `labels` everywhere else.

I also removed the truncation, truncate should only be used in height restricted space (such as table rows), for the summary and detail pages we have as much vertical space as we like because the user can use the native scroll bar to see more.