### PR TITLE
chore(config/eslint): disable sorting imports

### DIFF
--- a/packages/config/src/eslint.js
+++ b/packages/config/src/eslint.js
@@ -170,8 +170,8 @@ export function createEslintConfig(
           ],
           'newlines-between': 'always',
           alphabetize: {
-            order: 'asc',
-            caseInsensitive: true,
+            order: 'ignore',
+            orderImportKind: 'ignore',
           },
         }],
         'no-console': ['error', { allow: ['info', 'warn', 'error'] }],


### PR DESCRIPTION
We wanted to do this for quite some time. The enforcement of alphabetical ordering is hurting more than it's beneficial. I still think there is _some_ value in grouping and if there was no rule/config for that I'd probably do this manually. But the alphabetical order doesn't really matter and sometimes it conflicts with how we want to order imports ourselves.

That being said I've not removed the entire rule but just disabled the alphabetical ordering. I have no strong opinion in keeping the whole rule and if wanted I can remove it, but as I said above I think there is _some_ value in grouping.

There is currently one disable-directive in https://github.com/kumahq/kuma-gui/blob/1131f1e0f4dc282e35cfa00e0fbbc61a543def1b/packages/x/src/components/x-router/XRouter.vue#L90-L91 and unfortunately we'd have to keep this if we want to keep the grouping. I think this is a rare case as usually we only have one script-tag with imports in our vue-files.