### PR TITLE
chore(kuma-http-api): remove leftover path overlays

### DIFF
--- a/packages/kuma-http-api/src/openapi.overlay.yaml
+++ b/packages/kuma-http-api/src/openapi.overlay.yaml
@@ -15,15 +15,6 @@ actions:
       /mesh-insights/{name}:
         $ref: "paths/mesh-insights_{name}.yaml"
 
-      /meshes/{mesh}/service-insights:
-        $ref: "paths/meshes_{mesh}_service-insights.yaml"
-      /meshes/{mesh}/service-insights/{name}:
-        $ref: "paths/meshes_{mesh}_service-insights_{name}.yaml"
-      /meshes/{mesh}/external-services:
-        $ref: "paths/meshes_{mesh}_external-services.yaml"
-      /meshes/{mesh}/external-services/{name}:
-        $ref: "paths/meshes_{mesh}_external-services_{name}.yaml"
-
       /meshes/{mesh}/dataplanes/{name}/xds:
         $ref: "paths/meshes_{mesh}_dataplanes_{name}_xds.yaml"
       /meshes/{mesh}/dataplanes/{name}/stats:
@@ -43,8 +34,6 @@ actions:
     update:
       Policy:
         $ref: "components/schemas/Policy.yaml"
-      Zone:
-        $ref: "components/schemas/Zone.yaml"
       PolicyCollection:
         $ref: "components/schemas/PolicyCollection.yaml"
       LegacyPolicy:


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/5276 I somehow missed to remove the overlay references for some paths. I also found there is this reference of `Zone` schema which doesn't exist (anymore).