### PR TITLE
fix(meshes): keep mtls between v2 and v3 temporarily

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
@@ -330,10 +330,10 @@ describe('DataplaneOverview', () => {
       async ({ fixture }) => {
         const actual = await fixture.setup((item) => {
           if (item.dataplane.networking.inbound?.length === 1) {
-            const inbound = item.dataplane.networking.inbound[0] as {
-              port: number
+            type Inbound = NonNullable<(typeof item.dataplane.networking.inbound)>[number] & {
               tags: Record<string, string>
             }
+            const { state: _, ...inbound } = item.dataplane.networking.inbound[0] as Inbound
             inbound.port = 1
             inbound.tags = {
               'kuma.io/service': 'service-name',

--- a/packages/kuma-gui/src/app/meshes/data/Mesh.ts
+++ b/packages/kuma-gui/src/app/meshes/data/Mesh.ts
@@ -21,6 +21,7 @@ export const Mesh = {
       config: item,
       labels: item.labels ?? {},
       // @TODO(types) provide support for v2 and v3
+      mtls: 'mtls' in item ? item.mtls as MeshBackend : undefined,
       mtlsBackend: ((mtls: MeshBackend | undefined) => {
         if(typeof mtls === 'undefined') {
           return


### PR DESCRIPTION
Temporarily adds `Mesh.mtls` back if its set in the response.