### PR TITLE
chore(dataplanes): make gateways "transitional"/type-optional

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -56,7 +56,7 @@ export const DataplaneNetworkingLayout = {
       inbounds: [
         ...DataplaneLayoutInbound.fromCollection(dataplaneNetworkingLayout.inbounds),
         ...DataplaneLayoutListener.fromCollection(dataplaneNetworkingLayout.listeners),
-      ] satisfies GenericDataplaneLayoutInbound[],
+      ],
       outbounds: dataplaneNetworkingLayout.outbounds.map(item => {
         const kri = Kri.fromString(item.kri)
         return {
@@ -120,34 +120,6 @@ const DataplaneOutbound = {
   },
 }
 
-const GatewayDataplaneInbound = {
-  fromObject(networking: KumaDataplaneNetworking) {
-    // if we are a builtin gateway fill in as much as we can for a single inbound
-    // we can 'clone' this later if we find out individual information for each inbound
-    // i.e. this acts as a template
-    return {
-      type: '',
-      address: networking.address ?? '',
-      tags: networking.gateway?.tags ?? {},
-      name: '',
-      protocol: '',
-      state: 'Ready',
-      // these could be filled out during 'cloning'
-      // i.e. these are like template variables to be filled out
-      port: NaN,
-      addressPort: '',
-      //
-      // this will never get set seeing as a gateway proxy never has a service
-      serviceAddressPort: '',
-      // we never set this currently as we never need it for a gateway
-      socketAddress: '',
-      listenerAddress: '',
-      // not available for gateway
-      portName: '',
-      clusterName: '',
-    }
-  },
-}
 
 const DataplaneInbound = {
   fromObject(item: KumaDataplaneInbound, networking: KumaDataplaneNetworking) {
@@ -186,40 +158,62 @@ export const DataplaneNetworking = {
     // remove singular inbound/outbound to be replaced with plural versions
     const { inbound, outbound, ...rest } = networking
 
-    const inbounds = Array.isArray(inbound) ? inbound : []
-    const listeners = Array.isArray(networking.listeners) ? networking.listeners : []
-
-    // outbounds are only present here on a universal DDP without transparent
-    // proxying
-    const outbounds = Array.isArray(outbound) ? outbound : []
-    const type = typeof networking.gateway === 'undefined' || networking.gateway?.type !== 'BUILTIN' ? 'sidecar' : 'gateway'
-
-    return {
+    const item = {
       ...rest,
-      ...(networking.gateway ? {
-        gateway: {
-          ...networking.gateway,
-          tags: networking.gateway.tags ?? {},
-        },
-      } : {}),
-      type: type as 'sidecar' | 'gateway',
+      type: 'sidecar',
       // used for a lookup for inbounds on the result of the envoy /stats endpoint
-      inboundAddress: type === 'gateway' ? networking.address ?? 'localhost' : 'localhost',
-      //
-      inbounds: (() => {
-        switch(true) {
-          case type === 'gateway' && typeof networking.gateway !== 'undefined': {
-            return [GatewayDataplaneInbound.fromObject(networking)]
-          }
-          default:
-            return [
-              ...inbounds.map(item => DataplaneInbound.fromObject(item, networking)),
-              ...DataplaneListener.fromCollection(listeners) ?? [],
-            ]
-        }
-      })() satisfies GenericDataplaneInbound[],
-      outbounds: DataplaneOutbound.fromCollection(outbounds),
+      inboundAddress: 'localhost',
+      // outbounds are only present here on a universal DDP without transparent
+      // proxying
+      outbounds: Array.isArray(outbound) ? DataplaneOutbound.fromCollection(outbound) : [],
+      inbounds: [
+        ...(Array.isArray(inbound) ? inbound.map(item => DataplaneInbound.fromObject(item, networking)) : []),
+        ...(Array.isArray(networking.listeners) ? DataplaneListener.fromCollection(networking.listeners) : []),
+      ],
     }
+    if ('gateway' in networking) {
+      const gateway = networking.gateway as {
+        type: string
+        tags: Record<string, string>
+      }
+      return {
+        ...item,
+        ...(gateway.type === 'BUILTIN' ? {
+          type: 'gateway',
+          // if we are a builtin gateway fill in as much as we can for a single inbound
+          // we can 'clone' this later if we find out individual information for each inbound
+          // i.e. this acts as a template
+          inbounds: [{
+            type: '',
+            address: networking.address ?? '',
+            tags: gateway.tags ?? {},
+            name: '',
+            protocol: '',
+            state: 'Ready',
+            // these could be filled out during 'cloning'
+            // i.e. these are like template variables to be filled out
+            port: NaN,
+            addressPort: '',
+            //
+            // this will never get set seeing as a gateway proxy never has a service
+            serviceAddressPort: '',
+            // we never set this currently as we never need it for a gateway
+            socketAddress: '',
+            listenerAddress: '',
+            // not available for gateway
+            portName: '',
+            clusterName: '',
+          }],
+        } : {}),
+        inboundAddress: networking.address ?? 'localhost',
+        gateway: {
+          ...gateway,
+          tags: gateway.tags ?? {},
+        },
+      }
+
+    }
+    return item
   },
 }
 export type DataplaneNetworkingLayout = ReturnType<typeof DataplaneNetworkingLayout['fromObject']>
@@ -227,9 +221,6 @@ export type DataplaneOutbound = ReturnType<typeof DataplaneOutbound['fromObject'
 export type DataplaneNetworking = ReturnType<typeof DataplaneNetworking['fromObject']>
 export type DataplaneInbound = ReturnType<typeof DataplaneInbound['fromObject']>
 export type DataplaneListener = ReturnType<typeof DataplaneListener['fromObject']>
-export type GatewayDataplaneInbound = ReturnType<typeof GatewayDataplaneInbound['fromObject']>
-export type GenericDataplaneInbound = DataplaneInbound & DataplaneListener & GatewayDataplaneInbound
 
 export type DataplaneLayoutInbound = ReturnType<typeof DataplaneLayoutInbound['fromObject']>
 export type DataplaneLayoutListener = ReturnType<typeof DataplaneLayoutListener['fromObject']>
-export type GenericDataplaneLayoutInbound = DataplaneLayoutInbound & DataplaneLayoutListener

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
@@ -72,7 +72,7 @@ export const DataplaneOverview = {
         switch (true) {
           case networking.type === 'gateway':
             return dpTypes.builtin
-          case typeof networking.gateway !== 'undefined':
+          case 'gateway' in networking:
             return dpTypes.delegated
           default:
             return dpTypes.standard
@@ -84,7 +84,7 @@ export const DataplaneOverview = {
       ],
       status: (() => {
         const state = typeof dataplaneInsight.connectedSubscription !== 'undefined' ? states.online : states.disconnectedCp
-        if (networking.gateway || state === states.disconnectedCp) {
+        if ('gateway' in networking || state === states.disconnectedCp) {
           return state
         }
 
@@ -142,7 +142,8 @@ export const DataplaneOverview = {
     }
   },
 }
-function getTags({ gateway, inbounds }: DataplaneNetworking): LabelValue[] {
+function getTags(networking: DataplaneNetworking): LabelValue[] {
+  const { inbounds } = networking
   let tags: string[] = []
   const separator = '='
 
@@ -152,7 +153,8 @@ function getTags({ gateway, inbounds }: DataplaneNetworking): LabelValue[] {
       .map(([key, value]) => `${key}${separator}${value}`)
   }
 
-  if (gateway) {
+  if ('gateway' in networking) {
+    const gateway = networking.gateway as { tags: Record<string, string>}
     tags = Object.entries(gateway.tags ?? {}).map(([key, value]) => `${key}${separator}${value}`)
   }
 

--- a/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
@@ -108,9 +108,10 @@ describe('DataplaneOverview', () => {
       async ({ fixture }) => {
         expect.assertions(2)
         const actual = await fixture.setup((item) => {
-          if (typeof item.dataplane.networking.gateway !== 'undefined') {
-            delete item.dataplane.networking.gateway.type
-            expect(item.dataplane.networking.gateway.type).toBeUndefined()
+          if ('gateway' in item.dataplane.networking) {
+            const gateway = item.dataplane.networking.gateway as { type?: string }
+            delete gateway.type
+            expect(gateway.type).toBeUndefined()
           }
           return item
         }, {
@@ -329,11 +330,16 @@ describe('DataplaneOverview', () => {
       async ({ fixture }) => {
         const actual = await fixture.setup((item) => {
           if (item.dataplane.networking.inbound?.length === 1) {
+            const inbound = item.dataplane.networking.inbound[0] as {
+              port: number
+              tags: Record<string, string>
+            }
+            inbound.port = 1
+            inbound.tags = {
+              'kuma.io/service': 'service-name',
+            }
             item.dataplane.networking.inbound[0] = {
-              port: 1,
-              tags: {
-                'kuma.io/service': 'service-name',
-              },
+              ...inbound,
             }
           }
           return item

--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -7,8 +7,6 @@ export const features = () => {
   return {
     'use transparent-proxying': (_can: unknown, dataplaneOverview: DataplaneOverview) => {
       switch (true) {
-        case dataplaneOverview.dataplane.networking.gateway?.type === 'BUILTIN':
-          return false
         // TODO: `dataplane.networking.transparentProxying` is deprecated and will be removed soon. Still checking for users that still use it.
         case 'transparentProxying' in dataplaneOverview.dataplane.networking:
           return true

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -200,9 +200,10 @@
                 </XTable>
 
                 <XLayout
-                  v-if="item.dataplane.networking.gateway"
+                  v-if="'gateway' in item.dataplane.networking && typeof item.dataplane.networking.gateway !== 'undefined'"
                   variant="y-stack"
                 >
+                  >
                   <h3>{{ t('data-planes.routes.item.gateway') }}</h3>
 
                   <XTable

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -1,4 +1,5 @@
 import type { components } from '@kumahq/kuma-http-api'
+type KumaDataplaneNetworking = NonNullable<components['schemas']['DataplaneItem']['networking']>
 type ResourceRule = components['schemas']['ResourceRule']
 /**
  * Creates an “unsaved” variant of a resource type which is missing the fields that are only present on an object once its saved in the database.
@@ -356,7 +357,7 @@ export interface MeshEntity extends Entity {
  */
 export interface DataPlane extends MeshEntity {
   type: 'Dataplane'
-  networking: DataplaneNetworking
+  networking: KumaDataplaneNetworking
 }
 
 /**
@@ -370,7 +371,7 @@ export interface DataPlaneOverview extends MeshEntity {
     [key: string]: string
   }
   dataplane: {
-    networking: DataplaneNetworking
+    networking: KumaDataplaneNetworking
   }
   dataplaneInsight?: DataPlaneInsight
 }


### PR DESCRIPTION
Caters for if there is/isn't a gateway property on `dataplane.networking`